### PR TITLE
fix(api): make /metrics and /sd public (no auth required)

### DIFF
--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -399,18 +399,13 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Get("/api/v1/notification/logs", notificationHandler.ListNotificationLogs)
 	})
 
-	// Prometheus metrics (admin only)
-	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
-		r.Handle("/metrics", handler.MetricsHandler())
-	})
-
-	// Prometheus HTTP Service Discovery (admin only)
-	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
-		sdHandler := handler.NewSDHandler(dbConn, deviceSystemRepo)
-		r.Get("/sd", sdHandler.ServeHTTP)
-	})
+	// Prometheus metrics + HTTP service discovery are PUBLIC: Prometheus
+	// scrapes these endpoints without credentials, and they leak no secrets
+	// (metrics are aggregate counters; SD exposes only device IPs/labels
+	// that the scanner already published). Keep them out of RequireAuth/Admin.
+	r.Handle("/metrics", handler.MetricsHandler())
+	sdHandler := handler.NewSDHandler(dbConn, deviceSystemRepo)
+	r.Get("/sd", sdHandler.ServeHTTP)
 
 	// Seed initial device metrics
 	go handler.UpdateDeviceMetrics(context.Background(), dbConn)


### PR DESCRIPTION
## Problem
`/metrics` and `/sd` were wrapped in `RequireAdmin`, but they must be reachable without credentials — Prometheus scrapes `/metrics` and reads `/sd` during its scrape cycle with no JWT/cookie. This contradicted both:
- The documented public route list (`AGENTS.md`: *Public: /health, /auth/login, /auth/register, /metrics, /sd*)
- The intent comment at `routes.go:107`: `// API routes (public: health, login, metrics, sd)`

## Fix
Move both routes out of the `RequireAdmin` groups, registering them directly on the root router (alongside `/health`) so they sit before the `RequireAuth` middleware.

## Security note
No secret exposure:
- `/metrics` — aggregate counters only (request counts, durations, device status gauges)
- `/sd` — device IPs/labels the scanner already recorded (same data the device list shows)

CSRF middleware already passes GET through, so no other change is needed.

## Verification (test server 192.168.63.101)
| Endpoint | No token | Before |
|---|---|---|
| `GET /metrics` | **200** (12.6KB Prometheus) | 401 |
| `GET /sd` | **200** (11.5KB SD JSON) | 401 |
| `GET /api/v1/devices` | 401 (unchanged) | 401 |
| `GET /api/v1/health` | 200 (unchanged) | 200 |

Local: `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./internal/api/...` all green.