### PR TITLE
feat(scanner): dual JSON attributes + scan/discovery/field-completion overhaul

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -242,6 +242,57 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		"ALTER TABLE scan_results ADD COLUMN node_exporter_detected INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE scan_results ADD COLUMN node_exporter_url TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE scan_results ADD COLUMN node_exporter_data TEXT NOT NULL DEFAULT '{}'",
+		// Dual JSON layer (scan_attributes + user_attributes). Generated columns
+		// (scan_vendor/scan_mac/scan_os/scan_hostname) can't be added via ALTER
+		// on existing DBs — those are only present on fresh installs. For
+		// upgraded DBs we add expression indexes below so the json_extract
+		// queries work without the generated columns.
+		"ALTER TABLE devices ADD COLUMN scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes))",
+		"ALTER TABLE devices ADD COLUMN user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes))",
+	}
+	for _, m := range migrations {
+		if _, err := db.Exec(m); err != nil {
+			// Ignore "duplicate column" errors — column already exists
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("failed to run migration %q: %w", m, err)
+			}
+		}
+	}
+
+	// Backfill scan_attributes from the legacy scan-info columns on existing
+	// rows that haven't been touched by the v2 engine yet (scan_attributes is
+	// still the empty default '{}'). Idempotent: once a row's scan_attributes
+	// is non-empty, the engine owns it and this merge won't run again.
+	if _, err := db.Exec(`UPDATE devices
+		SET scan_attributes = json_object(
+			'open_ports',         json(open_ports),
+			'detected_services',  json(detected_services),
+			'prometheus',         json_object(
+				'url',               prometheus_url,
+				'node_exporter_url', node_exporter_url,
+				'labels',            json(prometheus_labels)
+			),
+			'scan_source',        scan_source,
+			'last_scan_rtt_ms',   last_scan_rtt_ms,
+			'last_scanned_at',    COALESCE(strftime('%Y-%m-%dT%H:%M:%SZ', last_scanned_at), '')
+		)
+		WHERE scan_attributes = '{}'`); err != nil {
+		// Non-fatal: legacy rows just won't be back-filled; new scans populate
+		// scan_attributes directly. Log and continue.
+		slog.Warn("scan_attributes backfill failed", "error", err)
+	}
+
+	// Expression indexes (work on existing DBs without the generated columns).
+	// Safe to re-run via IF NOT EXISTS.
+	for _, idx := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_devices_scan_mac_expr    ON devices(json_extract(scan_attributes, '$.mac'))`,
+		`CREATE INDEX IF NOT EXISTS idx_devices_scan_vendor_expr ON devices(json_extract(scan_attributes, '$.vendor'))`,
+	} {
+		if _, err := db.Exec(idx); err != nil {
+			// Some SQLite builds gate expression indexes behind a compile flag;
+			// absence just means slower MAC/vendor lookups, not a failure.
+			slog.Warn("scan_attributes expression index creation skipped", "index", idx, "error", err)
+		}
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m); err != nil {
@@ -268,7 +319,132 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		return fmt.Errorf("scan_task_runs status migration: %w", err)
 	}
 
+	// Add the scan_attributes generated columns (scan_vendor/scan_mac/scan_os/
+	// scan_hostname) to existing DBs. SQLite can't ALTER ADD COLUMN with a
+	// non-constant expression, so a table rebuild is required. Fresh installs
+	// already get them from schema.sql; this is a no-op there.
+	if err := addDevicesGeneratedColumns(context.Background(), db); err != nil {
+		return fmt.Errorf("devices generated-columns migration: %w", err)
+	}
+
 	slog.Info("database schema applied")
+	return nil
+}
+
+// addDevicesGeneratedColumns adds the scan_attributes-derived generated columns
+// (scan_vendor/scan_mac/scan_os/scan_hostname) to existing DBs via SQLite's
+// 12-step table rebuild. SQLite disallows ALTER TABLE ADD COLUMN with a
+// non-constant generated expression, so the rebuild is the only path.
+//
+// Idempotent: if scan_mac already exists (fresh install, or already rebuilt),
+// this is a no-op. FK references to devices(id) in heartbeat_configs,
+// device_systems, and device_documents are preserved by name through the
+// rename (SQLite resolves FK by table name, not by internal rootpage).
+func addDevicesGeneratedColumns(ctx context.Context, db *sql.DB) error {
+	// Idempotency probe: does scan_mac already exist? Note that the older
+	// pragma_table_info HIDES generated columns — pragma_table_xinfo is the
+	// only pragma that surfaces them. Use it here so the rebuild doesn't run
+	// on every startup.
+	var ignore string
+	err := db.QueryRowContext(ctx,
+		`SELECT name FROM pragma_table_xinfo('devices') WHERE name = 'scan_mac' LIMIT 1`,
+	).Scan(&ignore)
+	if err == nil {
+		// Column already present — nothing to do.
+		return nil
+	}
+	if !strings.Contains(err.Error(), "no rows") {
+		return fmt.Errorf("probe devices.scan_mac: %w", err)
+	}
+
+	slog.Info("rebuilding devices table to add scan_attributes generated columns")
+
+	// Rebuild preserving the FULL current column set plus the 4 new generated
+	// columns. We list every column from schema.sql's CREATE TABLE so the copy
+	// is shape-identical (no data loss, no type drift). GENERATED ALWAYS AS
+	// columns are NOT copied explicitly — SQLite derives them on insert from
+	// the scan_attributes value being copied.
+	stmts := []string{
+		`CREATE TABLE devices_new (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'other' CHECK(type IN ('pc', 'embedded', 'iot', 'other', 'server', 'switch', 'router', 'firewall', 'nas', 'camera')),
+			brand TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			location TEXT NOT NULL DEFAULT '',
+			purpose TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('online', 'offline', 'unknown')),
+			ip_address TEXT NOT NULL DEFAULT '',
+			mac_address TEXT NOT NULL DEFAULT '',
+			serial_number TEXT NOT NULL DEFAULT '',
+			purchase_date TEXT NOT NULL DEFAULT '',
+			warranty_expiry TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT '{}',
+			scan_source TEXT NOT NULL DEFAULT 'manual',
+			prometheus_labels TEXT NOT NULL DEFAULT '{}',
+			last_scanned_at TIMESTAMP,
+			last_scan_task_id INTEGER,
+			open_ports TEXT NOT NULL DEFAULT '[]',
+			detected_services TEXT NOT NULL DEFAULT '[]',
+			prometheus_url TEXT NOT NULL DEFAULT '',
+			node_exporter_url TEXT NOT NULL DEFAULT '',
+			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`INSERT INTO devices_new (id, name, type, brand, model, location, purpose, description,
+			status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags,
+			scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports,
+			detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms,
+			scan_attributes, user_attributes, created_at, updated_at)
+		SELECT id, name, type, brand, model, location, purpose, description,
+			status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags,
+			scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports,
+			detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms,
+			scan_attributes, user_attributes, created_at, updated_at FROM devices`,
+		`DROP TABLE devices`,
+		`ALTER TABLE devices_new RENAME TO devices`,
+		// Re-create the indexes that existed on the original devices table.
+		`CREATE INDEX IF NOT EXISTS idx_devices_status ON devices(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_devices_type ON devices(type)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_ip_address ON devices(ip_address)`,
+		`CREATE INDEX IF NOT EXISTS idx_devices_scan_mac_expr    ON devices(json_extract(scan_attributes, '$.mac'))`,
+		`CREATE INDEX IF NOT EXISTS idx_devices_scan_vendor_expr ON devices(json_extract(scan_attributes, '$.vendor'))`,
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin devices rebuild tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// FK enforcement off for the rebuild (we're recreating the parent table;
+	// child rows in heartbeat_configs/device_systems/device_documents would
+	// otherwise fail the FK check mid-rebuild because the parent briefly
+	// doesn't exist). Re-enabled when the connection's next transaction opens
+	// (SQLite resets it per-transaction under WAL).
+	if _, err := tx.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return fmt.Errorf("disable FKs for rebuild: %w", err)
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("devices rebuild step failed: %w (stmt: %s)", err, s)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+		return fmt.Errorf("re-enable FKs after rebuild: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit devices rebuild: %w", err)
+	}
+	slog.Info("devices table rebuilt with scan_attributes generated columns")
 	return nil
 }
 

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -80,11 +80,30 @@ scanner:
   # persist_raw_evidence writes every probe observation to service_evidence.
   # Off by default — raw evidence can be voluminous; enable for debugging.
   persist_raw_evidence: false
+  # oui_path points to the IEEE OUI vendor-mapping file. The ARP probe derives
+  # a vendor from each discovered MAC via this table. Optional — when empty or
+  # missing, MACs are still recorded but no vendor is attached. Override at
+  # runtime with MIBEE_SCANNER_OUI_PATH. Fetch the canonical list with
+  # scripts/fetch-oui.sh (downloads from standardeee.org).
+  oui_path: ""
+  # snmp_community overrides the default SNMP community ("public") used by the
+  # SNMP probe. Override at runtime with MIBEE_SCANNER_SNMP_COMMUNITY.
+  snmp_community: "public"
+  # router_arp enables cross-subnet MAC resolution. When populated, the scanner
+  # walks these routers' SNMP ARP tables (ipNetToMediaPhysAddress) to find MACs
+  # for hosts the scanner can't reach at L2 (e.g. cameras on a different VLAN).
+  # Requires the router to run SNMP with the given community. Empty (default)
+  # → cross-subnet MAC disabled; the scanner falls back to /proc/net/arp (local
+  # subnet only).
+  router_arp:
+    routers: []        # e.g. ["192.168.63.1", "192.168.62.1"]
+    community: "public"
+    timeout: 4         # seconds per router walk
   pipeline_defaults:
     icmp_enabled: true
     snmp_enabled: true
     port_scan_enabled: true
-    default_ports: "22,80,443,8080,8443,8000,554,8554,9090,9100,9104,9113,9121,9187,161"
+    default_ports: "22,21,23,25,53,80,110,143,389,443,445,554,631,636,8554,1433,3306,3389,5432,5900,6379,8000,8080,8081,8443,8888,9000,9090,9100,9104,9113,9121,9187,9200,9443,11211,27017,161"
     service_detection_enabled: true
     prometheus_check_enabled: true
     node_exporter_enabled: true

--- a/configs/oui-curated.txt
+++ b/configs/oui-curated.txt
@@ -1,0 +1,41 @@
+# MiBee curated OUI subset — common vendor prefixes for the test environment.
+# Format: <6-hex-prefix>\t<vendor>. Covers cameras, printers, networking, and
+# consumer gear likely on the 192.168.62/63 test subnets. Replace with the full
+# IEEE list via scripts/fetch-oui.sh for production coverage.
+# Camera / NVR vendors
+BCAD28	Hikvision Digital Technology
+54E4BD	Hikvision Digital Technology
+EC7129	Hikvision Digital Technology
+4C11BF	Hikvision Digital Technology
+3CEFFB	Hikvision Digital Technology
+A04CB1	Dahua Technology
+C8147D	Dahua Technology
+14A7EC	Dahua Technology
+38AF29	Dahua Technology
+ACCC0E	Axis Communications
+00408F	Axis Communications
+B8A44F	Axis Communications
+# Printers
+002A4A	Epson
+B85ACF	Epson
+0021B7	Hewlett-Packard
+002258	Hewlett-Packard
+# Networking
+005056	VMware
+000C29	VMware
+080027	PCS Systemtechnik (VirtualBox)
+B827EB	Raspberry Pi Foundation
+DCA632	Raspberry Pi Trading
+E45F01	Raspberry Pi Trading
+00E04C	Realtek
+# Consumer / general
+001122	Google
+F09FC2	Apple
+ACDE48	Apple
+ACBC32	Apple
+001F5B	Apple
+A4B10C	Apple
+# Generic NAS / consumer routers
+001122	Synology
+00011D	Synology
+002211	QNAP Systems

--- a/db/queries/devices.sql
+++ b/db/queries/devices.sql
@@ -2,17 +2,17 @@
 INSERT INTO devices (
     name, type, brand, model, location, purpose, description,
     status, ip_address, mac_address, serial_number,
-    purchase_date, warranty_expiry, tags
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at;
+    purchase_date, warranty_expiry, tags, user_attributes
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at;
 
 -- name: GetDevice :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE id = ?;
 
 -- name: ListDevices :many
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -20,12 +20,23 @@ ORDER BY id
 LIMIT ? OFFSET ?;
 
 -- name: UpdateDevice :one
+-- Note: scan_attributes is engine-owned and intentionally NOT updated here.
+-- user_attributes is updated via UpdateUserAttributes so the full-row update
+-- can't race the user-edit path.
 UPDATE devices
 SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, description = ?,
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at;
+RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at;
+
+-- name: UpdateUserAttributes :exec
+UPDATE devices SET user_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?;
+
+-- name: UpdateScanAttributes :exec
+-- Engine-only: replaces the full scan_attributes document. Device bridge and
+-- store/sqlite call this with the freshly-marshalled JSON after a scan run.
+UPDATE devices SET scan_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?;
 
 -- name: DeleteDevice :execrows
 DELETE FROM devices
@@ -54,9 +65,19 @@ SET scan_source = ?, prometheus_labels = ?, last_scanned_at = ?, last_scan_task_
 WHERE id = ?;
 
 -- name: GetDeviceByIP :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
+LIMIT 1;
+
+-- name: GetDeviceByMAC :one
+-- Looks up by normalized scan MAC. Uses json_extract so the query works on
+-- both fresh installs (which have the scan_mac generated column) and upgraded
+-- DBs (which have an expression index on json_extract instead). The expression
+-- index idx_devices_scan_mac_expr covers this WHERE clause on either shape.
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
+FROM devices
+WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1;
 
 -- name: UpdateDeviceStatus :exec

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,6 +43,19 @@ CREATE TABLE IF NOT EXISTS devices (
     prometheus_url TEXT NOT NULL DEFAULT '',
     node_exporter_url TEXT NOT NULL DEFAULT '',
     last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+    -- Dual JSON layer: scan_attributes (engine-written discovery aggregation)
+    -- and user_attributes (free-form user-edited key/value map). See
+    -- internal/domain/device_attributes.go for the typed structs.
+    scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+    user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+    -- Hot-path generated columns extracted from scan_attributes for filtering/
+    -- indexing. STORED so they can be indexed directly. Added via ALTER on
+    -- existing DBs (see cmd/server/main.go rebuild migration); defined inline
+    -- here so fresh installs get them automatically.
+    scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+    scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+    scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+    scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -139,6 +152,11 @@ CREATE TABLE IF NOT EXISTS device_systems (
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_devices_status ON devices(status);
 CREATE INDEX IF NOT EXISTS idx_devices_type ON devices(type);
+-- NOTE: scan_attributes expression indexes are created in
+-- cmd/server/main.go (runMigrations) AFTER the ALTER TABLE that adds the
+-- scan_attributes column. They cannot live here because schema replay runs
+-- before the ALTER on existing DBs and would fail with "no such column".
+-- (Fresh installs get them via the same migration step, which is idempotent.)
 CREATE INDEX IF NOT EXISTS idx_heartbeat_results_device ON heartbeat_results(device_id, checked_at);
 CREATE INDEX IF NOT EXISTS idx_heartbeat_results_checked_at ON heartbeat_results(checked_at);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -20,6 +20,7 @@ import (
 	scannerv2cleanup "mibee-steward/internal/service/scannerv2/cleanup"
 	scannerv2ebpf "mibee-steward/internal/service/scannerv2/ebpf"
 	scannerv2engine "mibee-steward/internal/service/scannerv2/engine"
+	scannerv2probe "mibee-steward/internal/service/scannerv2/probe"
 	scannerv2runner "mibee-steward/internal/service/scannerv2/runner"
 	scannerv2scheduler "mibee-steward/internal/service/scannerv2/scheduler"
 	scannerv2task "mibee-steward/internal/service/scannerv2/taskservice"
@@ -161,7 +162,17 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	scanQueries := db.New(dbConn)
 
 	// Construct the v2 engine: probes/classifiers/handlers + persistence + eBPF observer.
-	scannerPortSpec := "22,80,443,8080,8443,8000,554,8554,9090,9100,9104,9113,9121,9187,161"
+	// Port spec: prefer the configured default_ports (config.yaml
+	// scanner.pipeline_defaults.default_ports) and fall back to the v2 default
+	// set if unset. The default set covers web/admin + cameras + prometheus +
+	// databases + mail + remote-access so the common inventory cases are caught
+	// out of the box.
+	scannerPortSpec := cfg.Scanner.PipelineDefaults.DefaultPorts
+	if scannerPortSpec == "" {
+		scannerPortSpec = "22,21,23,25,53,80,110,143,389,443,445,554,631,636,8554,1433," +
+			"3306,3389,5432,5900,6379,8000,8080,8081,8443,8888,9000,9090,9100,9104," +
+			"9113,9121,9187,9200,9443,11211,27017,161"
+	}
 	v2Engine, engineErr := scannerv2engine.NewEngine(dbConn, scannerv2engine.Config{
 		PortSpec:           scannerPortSpec,
 		MaxConcurrentHosts: cfg.Scanner.MaxConcurrentHosts,
@@ -169,8 +180,15 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		PerHostTimeout:     time.Duration(cfg.Scanner.DefaultTimeout) * time.Second,
 		PerProbeTimeout:    time.Duration(cfg.Scanner.PerProbeTimeout) * time.Second,
 		PersistRawEvidence: cfg.Scanner.PersistRawEvidence,
-		HeartbeatInterval:  cfg.Heartbeat.DefaultInterval,
-		HeartbeatTimeout:   cfg.Heartbeat.Timeout,
+		OUIPath:            cfg.Scanner.OUIPath,
+		SNMPCommunity:      cfg.Scanner.SNMPCommunity,
+		RouterARP: scannerv2probe.RouterARPConfig{
+			Routers:   cfg.Scanner.RouterARP.Routers,
+			Community: routerCommunity(cfg.Scanner),
+			Timeout:   time.Duration(routerTimeout(cfg.Scanner)) * time.Second,
+		},
+		HeartbeatInterval: cfg.Heartbeat.DefaultInterval,
+		HeartbeatTimeout:  cfg.Heartbeat.Timeout,
 		EBPF: scannerv2ebpf.Config{
 			Enabled:    cfg.Scanner.EBPF.Enabled,
 			Interfaces: cfg.Scanner.EBPF.Interfaces,
@@ -439,4 +457,24 @@ func chunkSlice[S any](items []S, batchSize int) [][]S {
 		chunks = append(chunks, items[i:end])
 	}
 	return chunks
+}
+
+// routerCommunity resolves the SNMP community for cross-subnet ARP walks:
+// prefer the dedicated router_arp.community, fall back to the global snmp_community.
+func routerCommunity(cfg config.ScannerConfig) string {
+	if cfg.RouterARP.Community != "" {
+		return cfg.RouterARP.Community
+	}
+	if cfg.SNMPCommunity != "" {
+		return cfg.SNMPCommunity
+	}
+	return "public"
+}
+
+// routerTimeout resolves the per-router ARP-walk timeout in seconds (default 4).
+func routerTimeout(cfg config.ScannerConfig) int {
+	if cfg.RouterARP.Timeout > 0 {
+		return cfg.RouterARP.Timeout
+	}
+	return 4
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,7 +121,28 @@ type ScannerConfig struct {
 	PipelineDefaults   PipelineDefaultsConfig `koanf:"pipeline_defaults"`
 	Engine             string                 `koanf:"engine"` // "v1" (legacy) or "v2" (new); default "v1" during transition
 	PersistRawEvidence bool                   `koanf:"persist_raw_evidence"`
-	EBPF               EBPFConfig             `koanf:"ebpf"`
+	// OUIPath points to the IEEE OUI vendor-mapping file used by the ARP probe
+	// to derive a vendor from a MAC address. Optional; when empty or missing,
+	// the MAC is still recorded but no vendor is attached. Override with the
+	// MIBEE_SCANNER_OUI_PATH env var.
+	OUIPath string `koanf:"oui_path"`
+	// SNMPCommunity is the default community string for the SNMP probe
+	// (default "public" if empty). Override with MIBEE_SCANNER_SNMP_COMMUNITY.
+	SNMPCommunity string `koanf:"snmp_community"`
+	// RouterARP enables cross-subnet MAC resolution. When populated, the scanner
+	// walks these routers' SNMP ARP tables (ipNetToMediaPhysAddress) to find MACs
+	// for hosts the scanner can't reach at L2. The community defaults to
+	// SNMPCommunity when empty.
+	RouterARP RouterARPConfig `koanf:"router_arp"`
+	EBPF      EBPFConfig      `koanf:"ebpf"`
+}
+
+// RouterARPConfig configures cross-subnet MAC resolution via SNMP ARP walks of
+// routers on the target subnets.
+type RouterARPConfig struct {
+	Routers   []string `koanf:"routers"`
+	Community string   `koanf:"community"`
+	Timeout   int      `koanf:"timeout"` // seconds; default 4
 }
 
 // EBPFConfig controls the passive eBPF observer (v2 engine only). Even with

--- a/internal/db/devices.sql.go
+++ b/internal/db/devices.sql.go
@@ -108,9 +108,9 @@ const createDevice = `-- name: CreateDevice :one
 INSERT INTO devices (
     name, type, brand, model, location, purpose, description,
     status, ip_address, mac_address, serial_number,
-    purchase_date, warranty_expiry, tags
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+    purchase_date, warranty_expiry, tags, user_attributes
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 `
 
 type CreateDeviceParams struct {
@@ -128,6 +128,7 @@ type CreateDeviceParams struct {
 	PurchaseDate   string `json:"purchase_date"`
 	WarrantyExpiry string `json:"warranty_expiry"`
 	Tags           string `json:"tags"`
+	UserAttributes string `json:"user_attributes"`
 }
 
 func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Device, error) {
@@ -146,6 +147,7 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 		arg.PurchaseDate,
 		arg.WarrantyExpiry,
 		arg.Tags,
+		arg.UserAttributes,
 	)
 	var i Device
 	err := row.Scan(
@@ -173,6 +175,12 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 		&i.PrometheusUrl,
 		&i.NodeExporterUrl,
 		&i.LastScanRttMs,
+		&i.ScanAttributes,
+		&i.UserAttributes,
+		&i.ScanVendor,
+		&i.ScanMac,
+		&i.ScanOs,
+		&i.ScanHostname,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -193,7 +201,7 @@ func (q *Queries) DeleteDevice(ctx context.Context, id int64) (int64, error) {
 }
 
 const getDevice = `-- name: GetDevice :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE id = ?
 `
@@ -226,6 +234,12 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 		&i.PrometheusUrl,
 		&i.NodeExporterUrl,
 		&i.LastScanRttMs,
+		&i.ScanAttributes,
+		&i.UserAttributes,
+		&i.ScanVendor,
+		&i.ScanMac,
+		&i.ScanOs,
+		&i.ScanHostname,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -233,7 +247,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 }
 
 const getDeviceByIP = `-- name: GetDeviceByIP :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1
@@ -267,30 +281,71 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 		&i.PrometheusUrl,
 		&i.NodeExporterUrl,
 		&i.LastScanRttMs,
+		&i.ScanAttributes,
+		&i.UserAttributes,
+		&i.ScanVendor,
+		&i.ScanMac,
+		&i.ScanOs,
+		&i.ScanHostname,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
 	return i, err
 }
 
-const updateDeviceStatus = `-- name: UpdateDeviceStatus :exec
-UPDATE devices
-SET status = ?, updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
+const getDeviceByMAC = `-- name: GetDeviceByMAC :one
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
+FROM devices
+WHERE json_extract(scan_attributes, '$.mac') = ?
+LIMIT 1
 `
 
-type UpdateDeviceStatusParams struct {
-	Status string `json:"status"`
-	ID     int64  `json:"id"`
-}
-
-func (q *Queries) UpdateDeviceStatus(ctx context.Context, arg UpdateDeviceStatusParams) error {
-	_, err := q.db.ExecContext(ctx, updateDeviceStatus, arg.Status, arg.ID)
-	return err
+// Looks up by normalized scan MAC. Uses json_extract so the query works on
+// both fresh installs (which have the scan_mac generated column) and upgraded
+// DBs (which have an expression index on json_extract instead). The expression
+// index idx_devices_scan_mac_expr covers this WHERE clause on either shape.
+func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (Device, error) {
+	row := q.db.QueryRowContext(ctx, getDeviceByMAC, scanAttributes)
+	var i Device
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Type,
+		&i.Brand,
+		&i.Model,
+		&i.Location,
+		&i.Purpose,
+		&i.Description,
+		&i.Status,
+		&i.IpAddress,
+		&i.MacAddress,
+		&i.SerialNumber,
+		&i.PurchaseDate,
+		&i.WarrantyExpiry,
+		&i.Tags,
+		&i.ScanSource,
+		&i.PrometheusLabels,
+		&i.LastScannedAt,
+		&i.LastScanTaskID,
+		&i.OpenPorts,
+		&i.DetectedServices,
+		&i.PrometheusUrl,
+		&i.NodeExporterUrl,
+		&i.LastScanRttMs,
+		&i.ScanAttributes,
+		&i.UserAttributes,
+		&i.ScanVendor,
+		&i.ScanMac,
+		&i.ScanOs,
+		&i.ScanHostname,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const listDevices = `-- name: ListDevices :many
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -348,6 +403,12 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 			&i.PrometheusUrl,
 			&i.NodeExporterUrl,
 			&i.LastScanRttMs,
+			&i.ScanAttributes,
+			&i.UserAttributes,
+			&i.ScanVendor,
+			&i.ScanMac,
+			&i.ScanOs,
+			&i.ScanHostname,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -370,7 +431,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, created_at, updated_at
+RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, created_at, updated_at
 `
 
 type UpdateDeviceParams struct {
@@ -391,6 +452,9 @@ type UpdateDeviceParams struct {
 	ID             int64  `json:"id"`
 }
 
+// Note: scan_attributes is engine-owned and intentionally NOT updated here.
+// user_attributes is updated via UpdateUserAttributes so the full-row update
+// can't race the user-edit path.
 func (q *Queries) UpdateDevice(ctx context.Context, arg UpdateDeviceParams) (Device, error) {
 	row := q.db.QueryRowContext(ctx, updateDevice,
 		arg.Name,
@@ -435,6 +499,12 @@ func (q *Queries) UpdateDevice(ctx context.Context, arg UpdateDeviceParams) (Dev
 		&i.PrometheusUrl,
 		&i.NodeExporterUrl,
 		&i.LastScanRttMs,
+		&i.ScanAttributes,
+		&i.UserAttributes,
+		&i.ScanVendor,
+		&i.ScanMac,
+		&i.ScanOs,
+		&i.ScanHostname,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -473,5 +543,55 @@ func (q *Queries) UpdateDeviceScanInfo(ctx context.Context, arg UpdateDeviceScan
 		arg.LastScanRttMs,
 		arg.ID,
 	)
+	return err
+}
+
+const updateDeviceStatus = `-- name: UpdateDeviceStatus :exec
+UPDATE devices
+SET status = ?, updated_at = CURRENT_TIMESTAMP
+WHERE id
+`
+
+type UpdateDeviceStatusParams struct {
+	Status string `json:"status"`
+	ID     int64  `json:"id"`
+}
+
+// Updates ONLY the status column (and updated_at). Used by the heartbeat
+// service so a status transition doesn't clobber other columns (name, tags,
+// location, …) that may have been edited between the GetDevice read and this
+// write — the full-row UpdateDevice path is racy in that window.
+func (q *Queries) UpdateDeviceStatus(ctx context.Context, arg UpdateDeviceStatusParams) error {
+	_, err := q.db.ExecContext(ctx, updateDeviceStatus, arg.Status, arg.ID)
+	return err
+}
+
+const updateScanAttributes = `-- name: UpdateScanAttributes :exec
+UPDATE devices SET scan_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?
+`
+
+type UpdateScanAttributesParams struct {
+	ScanAttributes string `json:"scan_attributes"`
+	ID             int64  `json:"id"`
+}
+
+// Engine-only: replaces the full scan_attributes document. Device bridge and
+// store/sqlite call this with the freshly-marshalled JSON after a scan run.
+func (q *Queries) UpdateScanAttributes(ctx context.Context, arg UpdateScanAttributesParams) error {
+	_, err := q.db.ExecContext(ctx, updateScanAttributes, arg.ScanAttributes, arg.ID)
+	return err
+}
+
+const updateUserAttributes = `-- name: UpdateUserAttributes :exec
+UPDATE devices SET user_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?
+`
+
+type UpdateUserAttributesParams struct {
+	UserAttributes string `json:"user_attributes"`
+	ID             int64  `json:"id"`
+}
+
+func (q *Queries) UpdateUserAttributes(ctx context.Context, arg UpdateUserAttributesParams) error {
+	_, err := q.db.ExecContext(ctx, updateUserAttributes, arg.UserAttributes, arg.ID)
 	return err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -71,6 +71,12 @@ type Device struct {
 	PrometheusUrl    string     `json:"prometheus_url"`
 	NodeExporterUrl  string     `json:"node_exporter_url"`
 	LastScanRttMs    int64      `json:"last_scan_rtt_ms"`
+	ScanAttributes   string     `json:"scan_attributes"`
+	UserAttributes   string     `json:"user_attributes"`
+	ScanVendor       *string    `json:"scan_vendor"`
+	ScanMac          *string    `json:"scan_mac"`
+	ScanOs           *string    `json:"scan_os"`
+	ScanHostname     *string    `json:"scan_hostname"`
 	CreatedAt        time.Time  `json:"created_at"`
 	UpdatedAt        time.Time  `json:"updated_at"`
 }
@@ -130,6 +136,17 @@ type HeartbeatResult struct {
 	LatencyMs    float64   `json:"latency_ms"`
 	ErrorMessage string    `json:"error_message"`
 	CheckedAt    time.Time `json:"checked_at"`
+}
+
+type HostService struct {
+	ID         int64     `json:"id"`
+	Ip         string    `json:"ip"`
+	Service    string    `json:"service"`
+	Port       int64     `json:"port"`
+	Protocol   string    `json:"protocol"`
+	Confidence float64   `json:"confidence"`
+	Metadata   string    `json:"metadata"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 type NotificationChannel struct {
@@ -209,6 +226,18 @@ type ScanTaskRun struct {
 	StartedAt    *time.Time `json:"started_at"`
 	FinishedAt   *time.Time `json:"finished_at"`
 	CreatedAt    time.Time  `json:"created_at"`
+}
+
+type ServiceEvidence struct {
+	ID         int64     `json:"id"`
+	Ip         string    `json:"ip"`
+	Source     string    `json:"source"`
+	Kind       string    `json:"kind"`
+	Port       int64     `json:"port"`
+	Protocol   string    `json:"protocol"`
+	RawData    string    `json:"raw_data"`
+	Confidence float64   `json:"confidence"`
+	ObservedAt time.Time `json:"observed_at"`
 }
 
 type User struct {

--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -29,19 +29,20 @@ const (
 // Request types
 
 type CreateDeviceRequest struct {
-	Name           string `json:"name"`
-	Type           string `json:"type"`
-	Brand          string `json:"brand"`
-	Model          string `json:"model"`
-	Location       string `json:"location"`
-	Purpose        string `json:"purpose"`
-	Description    string `json:"description"`
-	IPAddress      string `json:"ip_address"`
-	MACAddress     string `json:"mac_address"`
-	SerialNumber   string `json:"serial_number"`
-	PurchaseDate   string `json:"purchase_date"`
-	WarrantyExpiry string `json:"warranty_expiry"`
-	Tags           string `json:"tags"`
+	Name           string         `json:"name"`
+	Type           string         `json:"type"`
+	Brand          string         `json:"brand"`
+	Model          string         `json:"model"`
+	Location       string         `json:"location"`
+	Purpose        string         `json:"purpose"`
+	Description    string         `json:"description"`
+	IPAddress      string         `json:"ip_address"`
+	MACAddress     string         `json:"mac_address"`
+	SerialNumber   string         `json:"serial_number"`
+	PurchaseDate   string         `json:"purchase_date"`
+	WarrantyExpiry string         `json:"warranty_expiry"`
+	Tags           string         `json:"tags"`
+	UserAttributes UserAttributes `json:"user_attributes,omitempty"`
 }
 
 type UpdateDeviceRequest struct {
@@ -58,6 +59,10 @@ type UpdateDeviceRequest struct {
 	PurchaseDate   *string `json:"purchase_date,omitempty"`
 	WarrantyExpiry *string `json:"warranty_expiry,omitempty"`
 	Tags           *string `json:"tags,omitempty"`
+	// UserAttributesPatch is merged into the existing user_attributes map.
+	// Empty-string values delete keys. scan_attributes is engine-owned and
+	// cannot be set through this request.
+	UserAttributesPatch UserAttributes `json:"user_attributes,omitempty"`
 }
 
 type DeviceFilter struct {
@@ -96,6 +101,12 @@ type DeviceResponse struct {
 	PrometheusURL    string     `json:"prometheus_url"`
 	NodeExporterURL  string     `json:"node_exporter_url"`
 	LastScanRttMs    int64      `json:"last_scan_rtt_ms"`
+	// Dual JSON layer. ScanAttributes is the typed view of the engine-written
+	// discovery document; UserAttributes is the free-form user map. The legacy
+	// JSON-string fields above (open_ports, detected_services, prometheus_labels)
+	// remain populated for backwards compatibility — frontend may read either.
+	ScanAttributes ScanAttributes `json:"scan_attributes"`
+	UserAttributes UserAttributes `json:"user_attributes"`
 }
 
 type DeviceListResponse struct {

--- a/internal/domain/device_attributes.go
+++ b/internal/domain/device_attributes.go
@@ -1,0 +1,189 @@
+package domain
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ScanAttributes is the engine-written aggregation of everything a scan
+// discovered about a device. It is serialized as JSON into the devices.
+// scan_attributes column. The four generated columns
+// (scan_vendor / scan_mac / scan_os / scan_hostname) are derived from the
+// top-level Vendor / MAC / OS / Hostname fields via json_extract, so those
+// field names and JSON keys are part of the query contract — rename with care.
+//
+// Ownership: ONLY the scanner engine (scannerv2 device bridge + store) writes
+// this struct. User edits go to UserAttributes. The split keeps engine and
+// user data from clobbering each other.
+type ScanAttributes struct {
+	// Identity / hardware
+	Vendor   string `json:"vendor,omitempty"`   // OUI lookup or SNMP/HTTP-derived vendor
+	MAC      string `json:"mac,omitempty"`      // normalized lowercase "aa:bb:cc:.."
+	Hostname string `json:"hostname,omitempty"` // rDNS / mDNS / TLS CN / SNMP sysName
+
+	// OS / firmware
+	OS              string `json:"os,omitempty"`             // "Linux", "Windows", "iOS", …
+	OSVersion       string `json:"os_version,omitempty"`     // parsed version string
+	KernelVersion   string `json:"kernel_version,omitempty"` // node_exporter node_uname_info release
+	FirmwareVersion string `json:"firmware_version,omitempty"`
+
+	// Resources (node_exporter)
+	CPUCount         int    `json:"cpu_count,omitempty"`
+	CPUModel         string `json:"cpu_model,omitempty"`
+	MemoryTotalBytes int64  `json:"memory_total_bytes,omitempty"`
+
+	// Liveness / timing
+	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
+	TTL           int    `json:"ttl,omitempty"`
+	LastScanRttMs int64  `json:"last_scan_rtt_ms,omitempty"`
+	ScanSource    string `json:"scan_source,omitempty"`
+	LastScannedAt string `json:"last_scanned_at,omitempty"` // RFC3339; empty when never scanned
+
+	// Scanner classification summary
+	InferredType        string `json:"inferred_type,omitempty"`
+	InferredDescription string `json:"inferred_description,omitempty"`
+
+	// Discovery surfaces (kept struct-shaped where stable, free-form otherwise)
+	SNMP             *SNMPDiscovery  `json:"snmp,omitempty"`
+	OpenPorts        []OpenPortEntry `json:"open_ports,omitempty"`
+	DetectedServices []ServiceEntry  `json:"detected_services,omitempty"`
+	Prometheus       *PrometheusInfo `json:"prometheus,omitempty"`
+
+	// Free-form overflow for probe-specific output that doesn't fit a typed
+	// field above (e.g. mDNS TXT records, SSDP location, TLS SAN list).
+	// Keys are dotted namespaced by source ("mdns.model", "ssdp.server", …).
+	Extras map[string]string `json:"extras,omitempty"`
+}
+
+// SNMPDiscovery holds the parsed result of an SNMP sysObject query.
+type SNMPDiscovery struct {
+	SysDescr    string `json:"sys_descr,omitempty"`
+	SysObjectID string `json:"sys_object_id,omitempty"`
+	SysName     string `json:"sys_name,omitempty"`
+	SysLocation string `json:"sys_location,omitempty"`
+	SysContact  string `json:"sys_contact,omitempty"`
+	SysServices int    `json:"sys_services,omitempty"`
+}
+
+// OpenPortEntry is one element of ScanAttributes.OpenPorts. Shape must match
+// the legacy open_ports JSON column so the frontend parser can read either.
+type OpenPortEntry struct {
+	Port    int    `json:"port"`
+	Service string `json:"service,omitempty"`
+}
+
+// ServiceEntry mirrors the legacy detected_services element shape.
+type ServiceEntry struct {
+	Port     int    `json:"port"`
+	Name     string `json:"name"`
+	Protocol string `json:"protocol,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+// PrometheusInfo aggregates prometheus_url / node_exporter_url + the legacy
+// prometheus_labels map (used by the /sd service-discovery endpoint).
+type PrometheusInfo struct {
+	URL             string            `json:"url,omitempty"`
+	NodeExporterURL string            `json:"node_exporter_url,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+}
+
+// UserAttributes is the user-edited free-form key/value map. Stored as JSON
+// in devices.user_attributes. The frontend renders it as an editable
+// {key,value} panel (see web/src/lib/components/scanner/LabelEditor.svelte).
+type UserAttributes map[string]string
+
+// MarshalScanAttributes serializes a ScanAttributes into the JSON string the
+// DB column holds. Empty struct → "{}" so the column never stores "null".
+func MarshalScanAttributes(s ScanAttributes) (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("marshal scan_attributes: %w", err)
+	}
+	return string(b), nil
+}
+
+// UnmarshalScanAttributes parses a scan_attributes JSON string. An empty or
+// NULL column yields the zero value with no error.
+func UnmarshalScanAttributes(raw string) (ScanAttributes, error) {
+	var s ScanAttributes
+	if raw == "" {
+		return s, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		return ScanAttributes{}, fmt.Errorf("unmarshal scan_attributes: %w", err)
+	}
+	return s, nil
+}
+
+// UnmarshalScanAttributesPtr is the sql.NullString variant for generated
+// queries when a left join may produce NULL. Currently the scan_attributes
+// column is NOT NULL DEFAULT '{}' so the plain string helper above suffices.
+func UnmarshalScanAttributesPtr(v sql.NullString) (ScanAttributes, error) {
+	if !v.Valid {
+		return ScanAttributes{}, nil
+	}
+	return UnmarshalScanAttributes(v.String)
+}
+
+// MarshalUserAttributes serializes a UserAttributes map. nil/empty → "{}".
+func MarshalUserAttributes(u UserAttributes) (string, error) {
+	if len(u) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(u)
+	if err != nil {
+		return "", fmt.Errorf("marshal user_attributes: %w", err)
+	}
+	return string(b), nil
+}
+
+// UnmarshalUserAttributes parses a user_attributes JSON string into a map.
+// Returns a non-nil (possibly empty) map.
+func UnmarshalUserAttributes(raw string) (UserAttributes, error) {
+	u := UserAttributes{}
+	if raw == "" {
+		return u, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &u); err != nil {
+		return UserAttributes{}, fmt.Errorf("unmarshal user_attributes: %w", err)
+	}
+	if u == nil {
+		u = UserAttributes{}
+	}
+	return u, nil
+}
+
+// MergeUserAttributes applies a patch over base: patch's keys overwrite base
+// (including empty-string values, which the caller can use to delete a key).
+// Returns a new map; base and patch are not mutated.
+func MergeUserAttributes(base UserAttributes, patch UserAttributes) UserAttributes {
+	out := UserAttributes{}
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range patch {
+		if v == "" {
+			delete(out, k)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// ScanLastScannedTime parses the LastScannedAt RFC3339 string; returns the
+// zero time when empty or unparseable. Convenience for callers that want a
+// time.Time instead of a string.
+func (s ScanAttributes) ScanLastScannedTime() time.Time {
+	if s.LastScannedAt == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s.LastScannedAt)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/internal/domain/device_attributes_test.go
+++ b/internal/domain/device_attributes_test.go
@@ -1,0 +1,111 @@
+package domain
+
+import (
+	"testing"
+)
+
+func TestMarshalScanAttributes_OmitsZeroValues(t *testing.T) {
+	out, err := MarshalScanAttributes(ScanAttributes{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if out != "{}" {
+		t.Errorf("empty struct marshalled to %q, want {}", out)
+	}
+}
+
+func TestMarshalScanAttributes_RoundTrip(t *testing.T) {
+	in := ScanAttributes{
+		OS:               "Linux",
+		OSVersion:        "6.19.0-arch",
+		Vendor:           "Hikvision",
+		MAC:              "bc:ad:28:11:22:33",
+		Hostname:         "cam-front",
+		CPUCount:         4,
+		MemoryTotalBytes: 8589934592,
+		UptimeSeconds:    1843200,
+		OpenPorts:        []OpenPortEntry{{Port: 80, Service: "http"}, {Port: 554, Service: "rtsp"}},
+		SNMP:             &SNMPDiscovery{SysDescr: "Linux 6.19", SysObjectID: "1.3.6.1.4.1.12345"},
+		Prometheus:       &PrometheusInfo{URL: "http://x:9090/metrics", NodeExporterURL: "http://x:9100/metrics"},
+	}
+	raw, err := MarshalScanAttributes(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := UnmarshalScanAttributes(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.OS != "Linux" || out.Vendor != "Hikvision" || out.MAC != "bc:ad:28:11:22:33" {
+		t.Errorf("identity fields lost: %+v", out)
+	}
+	if out.CPUCount != 4 || out.MemoryTotalBytes != 8589934592 || out.UptimeSeconds != 1843200 {
+		t.Errorf("numeric fields lost: %+v", out)
+	}
+	if out.SNMP == nil || out.SNMP.SysObjectID != "1.3.6.1.4.1.12345" {
+		t.Errorf("SNMP sub-struct lost: %+v", out.SNMP)
+	}
+	if len(out.OpenPorts) != 2 || out.OpenPorts[1].Service != "rtsp" {
+		t.Errorf("OpenPorts lost: %+v", out.OpenPorts)
+	}
+	if out.Prometheus == nil || out.Prometheus.NodeExporterURL == "" {
+		t.Errorf("Prometheus sub-struct lost: %+v", out.Prometheus)
+	}
+}
+
+func TestUnmarshalScanAttributes_EmptyAndInvalid(t *testing.T) {
+	if s, err := UnmarshalScanAttributes(""); err != nil || s.OS != "" {
+		t.Errorf("empty string should yield zero struct, got %+v err=%v", s, err)
+	}
+	if _, err := UnmarshalScanAttributes("{not json"); err == nil {
+		t.Errorf("invalid JSON should error")
+	}
+}
+
+func TestMarshalUserAttributes_EmptyIsBraceBrace(t *testing.T) {
+	out, err := MarshalUserAttributes(nil)
+	if err != nil || out != "{}" {
+		t.Errorf("nil map → %q err=%v, want {}", out, err)
+	}
+	out, err = MarshalUserAttributes(UserAttributes{})
+	if err != nil || out != "{}" {
+		t.Errorf("empty map → %q err=%v, want {}", out, err)
+	}
+}
+
+func TestMergeUserAttributes_OverwritesAndDeletes(t *testing.T) {
+	base := UserAttributes{"keep": "1", "overwrite": "old", "delete": "x"}
+	patch := UserAttributes{"overwrite": "new", "delete": "", "added": "y"}
+	merged := MergeUserAttributes(base, patch)
+	if merged["keep"] != "1" {
+		t.Errorf("unchanged key lost: %v", merged)
+	}
+	if merged["overwrite"] != "new" {
+		t.Errorf("overwrite failed: %v", merged)
+	}
+	if _, ok := merged["delete"]; ok {
+		t.Errorf("empty-value patch should delete key: %v", merged)
+	}
+	if merged["added"] != "y" {
+		t.Errorf("new key not added: %v", merged)
+	}
+	// Originals untouched.
+	if base["delete"] != "x" {
+		t.Errorf("base mutated: %v", base)
+	}
+}
+
+func TestScanLastScannedTime(t *testing.T) {
+	s := ScanAttributes{LastScannedAt: "2026-07-05T12:00:00Z"}
+	if got := s.ScanLastScannedTime(); got.IsZero() {
+		t.Errorf("valid RFC3339 parsed to zero time")
+	}
+	s2 := ScanAttributes{LastScannedAt: "garbage"}
+	if got := s2.ScanLastScannedTime(); !got.IsZero() {
+		t.Errorf("garbage string should yield zero time, got %v", got)
+	}
+	s3 := ScanAttributes{}
+	if got := s3.ScanLastScannedTime(); !got.IsZero() {
+		t.Errorf("empty string should yield zero time, got %v", got)
+	}
+}

--- a/internal/repository/device.go
+++ b/internal/repository/device.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"mibee-steward/internal/db"
@@ -30,6 +32,11 @@ func (r *DeviceRepository) Create(ctx context.Context, req domain.CreateDeviceRe
 		tags = "{}"
 	}
 
+	userAttrs, err := domain.MarshalUserAttributes(req.UserAttributes)
+	if err != nil {
+		return db.Device{}, fmt.Errorf("failed to marshal user_attributes: %w", err)
+	}
+
 	device, err := r.queries.CreateDevice(ctx, db.CreateDeviceParams{
 		Name:           req.Name,
 		Type:           deviceType,
@@ -45,11 +52,54 @@ func (r *DeviceRepository) Create(ctx context.Context, req domain.CreateDeviceRe
 		PurchaseDate:   req.PurchaseDate,
 		WarrantyExpiry: req.WarrantyExpiry,
 		Tags:           tags,
+		UserAttributes: userAttrs,
 	})
 	if err != nil {
 		return db.Device{}, fmt.Errorf("failed to create device: %w", err)
 	}
 	return device, nil
+}
+
+// UpdateUserAttributes replaces the user_attributes JSON document for a device.
+func (r *DeviceRepository) UpdateUserAttributes(ctx context.Context, id int64, attrs domain.UserAttributes) error {
+	raw, err := domain.MarshalUserAttributes(attrs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal user_attributes: %w", err)
+	}
+	return r.queries.UpdateUserAttributes(ctx, db.UpdateUserAttributesParams{
+		UserAttributes: raw,
+		ID:             id,
+	})
+}
+
+// UpdateScanAttributes replaces the engine-owned scan_attributes JSON
+// document for a device. Only the scanner engine should call this.
+func (r *DeviceRepository) UpdateScanAttributes(ctx context.Context, id int64, attrs domain.ScanAttributes) error {
+	raw, err := domain.MarshalScanAttributes(attrs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal scan_attributes: %w", err)
+	}
+	return r.queries.UpdateScanAttributes(ctx, db.UpdateScanAttributesParams{
+		ScanAttributes: raw,
+		ID:             id,
+	})
+}
+
+// GetByMAC looks up a device by its normalized scan MAC via the scan_attributes
+// JSON field (covered by idx_devices_scan_mac_expr). Returns the device and
+// whether a match existed.
+func (r *DeviceRepository) GetByMAC(ctx context.Context, mac string) (db.Device, bool, error) {
+	if mac == "" {
+		return db.Device{}, false, nil
+	}
+	device, err := r.queries.GetDeviceByMAC(ctx, mac)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.Device{}, false, nil
+		}
+		return db.Device{}, false, fmt.Errorf("failed to get device by MAC: %w", err)
+	}
+	return device, true, nil
 }
 
 // GetByID retrieves a device by its ID.

--- a/internal/repository/device_attributes_test.go
+++ b/internal/repository/device_attributes_test.go
@@ -1,0 +1,163 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"mibee-steward/internal/domain"
+
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// setupAttributesTestDB creates an in-memory DB with the devices table shape
+// (including scan_attributes + user_attributes + the 4 generated columns) and
+// returns a DeviceRepository plus a seeded device ID.
+func setupAttributesTestDB(t *testing.T) (*DeviceRepository, *sql.DB, int64) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = conn.Exec(`
+		CREATE TABLE IF NOT EXISTS devices (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'other',
+			brand TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			location TEXT NOT NULL DEFAULT '',
+			purpose TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'unknown',
+			ip_address TEXT NOT NULL DEFAULT '',
+			mac_address TEXT NOT NULL DEFAULT '',
+			serial_number TEXT NOT NULL DEFAULT '',
+			purchase_date TEXT NOT NULL DEFAULT '',
+			warranty_expiry TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT '{}',
+			scan_source TEXT NOT NULL DEFAULT 'manual',
+			prometheus_labels TEXT NOT NULL DEFAULT '{}',
+			last_scanned_at TIMESTAMP,
+			last_scan_task_id INTEGER,
+			open_ports TEXT NOT NULL DEFAULT '[]',
+			detected_services TEXT NOT NULL DEFAULT '[]',
+			prometheus_url TEXT NOT NULL DEFAULT '',
+			node_exporter_url TEXT NOT NULL DEFAULT '',
+			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE INDEX IF NOT EXISTS idx_devices_scan_mac_expr ON devices(json_extract(scan_attributes, '$.mac'));`)
+	require.NoError(t, err)
+
+	repo := NewDeviceRepository(conn)
+	ctx := context.Background()
+	device, err := repo.Create(ctx, domain.CreateDeviceRequest{
+		Name:      "test-cam",
+		Type:      "camera",
+		IPAddress: "192.168.63.133",
+	})
+	require.NoError(t, err)
+	return repo, conn, device.ID
+}
+
+func TestUpdateUserAttributes_MergesAndPersists(t *testing.T) {
+	repo, conn, id := setupAttributesTestDB(t)
+	ctx := context.Background()
+
+	// First write.
+	err := repo.UpdateUserAttributes(ctx, id, domain.UserAttributes{"owner": "ops", "rack": "A1"})
+	require.NoError(t, err)
+
+	var raw string
+	require.NoError(t, conn.QueryRow(`SELECT user_attributes FROM devices WHERE id = ?`, id).Scan(&raw))
+	got, err := domain.UnmarshalUserAttributes(raw)
+	require.NoError(t, err)
+	require.Equal(t, "ops", got["owner"])
+	require.Equal(t, "A1", got["rack"])
+}
+
+func TestUpdateScanAttributes_PopulatesGeneratedColumns(t *testing.T) {
+	repo, conn, id := setupAttributesTestDB(t)
+	ctx := context.Background()
+
+	err := repo.UpdateScanAttributes(ctx, id, domain.ScanAttributes{
+		Vendor:   "Hikvision",
+		MAC:      "bc:ad:28:11:22:33",
+		OS:       "Linux",
+		Hostname: "cam-front",
+	})
+	require.NoError(t, err)
+
+	// The generated columns should be populated from the JSON we just wrote.
+	var scanVendor, scanMac, scanOS, scanHostname sql.NullString
+	err = conn.QueryRow(
+		`SELECT scan_vendor, scan_mac, scan_os, scan_hostname FROM devices WHERE id = ?`, id,
+	).Scan(&scanVendor, &scanMac, &scanOS, &scanHostname)
+	require.NoError(t, err)
+	require.Equal(t, "Hikvision", scanVendor.String)
+	require.Equal(t, "bc:ad:28:11:22:33", scanMac.String)
+	require.Equal(t, "Linux", scanOS.String)
+	require.Equal(t, "cam-front", scanHostname.String)
+}
+
+func TestGetByMAC_FindsByScanAttributesMAC(t *testing.T) {
+	repo, _, id := setupAttributesTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.UpdateScanAttributes(ctx, id, domain.ScanAttributes{
+		MAC: "bc:ad:28:11:22:33",
+	}))
+
+	got, ok, err := repo.GetByMAC(ctx, "bc:ad:28:11:22:33")
+	require.NoError(t, err)
+	require.True(t, ok, "expected a device match by MAC")
+	require.Equal(t, id, got.ID)
+
+	// Miss.
+	_, ok, err = repo.GetByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Empty MAC query is a no-op (no scan, no error).
+	_, ok, err = repo.GetByMAC(ctx, "")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// TestCreateDeviceRejectsInvalidUserAttributes is a sanity check that the
+// json_valid CHECK on user_attributes guards against bad JSON slipping in via
+// the marshal helper — since the helper always produces valid JSON, this is
+// mostly asserting the CHECK constraint is in effect.
+func TestCreateDeviceRejectsInvalidUserAttributes(t *testing.T) {
+	conn, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	_, err = conn.Exec(`
+		CREATE TABLE devices (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'other',
+			status TEXT NOT NULL DEFAULT 'unknown',
+			tags TEXT NOT NULL DEFAULT '{}',
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`)
+	require.NoError(t, err)
+	// Direct raw insert of bad JSON must fail the CHECK.
+	_, err = conn.Exec(`INSERT INTO devices (name, type, status, user_attributes) VALUES ('x','other','unknown', '{not json')`)
+	require.Error(t, err, "json_valid CHECK should reject malformed JSON")
+	// And the empty default must be accepted.
+	_, err = conn.Exec(`INSERT INTO devices (name, type, status) VALUES ('y','other','unknown')`)
+	require.NoError(t, err)
+}

--- a/internal/repository/device_system_test.go
+++ b/internal/repository/device_system_test.go
@@ -48,6 +48,12 @@ func setupDeviceSystemTestDB(t *testing.T) (*DeviceSystemRepository, *sql.DB, in
 			prometheus_url TEXT NOT NULL DEFAULT '',
 			node_exporter_url TEXT NOT NULL DEFAULT '',
 			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/batch_test.go
+++ b/internal/service/batch_test.go
@@ -51,6 +51,12 @@ CREATE TABLE IF NOT EXISTS devices (
     prometheus_url TEXT NOT NULL DEFAULT '',
     node_exporter_url TEXT NOT NULL DEFAULT '',
     last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+    scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+    user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+    scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+    scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+    scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+    scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -176,6 +176,25 @@ func (s *DeviceService) Update(ctx context.Context, id int64, req domain.UpdateD
 		return nil, fmt.Errorf("failed to update device: %w", err)
 	}
 
+	// Apply user_attributes patch (merged with existing; empty values delete).
+	// scan_attributes is engine-owned and never touched here. We re-read the
+	// freshly updated row so the merge base reflects concurrent engine writes.
+	if len(req.UserAttributesPatch) > 0 {
+		base, err := domain.UnmarshalUserAttributes(device.UserAttributes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse existing user_attributes: %w", err)
+		}
+		merged := domain.MergeUserAttributes(base, req.UserAttributesPatch)
+		if err := s.repo.UpdateUserAttributes(ctx, id, merged); err != nil {
+			return nil, fmt.Errorf("failed to update user_attributes: %w", err)
+		}
+		// Re-fetch so the response reflects the merged map.
+		device, err = s.repo.GetByID(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to re-read device after user_attributes update: %w", err)
+		}
+	}
+
 	resp := toDeviceResponse(device)
 	return &resp, nil
 }
@@ -222,6 +241,16 @@ func (s *DeviceService) GetStats(ctx context.Context) (*domain.DeviceStatsRespon
 
 // toDeviceResponse converts a db.Device to domain.DeviceResponse.
 func toDeviceResponse(d db.Device) domain.DeviceResponse {
+	scanAttrs, err := domain.UnmarshalScanAttributes(d.ScanAttributes)
+	if err != nil {
+		slog.Warn("invalid scan_attributes JSON on device; defaulting to empty",
+			"device_id", d.ID, "ip", d.IpAddress, "error", err)
+	}
+	userAttrs, err := domain.UnmarshalUserAttributes(d.UserAttributes)
+	if err != nil {
+		slog.Warn("invalid user_attributes JSON on device; defaulting to empty",
+			"device_id", d.ID, "ip", d.IpAddress, "error", err)
+	}
 	return domain.DeviceResponse{
 		ID:               d.ID,
 		Name:             d.Name,
@@ -248,5 +277,7 @@ func toDeviceResponse(d db.Device) domain.DeviceResponse {
 		PrometheusURL:    d.PrometheusUrl,
 		NodeExporterURL:  d.NodeExporterUrl,
 		LastScanRttMs:    d.LastScanRttMs,
+		ScanAttributes:   scanAttrs,
+		UserAttributes:   userAttrs,
 	}
 }

--- a/internal/service/device_system_test.go
+++ b/internal/service/device_system_test.go
@@ -47,6 +47,12 @@ func setupDeviceSystemService(t *testing.T) (*DeviceSystemService, *sql.DB, int6
 			prometheus_url TEXT NOT NULL DEFAULT '',
 			node_exporter_url TEXT NOT NULL DEFAULT '',
 			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -45,6 +45,12 @@ func setupDeviceService(t *testing.T) (*DeviceService, *sql.DB) {
 			prometheus_url TEXT NOT NULL DEFAULT '',
 			node_exporter_url TEXT NOT NULL DEFAULT '',
 			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -51,6 +51,12 @@ func setupExportTest(t *testing.T) (*ExportService, *sql.DB) {
 			prometheus_url TEXT NOT NULL DEFAULT '',
 			node_exporter_url TEXT NOT NULL DEFAULT '',
 			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);

--- a/internal/service/heartbeat_test.go
+++ b/internal/service/heartbeat_test.go
@@ -51,6 +51,12 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 			prometheus_url TEXT NOT NULL DEFAULT '',
 			node_exporter_url TEXT NOT NULL DEFAULT '',
 			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
@@ -116,11 +122,12 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 func insertTestDevice(t *testing.T, q *db.Queries, ctx context.Context, name, ipAddr string) int64 {
 	t.Helper()
 	device, err := q.CreateDevice(ctx, db.CreateDeviceParams{
-		Name:      name,
-		Type:      "other",
-		Status:    "unknown",
-		IpAddress: ipAddr,
-		Tags:      "{}",
+		Name:           name,
+		Type:           "other",
+		Status:         "unknown",
+		IpAddress:      ipAddr,
+		Tags:           "{}",
+		UserAttributes: "{}",
 	})
 	require.NoError(t, err)
 	return device.ID

--- a/internal/service/scannerv2/classify/database.go
+++ b/internal/service/scannerv2/classify/database.go
@@ -1,0 +1,145 @@
+package classify
+
+import (
+	"strings"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// DatabaseClassifier inspects banners and port evidence for databases that
+// volunteer a greeting on connect (mysql, redis, postgresql, mongodb, mssql).
+// Most databases DO send a handshake/greeting immediately, so the passive
+// banner read in the port probe is usually enough; this classifier turns those
+// banners into typed service identities with version metadata when extractable.
+//
+// Service names emitted: "mysql", "redis", "postgresql", "mongodb", "mssql".
+//
+// Detection signatures (port → what the banner looks like):
+//   - 3306 mysql:     handshake packet, version string appears early as
+//     e.g. "10.11.8-MariaDB..." (the server sends its version
+//     in the initial greeting packet, plain ASCII within the
+//     binary packet)
+//   - 6379 redis:     "-ERR" / "+PONG" / "redis" — but on a fresh connect redis
+//     sends nothing; only the PING response classifies it. We
+//     also accept the literal "redis" in any banner.
+//   - 5432 postgres:  an error frame on a bare connect ("F...SFATAL") OR the
+//     "FATAL: no PostgreSQL" style text the server emits when
+//     it receives a non-protocol greeting.
+//   - 27017 mongodb:  "mongodb" in banner, or an ismaster response shape.
+//   - 1433 mssql:     TDS prelogin response — recognized by a leading 0x04/
+//     0x01 TDS header byte + the absence of any printable
+//     greeting. We key off a small TDS signature.
+type DatabaseClassifier struct{}
+
+func (DatabaseClassifier) Service() string { return "database" } // multi-emitter
+
+func (DatabaseClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	idx := indexEvidence(ev)
+	var out []scannerv2.ServiceIdentity
+
+	for _, e := range idx.byKind["banner"] {
+		b := strings.TrimSpace(bannerText(e))
+		if b == "" {
+			continue
+		}
+		lower := strings.ToLower(b)
+
+		// MySQL: the greeting packet's first 1-2 bytes are a length prefix
+		// (binary), but the version string follows as ASCII terminated by 0x00.
+		// Look for a MariaDB/MySQL version substring which is robust to the
+		// binary framing. Also catches Percona.
+		if strings.Contains(lower, "mariadb") || strings.Contains(lower, "mysql") ||
+			mysqlVersionRE.MatchString(b) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "mysql", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.9),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b, "version": extractMySQLVersion(b)},
+			})
+			continue
+		}
+
+		// Redis: redis doesn't greet on connect, so a banner here means either
+		// a PING reply ("+PONG") or an AUTH-required error ("-NOAUTH" / "-ERR").
+		if lower == "+pong" || strings.HasPrefix(lower, "-noauth") ||
+			(strings.HasPrefix(lower, "-err") && e.Port == 6379) ||
+			strings.Contains(lower, "redis_version") {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "redis", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.85),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+
+		// PostgreSQL: on a bare connect the server sends an error frame
+		// beginning with 'E' (0x45) followed by "SFATAL...". The readable text
+		// includes "FATAL" and often "PostgreSQL".
+		if strings.Contains(lower, "postgresql") ||
+			(strings.HasPrefix(b, "E\x00\x00\x00") && strings.Contains(lower, "fatal")) ||
+			(e.Port == 5432 && strings.Contains(lower, "fatal")) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "postgresql", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.85),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+
+		// MongoDB: the ismaster/hello response is BSON and won't be readable,
+		// but a mongod receiving a non-protocol greeting may emit "It looks
+		// like you are trying to connect over HTTP to a MongoDB server". Catch
+		// that and the literal "mongodb".
+		if strings.Contains(lower, "mongodb") {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "mongodb", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.85),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+	}
+
+	// Port-only fallbacks: when a known DB port is open but no banner was
+	// captured, assert a low-confidence identity so the host isn't blind. This
+	// is conservative (only the canonical port numbers) to avoid false
+	// positives on ports that happen to share a number.
+	for port, svc := range map[int]string{
+		3306: "mysql", 6379: "redis", 5432: "postgresql",
+		27017: "mongodb", 1433: "mssql", 11211: "memcached",
+	} {
+		// Only assert when the port is open AND no banner-based identity was
+		// already emitted for this port (avoids duplicates).
+		if portHasOpen(idx, port) && !outHasPort(out, port) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: svc, Port: port, Protocol: "tcp",
+				Confidence: 0.5, // port-shape only, no banner confirmation
+				Evidence:   idx.byPort[port],
+			})
+		}
+	}
+
+	return out
+}
+
+// portHasOpen reports whether any port_open evidence exists for the port.
+func portHasOpen(idx evidenceIndex, port int) bool {
+	for _, e := range idx.byPort[port] {
+		if e.Kind == "port_open" {
+			return true
+		}
+	}
+	return false
+}
+
+func outHasPort(out []scannerv2.ServiceIdentity, port int) bool {
+	for _, s := range out {
+		if s.Port == port {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/scannerv2/classify/database_test.go
+++ b/internal/service/scannerv2/classify/database_test.go
@@ -1,0 +1,240 @@
+package classify
+
+import (
+	"testing"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+func TestDatabaseClassifier_MySQLGreeting(t *testing.T) {
+	// MySQL greeting packet: the version string appears after a 1-byte length
+	// and is ASCII terminated by 0x00. Simulate the readable portion.
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 3306, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "\x5a\x00\x00\x0010.11.8-MariaDB\x00..."},
+		Confidence: 0.9,
+	}}
+	out := DatabaseClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "mysql" {
+		t.Fatalf("expected mysql, got %+v", out)
+	}
+	if out[0].Metadata["version"] == "" {
+		t.Errorf("expected version extracted, got %v", out[0].Metadata)
+	}
+}
+
+func TestDatabaseClassifier_RedisNoauth(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 6379, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "-NOAUTH Authentication required."},
+		Confidence: 0.9,
+	}}
+	out := DatabaseClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "redis" {
+		t.Fatalf("expected redis, got %+v", out)
+	}
+}
+
+func TestDatabaseClassifier_PostgresFatal(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 5432, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "SFATAL: no PostgreSQL"},
+		Confidence: 0.9,
+	}}
+	out := DatabaseClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "postgresql" {
+		t.Fatalf("expected postgresql, got %+v", out)
+	}
+}
+
+func TestDatabaseClassifier_PortOnlyFallback(t *testing.T) {
+	// Open MongoDB port, no banner → low-confidence identity.
+	ev := []scannerv2.Evidence{{
+		Kind: "port_open", Port: 27017, Protocol: "tcp", Confidence: 1.0,
+	}}
+	out := DatabaseClassifier{}.Classify(ev)
+	found := false
+	for _, s := range out {
+		if s.Service == "mongodb" && s.Port == 27017 {
+			if s.Confidence > 0.55 {
+				t.Errorf("port-only confidence should be ~0.5, got %f", s.Confidence)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mongodb port-only fallback, got %+v", out)
+	}
+}
+
+func TestDatabaseClassifier_NoBannerOnClosedPort(t *testing.T) {
+	// No evidence at all → no identities.
+	out := DatabaseClassifier{}.Classify(nil)
+	if len(out) != 0 {
+		t.Errorf("expected no identities, got %+v", out)
+	}
+}
+
+func TestMailClassifier_SMTPvsFTP(t *testing.T) {
+	// "220 mail ESMTP" → smtp (not ftp).
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 25, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "220 mail.example.com ESMTP Postfix"},
+		Confidence: 0.9,
+	}}
+	out := MailClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "smtp" {
+		t.Fatalf("expected smtp, got %+v", out)
+	}
+}
+
+func TestMailClassifier_Bare220IsNotSMTP(t *testing.T) {
+	// Bare "220 " without ESMTP/Postfix markers should NOT classify as smtp
+	// (it's likely FTP — left to BannerClassifier).
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 21, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "220 vsFTPd 3.0.5"},
+		Confidence: 0.9,
+	}}
+	out := MailClassifier{}.Classify(ev)
+	if len(out) != 0 {
+		t.Errorf("bare FTP-style 220 should not classify as smtp, got %+v", out)
+	}
+}
+
+func TestMailClassifier_POP3(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 110, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "+OK Dovecot ready."},
+		Confidence: 0.9,
+	}}
+	out := MailClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "pop3" {
+		t.Fatalf("expected pop3, got %+v", out)
+	}
+}
+
+func TestRemoteAccessClassifier_VNC(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 5900, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "RFB 003.008\n"},
+		Confidence: 0.9,
+	}}
+	out := RemoteAccessClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "vnc" {
+		t.Fatalf("expected vnc, got %+v", out)
+	}
+	if out[0].Metadata["version"] != "003.008" {
+		t.Errorf("expected version 003.008, got %q", out[0].Metadata["version"])
+	}
+}
+
+func TestRemoteAccessClassifier_TelnetIAC(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "banner", Port: 23, Protocol: "tcp",
+		RawData:    map[string]string{"banner": "\xff\xfd\x01\xff\xfd\x1fLogin: "},
+		Confidence: 0.9,
+	}}
+	out := RemoteAccessClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "telnet" {
+		t.Fatalf("expected telnet, got %+v", out)
+	}
+}
+
+func TestRemoteAccessClassifier_RDPPortOnly(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "port_open", Port: 3389, Protocol: "tcp", Confidence: 1.0,
+	}}
+	out := RemoteAccessClassifier{}.Classify(ev)
+	found := false
+	for _, s := range out {
+		if s.Service == "rdp" && s.Port == 3389 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected rdp port-only fallback, got %+v", out)
+	}
+}
+
+func TestMiscClassifier_LDAPandSMB(t *testing.T) {
+	ev := []scannerv2.Evidence{
+		{Kind: "port_open", Port: 389, Protocol: "tcp", Confidence: 1.0},
+		{Kind: "port_open", Port: 445, Protocol: "tcp", Confidence: 1.0},
+	}
+	out := MiscClassifier{}.Classify(ev)
+	svcs := map[string]bool{}
+	for _, s := range out {
+		svcs[s.Service] = true
+	}
+	if !svcs["ldap"] {
+		t.Errorf("expected ldap, got %v", svcs)
+	}
+	if !svcs["smb"] {
+		t.Errorf("expected smb, got %v", svcs)
+	}
+}
+
+func TestWebClassifier_ServerVersion(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "http", Port: 80, Protocol: "tcp",
+		RawData:    map[string]string{"status": "200 OK", "server": "nginx/1.25.3", "title": "Welcome"},
+		Confidence: 0.9,
+	}}
+	out := WebClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "http" {
+		t.Fatalf("expected http, got %+v", out)
+	}
+	if out[0].Metadata["version"] != "1.25.3" {
+		t.Errorf("expected nginx version 1.25.3, got %q", out[0].Metadata["version"])
+	}
+	if out[0].Metadata["title"] != "Welcome" {
+		t.Errorf("expected title, got %q", out[0].Metadata["title"])
+	}
+}
+
+func TestTLSClassifier_HikvisionCN(t *testing.T) {
+	ev := []scannerv2.Evidence{{
+		Kind: "tls", Port: 443, Protocol: "tcp",
+		RawData: map[string]string{
+			"subject_cn": "*.hikvision.com",
+			"issuer_cn":  "hikvision",
+		},
+		Confidence: 0.95,
+	}}
+	out := TLSClassifier{}.Classify(ev)
+	if len(out) != 1 || out[0].Service != "https" {
+		t.Fatalf("expected https, got %+v", out)
+	}
+	if out[0].Metadata["inferred_brand"] != "Hikvision" {
+		t.Errorf("expected Hikvision brand from CN, got %q", out[0].Metadata["inferred_brand"])
+	}
+}
+
+func TestServerVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"nginx/1.25.3", "1.25.3"},
+		{"Apache/2.4.58 (Debian)", "2.4.58"},
+		{"Caddy", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := serverVersion(c.in); got != c.want {
+			t.Errorf("serverVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVendorFromCertCN(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"*.hikvision.com", "Hikvision"},
+		{"camera.dahua.local", "Dahua"},
+		{"unifi.ui.com", "Ubiquiti"},
+		{"random.example.com", ""},
+	}
+	for _, c := range cases {
+		if got := vendorFromCertCN(c.in); got != c.want {
+			t.Errorf("vendorFromCertCN(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/service/scannerv2/classify/mail_remote.go
+++ b/internal/service/scannerv2/classify/mail_remote.go
@@ -1,0 +1,157 @@
+package classify
+
+import (
+	"strings"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// MailClassifier detects SMTP/POP3/IMAP from their greeting banners. These
+// services all volunteer a line on connect, so the passive read in the port
+// probe is the primary signal.
+//
+// Service names emitted: "smtp", "pop3", "imap".
+//
+// Note on FTP-vs-SMTP ambiguity: both start with "220 ". The BannerClassifier
+// already keys "220 " → ftp at 0.7 confidence. To avoid double-classifying,
+// this classifier asserts smtp ONLY when the banner contains "ESMTP" or
+// "Postfix"/"Sendmail"/"Exim" (which is how nmap disambiguates). A bare "220 "
+// without those markers falls through to ftp.
+type MailClassifier struct{}
+
+func (MailClassifier) Service() string { return "mail" }
+
+func (MailClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	idx := indexEvidence(ev)
+	var out []scannerv2.ServiceIdentity
+	for _, e := range idx.byKind["banner"] {
+		b := strings.TrimSpace(bannerText(e))
+		if b == "" {
+			continue
+		}
+		lower := strings.ToLower(b)
+
+		// SMTP: "220 ... ESMTP" or a known MTA name. The "220 " prefix alone
+		// is NOT enough (FTP also uses it) — require a mail-specific marker.
+		if strings.HasPrefix(b, "220 ") && (strings.Contains(lower, "esmtp") ||
+			strings.Contains(lower, "postfix") || strings.Contains(lower, "sendmail") ||
+			strings.Contains(lower, "exim") || strings.Contains(lower, "mail")) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "smtp", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.9),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+		// POP3: "+OK" greeting, often "OK POP3 ..." or "+OK Dovecot ready".
+		if strings.HasPrefix(b, "+OK") && (strings.Contains(lower, "pop3") ||
+			e.Port == 110) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "pop3", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.9),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+		// IMAP: "* OK" greeting with "IMAP" or on port 143.
+		if strings.HasPrefix(b, "* OK") && (strings.Contains(lower, "imap") ||
+			e.Port == 143) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "imap", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.9),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+	}
+	return out
+}
+
+// RemoteAccessClassifier detects VNC/RDP/Telnet from their distinctive banners.
+//
+// Service names emitted: "vnc", "rdp", "telnet".
+//
+//   - VNC: greeting is exactly "RFB 003.008\n" (12 bytes). Very distinctive.
+//   - RDP: no readable banner (X.224 TPKT); assert on port 3389 only, low conf.
+//   - Telnet: starts with IAC bytes 0xFF 0xFB/0xFD (WILL/DO negotiation).
+type RemoteAccessClassifier struct{}
+
+func (RemoteAccessClassifier) Service() string { return "remote" }
+
+func (RemoteAccessClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	idx := indexEvidence(ev)
+	var out []scannerv2.ServiceIdentity
+	for _, e := range idx.byKind["banner"] {
+		b := bannerText(e) // NOT trimmed — telnet IAC bytes are leading whitespace-adjacent
+		if b == "" {
+			continue
+		}
+		// VNC: "RFB 003.xxx" prefix.
+		if strings.HasPrefix(b, "RFB ") {
+			ver := strings.TrimRight(b[4:], "\r\n\x00")
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "vnc", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.95),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b, "version": ver},
+			})
+			continue
+		}
+		// Telnet: IAC (0xFF) followed by WILL(0xFB)/DO(0xFD)/WONT(0xFC)/DONT(0xFE).
+		if len(b) >= 2 && b[0] == '\xff' && (b[1] == '\xfb' || b[1] == '\xfd' || b[1] == '\xfc' || b[1] == '\xfe') {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: "telnet", Port: e.Port, Protocol: "tcp",
+				Confidence: fuseConfidence(e.Confidence, 0.9),
+				Evidence:   []scannerv2.Evidence{e},
+				Metadata:   map[string]string{"banner": b},
+			})
+			continue
+		}
+	}
+
+	// Port-only fallback for RDP (no readable banner; X.224 is binary TPKT).
+	if portHasOpen(idx, 3389) && !outHasPort(out, 3389) {
+		out = append(out, scannerv2.ServiceIdentity{
+			Service: "rdp", Port: 3389, Protocol: "tcp",
+			Confidence: 0.6, // port-shape only
+			Evidence:   idx.byPort[3389],
+		})
+	}
+	return out
+}
+
+// MiscClassifier catches a few remaining common services: LDAP (bind-response
+// banner on a non-protocol greeting is unreadable, so port-only), DNS (no TCP
+// banner; port-only for 53), and NTP (UDP 123 — port-only). These are
+// intentionally low-confidence because they're port-shape-only, but they make
+// the device record far more useful than a bare "open port".
+//
+// Service names emitted: "ldap", "ldaps", "smb", "ntp", "dns-tcp".
+type MiscClassifier struct{}
+
+func (MiscClassifier) Service() string { return "misc" }
+
+func (MiscClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	idx := indexEvidence(ev)
+	var out []scannerv2.ServiceIdentity
+	for port, svc := range map[int]string{
+		389: "ldap",
+		636: "ldaps",
+		445: "smb",
+		23:  "telnet", // in case the IAC banner wasn't captured
+		21:  "ftp",    // in case the 220 banner wasn't captured
+		53:  "dns-tcp",
+	} {
+		if portHasOpen(idx, port) {
+			out = append(out, scannerv2.ServiceIdentity{
+				Service: svc, Port: port, Protocol: "tcp",
+				Confidence: 0.5, // port-shape only
+				Evidence:   idx.byPort[port],
+			})
+		}
+	}
+	return out
+}

--- a/internal/service/scannerv2/classify/regex.go
+++ b/internal/service/scannerv2/classify/regex.go
@@ -1,0 +1,17 @@
+package classify
+
+import "regexp"
+
+// mysqlVersionRE matches a MySQL/MariaDB/Percona version string embedded in
+// the binary greeting packet (the version is ASCII, terminated by 0x00). The
+// pattern accepts digit.digit.digit with an optional suffix (-MariaDB, -log,
+// -Percona, etc.). Robust to the binary framing because we anchor on the
+// version shape rather than a magic prefix.
+var mysqlVersionRE = regexp.MustCompile(`(\d+\.\d+\.\d+[-\w.]*(?:-MariaDB|-Percona|-log)?[-\w.]*)`)
+
+// extractMySQLVersion pulls the version substring out of a MySQL greeting.
+// Returns "" if no version-shaped substring is present.
+func extractMySQLVersion(b string) string {
+	m := mysqlVersionRE.FindString(b)
+	return m
+}

--- a/internal/service/scannerv2/classify/registry.go
+++ b/internal/service/scannerv2/classify/registry.go
@@ -15,5 +15,11 @@ func DefaultClassifiers() []scannerv2.ServiceClassifier {
 		PrometheusClassifier{},
 		SNMPClassifier{},
 		CameraClassifier{},
+		DatabaseClassifier{},
+		MailClassifier{},
+		RemoteAccessClassifier{},
+		WebClassifier{},
+		TLSClassifier{},
+		MiscClassifier{},
 	}
 }

--- a/internal/service/scannerv2/classify/web_tls.go
+++ b/internal/service/scannerv2/classify/web_tls.go
@@ -1,0 +1,124 @@
+package classify
+
+import (
+	"strings"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// WebClassifier turns the structured "http" evidence from the HTTPProbe into a
+// service identity, and infers OS/vendor hints from the Server / X-Powered-By
+// headers and the page <title>. This complements the BannerClassifier (which
+// keys off the raw HTTP/ response line) by adding the structured fields.
+//
+// Service names emitted: "http" (re-asserted with version/server metadata).
+type WebClassifier struct{}
+
+func (WebClassifier) Service() string { return "web" }
+
+func (WebClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	var out []scannerv2.ServiceIdentity
+	for _, e := range ev {
+		if e.Kind != "http" || e.RawData == nil {
+			continue
+		}
+		md := map[string]string{}
+		for k, v := range e.RawData {
+			md[k] = v
+		}
+		// Infer a product version from the Server header where possible.
+		if srv := e.RawData["server"]; srv != "" {
+			if v := serverVersion(srv); v != "" {
+				md["version"] = v
+			}
+		}
+		out = append(out, scannerv2.ServiceIdentity{
+			Service: "http", Port: e.Port, Protocol: "tcp",
+			Confidence: fuseConfidence(e.Confidence, 0.85),
+			Evidence:   []scannerv2.Evidence{e},
+			Metadata:   md,
+		})
+	}
+	return out
+}
+
+// serverVersion extracts a version-ish substring from an HTTP Server header
+// (e.g. "nginx/1.25.3" → "1.25.3", "Apache/2.4.58 (Debian)" → "2.4.58"). Empty
+// when no version is present.
+func serverVersion(server string) string {
+	i := strings.IndexByte(server, '/')
+	if i < 0 {
+		return ""
+	}
+	rest := server[i+1:]
+	// Version runs until the next space or paren.
+	for j := 0; j < len(rest); j++ {
+		if rest[j] == ' ' || rest[j] == '(' {
+			return rest[:j]
+		}
+	}
+	return rest
+}
+
+// TLSClassifier turns the structured "tls" evidence from the TLSProbe into a
+// service identity. It also surfaces the cert CN/SAN as a hostname source and
+// the issuer as a vendor hint (e.g. "*.hikvision.com" CN → vendor "Hikvision").
+//
+// Service names emitted: "https" (on TLS ports), plus host-level metadata.
+type TLSClassifier struct{}
+
+func (TLSClassifier) Service() string { return "tls" }
+
+func (TLSClassifier) Classify(ev []scannerv2.Evidence) []scannerv2.ServiceIdentity {
+	var out []scannerv2.ServiceIdentity
+	for _, e := range ev {
+		if e.Kind != "tls" || e.RawData == nil {
+			continue
+		}
+		// The presence of a TLS handshake on a port is itself strong evidence
+		// of HTTPS (or a TLS-wrapped service). Emit an https identity.
+		md := map[string]string{}
+		for k, v := range e.RawData {
+			md[k] = v
+		}
+		// Vendor hint from the cert CN's domain.
+		if cn := e.RawData["subject_cn"]; cn != "" {
+			if v := vendorFromCertCN(cn); v != "" {
+				md["inferred_brand"] = v
+			}
+		}
+		out = append(out, scannerv2.ServiceIdentity{
+			Service: "https", Port: e.Port, Protocol: "tcp",
+			Confidence: fuseConfidence(e.Confidence, 0.9),
+			Evidence:   []scannerv2.Evidence{e},
+			Metadata:   md,
+		})
+	}
+	return out
+}
+
+// vendorFromCertCN maps a cert CN/SAN domain to a vendor when the domain is a
+// known vendor's. Covers the camera/networking vendors already in the OUI +
+// ONVIF brand lists plus a few common infrastructure ones.
+func vendorFromCertCN(cn string) string {
+	lower := strings.ToLower(cn)
+	switch {
+	case strings.Contains(lower, "hikvision") || strings.Contains(lower, "hik"):
+		return "Hikvision"
+	case strings.Contains(lower, "dahua"):
+		return "Dahua"
+	case strings.Contains(lower, "axis"):
+		return "Axis"
+	case strings.Contains(lower, "unifi") || strings.Contains(lower, "ubiquiti"):
+		return "Ubiquiti"
+	case strings.Contains(lower, "synology"):
+		return "Synology"
+	case strings.Contains(lower, "qnap"):
+		return "QNAP"
+	case strings.Contains(lower, "cisco"):
+		return "Cisco"
+	case strings.Contains(lower, "fortinet") || strings.Contains(lower, "fortigate"):
+		return "Fortinet"
+	}
+	return ""
+}

--- a/internal/service/scannerv2/engine/engine.go
+++ b/internal/service/scannerv2/engine/engine.go
@@ -23,6 +23,7 @@ import (
 	"mibee-steward/internal/service/scannerv2/handler"
 	"mibee-steward/internal/service/scannerv2/probe"
 	"mibee-steward/internal/service/scannerv2/store"
+	"mibee-steward/internal/service/scannerv2/vendor"
 )
 
 // Engine bundles everything the API layer needs to run a v2 scan: the
@@ -36,6 +37,9 @@ type Engine struct {
 	// via ProbeHint.Timeout). Stored on Engine so ScanTargets can read it
 	// without re-deriving. <=0 falls back to 3s at use time.
 	perProbeTimeout time.Duration
+	// snmpCommunity is the default SNMP community string, passed to the SNMP
+	// probe via ProbeHint.Community. Empty → probe defaults to "public".
+	snmpCommunity string
 	// scanSem caps the number of concurrent top-level scans (sync POST /scan +
 	// cron-triggered task runs). Caps total resource use across the process;
 	// per-host parallelism within a scan is governed by Orchestrator config.
@@ -68,6 +72,17 @@ type Config struct {
 	MaxConcurrentScans int
 	// PersistRawEvidence toggles writing raw evidence rows (default off).
 	PersistRawEvidence bool
+	// OUIPath is the path to the IEEE OUI vendor-mapping file (optional). When
+	// empty or missing, the ARP probe still records MAC addresses but skips the
+	// vendor lookup. The path is overridable via MIBEE_SCANNER_OUI_PATH.
+	OUIPath string
+	// SNMPCommunity is the default community string passed to the SNMP probe
+	// via ProbeHint.Community (default "public" if empty).
+	SNMPCommunity string
+	// RouterARP enables cross-subnet MAC resolution by walking routers' SNMP
+	// ARP tables (ipNetToMediaPhysAddress). Empty routers → cross-subnet MAC is
+	// disabled and the scanner falls back to /proc/net/arp (local subnet only).
+	RouterARP probe.RouterARPConfig
 	// HeartbeatInterval/Timeout are the defaults applied to generated configs.
 	HeartbeatInterval int
 	HeartbeatTimeout  int
@@ -85,8 +100,26 @@ func NewEngine(db *sql.DB, cfg Config, logger *slog.Logger) (*Engine, error) {
 
 	reg := scannerv2.NewRegistry()
 
+	// Load the OUI vendor table once (silent degradation if the file is absent
+	// — the ARP probe still records MAC addresses, just without vendor).
+	oui := vendor.New()
+	if cfg.OUIPath != "" {
+		if err := oui.Load(cfg.OUIPath); err != nil {
+			logger.Warn("scannerv2: OUI file load failed; vendor lookup disabled",
+				"path", cfg.OUIPath, "error", err)
+		} else if oui.Loaded() {
+			logger.Info("scannerv2: OUI vendor table loaded",
+				"path", cfg.OUIPath, "entries", oui.Size())
+		} else {
+			logger.Info("scannerv2: OUI file not present; vendor lookup disabled (MAC still recorded)",
+				"path", cfg.OUIPath)
+		}
+	} else {
+		logger.Info("scannerv2: no OUI path configured; vendor lookup disabled (MAC still recorded)")
+	}
+
 	// ① Probes: active set + optional passive eBPF observer.
-	for _, p := range probe.DefaultProbeSources(cfg.PortSpec) {
+	for _, p := range probe.DefaultProbeSources(cfg.PortSpec, oui) {
 		reg.RegisterProbe(p)
 	}
 	observer := ebpf.New(cfg.EBPF)
@@ -121,6 +154,36 @@ func NewEngine(db *sql.DB, cfg Config, logger *slog.Logger) (*Engine, error) {
 		MaxConcurrentHosts: cfg.MaxConcurrentHosts,
 		PerHostTimeout:     cfg.PerHostTimeout,
 	}, logger)
+	// Inject the post-scan MAC resolver so cold scans still capture MAC after the
+	// ICMP/TCP probes have populated the kernel ARP cache. The engine (not the
+	// scannerv2 root package) wires this to avoid an import cycle. The closure
+	// carries the OUI table so the synthesized evidence includes the vendor.
+	//
+	// Resolution order: (1) /proc/net/arp (local subnet, populated by the ICMP
+	// probe during gather); (2) when that misses AND routers are configured,
+	// walk the router's SNMP ARP table (cross-subnet). The first hit wins.
+	routerCfg := cfg.RouterARP
+	probe.SetPostScanResolver(func(ip string) (mac, device, vendor string) {
+		m, d := probe.LookupMACPostScan(ip)
+		if m == "" && len(routerCfg.Routers) > 0 {
+			// Cross-subnet: ask the router. The OUI lookup happens below on
+			// whichever MAC we end up with.
+			ctx, cancel := context.WithTimeout(context.Background(), routerCfg.Timeout)
+			if rm, ok := probe.LookupMACViaRouters(ctx, routerCfg, ip); ok {
+				m = rm
+			}
+			cancel()
+		}
+		if m == "" {
+			return "", "", ""
+		}
+		v := ""
+		if oui != nil {
+			v = oui.Lookup(m)
+		}
+		return m, d, v
+	})
+	orch.SetMACResolver(probe.ResolveMACPostScan)
 
 	logger.Info("scannerv2 engine ready", "registry", reg.String())
 	e := &Engine{Orchestrator: orch, Registry: reg, Repository: repo}
@@ -130,7 +193,11 @@ func NewEngine(db *sql.DB, cfg Config, logger *slog.Logger) (*Engine, error) {
 	if e.perProbeTimeout <= 0 {
 		e.perProbeTimeout = 3 * time.Second
 	}
+	e.snmpCommunity = cfg.SNMPCommunity
 	logger.Info("scannerv2: per-probe timeout", "timeout", e.perProbeTimeout)
+	if e.snmpCommunity != "" && e.snmpCommunity != "public" {
+		logger.Info("scannerv2: SNMP community override configured", "community", e.snmpCommunity)
+	}
 	if cfg.MaxConcurrentScans > 0 {
 		e.scanSem = make(chan struct{}, cfg.MaxConcurrentScans)
 		logger.Info("scannerv2: concurrent-scan cap enabled", "max", cfg.MaxConcurrentScans)
@@ -179,7 +246,7 @@ func (e *Engine) ScanTargets(ctx context.Context, targets string, fastScan bool)
 	// this long. A dead host fails in seconds across all its probes rather than
 	// blocking the full PerHostTimeout on each. The per-host pipeline ceiling
 	// is enforced separately by the hostCtx deadline below.
-	hint := scannerv2.ProbeHint{Timeout: e.perProbeTimeout}
+	hint := scannerv2.ProbeHint{Timeout: e.perProbeTimeout, Community: e.snmpCommunity}
 
 	reports := make([]scannerv2.HostReport, len(ips))
 	sem := make(chan struct{}, maxConc)

--- a/internal/service/scannerv2/orchestrator.go
+++ b/internal/service/scannerv2/orchestrator.go
@@ -73,6 +73,20 @@ type Orchestrator struct {
 	// immutable after construction.
 	cfgMu  sync.RWMutex
 	logger *slog.Logger
+	// macResolver re-reads the kernel ARP cache after gather, closing the race
+	// where the concurrent ARPProbe runs before ICMP has populated the cache.
+	// Returns (mac, device, vendor) — vendor comes from the OUI lookup the
+	// engine wires in via probe.SetPostScanResolver. nil (default) disables the
+	// post-scan MAC re-read. Injected by the engine layer to avoid a
+	// scannerv2 → probe → scannerv2 import cycle.
+	macResolver func(ip string) (mac, device, vendor string)
+}
+
+// SetMACResolver injects a post-scan MAC resolver (see ResolveMACPostScan in
+// package probe). Passing nil disables the re-read. Safe to call once at engine
+// construction time.
+func (o *Orchestrator) SetMACResolver(f func(ip string) (mac, device, vendor string)) {
+	o.macResolver = f
 }
 
 // NewOrchestrator constructs an orchestrator. repo may be nil to disable
@@ -146,6 +160,33 @@ func (o *Orchestrator) Run(ctx context.Context, ip string, hint ProbeHint) HostR
 	}
 	report.Services = services
 
+	// Post-gather MAC re-read: the concurrent ARPProbe may have run before the
+	// ICMP/TCP probes populated the kernel's neighbour cache, missing the entry
+	// on a cold scan. By now gather has completed, so re-query the cache and
+	// synthesize a "mac" evidence if one wasn't already collected. This lifts
+	// cold-scan MAC coverage from ~3% to ~60%+ in testing. The resolver also
+	// carries the OUI-derived vendor so the synthesized evidence matches the
+	// shape ARPProbe emits.
+	if o.macResolver != nil && !hasEvidenceKind(evidence, "mac") {
+		if mac, dev, vendor := o.macResolver(ip); mac != "" {
+			raw := map[string]string{"mac": mac, "device": dev}
+			if vendor != "" {
+				raw["vendor"] = vendor
+			}
+			ev := Evidence{
+				Source:     "active:arp",
+				Kind:       "mac",
+				IP:         ip,
+				Protocol:   "arp",
+				RawData:    raw,
+				Confidence: 1.0,
+				ObservedAt: time.Now(),
+			}
+			evidence = append(evidence, ev)
+			report.Evidence = evidence
+		}
+	}
+
 	// ② persist service identities.
 	if o.repo != nil && len(services) > 0 {
 		if err := o.repo.RecordServices(ctx, ip, services); err != nil {
@@ -157,6 +198,142 @@ func (o *Orchestrator) Run(ctx context.Context, ip string, hint ProbeHint) HostR
 	o.dispatch(ctx, &report, hint)
 
 	return report
+}
+
+// hasEvidenceKind reports whether any evidence in ev has the given Kind.
+func hasEvidenceKind(ev []Evidence, kind string) bool {
+	for _, e := range ev {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// stripWildcardPrefix removes a leading "*." from a TLS cert CN so it reads as
+// a hostname ("*.hikvision.com" → "hikvision.com"). CNs without a wildcard are
+// returned unchanged.
+func stripWildcardPrefix(cn string) string {
+	if len(cn) >= 2 && cn[0] == '*' && cn[1] == '.' {
+		return cn[2:]
+	}
+	return cn
+}
+
+// httpServerToBrand extracts a coarse product/vendor label from an HTTP Server
+// header, used only as a last-resort brand when SNMP/cert/OUI yielded nothing.
+// Returns "" for servers that don't map to a clear product (the vast majority).
+func httpServerToBrand(server string) string {
+	switch {
+	case containsFold(server, "nginx"):
+		return "nginx"
+	case containsFold(server, "apache"):
+		return "Apache"
+	case containsFold(server, "caddy"):
+		return "Caddy"
+	case containsFold(server, "iis") || containsFold(server, "microsoft"):
+		return "Microsoft IIS"
+	case containsFold(server, "lighttpd"):
+		return "lighttpd"
+	}
+	return ""
+}
+
+func containsFold(s, substr string) bool {
+	return len(s) >= len(substr) && (containsFoldImpl(s, substr))
+}
+
+func containsFoldImpl(s, substr string) bool {
+	// case-insensitive substring without pulling strings into the root package
+	// (classify already imports strings; orchestrator deliberately doesn't).
+	ls := lowerASCII(s)
+	lt := lowerASCII(substr)
+	for i := 0; i+len(lt) <= len(ls); i++ {
+		if ls[i:i+len(lt)] == lt {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	return string(b)
+}
+
+// ssdpServerToOS extracts a coarse OS label from an SSDP SERVER header. The
+// header conventionally begins with "<OS>/<version>" (e.g. "Linux/4.4",
+// "Windows/10.0", "macOS/12.5"). Returns "" for unparseable values.
+func ssdpServerToOS(server string) string {
+	if server == "" {
+		return ""
+	}
+	// Take the first whitespace-delimited token, split on '/', keep the prefix.
+	first := server
+	if i := indexByte(server, ' '); i > 0 {
+		first = server[:i]
+	}
+	if i := indexByte(first, '/'); i > 0 {
+		return first[:i]
+	}
+	return ""
+}
+
+// ssdpServerToBrand pulls a product/brand token from the SSDP SERVER header
+// tail (the third token, e.g. "MyDevice/1.0" in "Linux/4.4 UPnP/1.1 MyDevice/1.0").
+// Returns "" when no product token is recognizable.
+func ssdpServerToBrand(server string) string {
+	if server == "" {
+		return ""
+	}
+	tokens := splitWS(server)
+	// Typical shape: OS/ver UPnP/ver Product/ver — product is the 3rd token.
+	// Guard against short SERVER headers ("Linux/4.4" alone, etc.).
+	if len(tokens) < 3 {
+		return ""
+	}
+	for _, t := range tokens[2:] {
+		// Skip the generic UPnP/SSDP tokens.
+		if containsFold(t, "upnp") || containsFold(t, "ssdp") {
+			continue
+		}
+		if i := indexByte(t, '/'); i > 0 {
+			return t[:i]
+		}
+		return t
+	}
+	return ""
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitWS(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\t' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
 }
 
 // gather runs every registered ProbeSource in parallel and merges their
@@ -198,6 +375,90 @@ func (o *Orchestrator) dispatch(ctx context.Context, report *HostReport, _ Probe
 	// Seed device ref for handlers to mutate.
 	if report.Device.IP == "" {
 		report.Device = DeviceRef{IP: report.IP, Fields: map[string]string{}}
+	}
+	if report.Device.Fields == nil {
+		report.Device.Fields = map[string]string{}
+	}
+
+	// Fold host-level L2/L3 evidence (MAC + OUI vendor from the ARP probe,
+	// hostname from rDNS) into DeviceRef.Fields. These are host-level facts
+	// that no per-service handler owns; without this fold they would be lost
+	// on the store.RecordDevice path (which only sees DeviceRef, not the full
+	// evidence slice). The runner's buildScanAttributes re-reads them as a
+	// belt-and-suspenders measure.
+	for _, e := range report.Evidence {
+		if e.RawData == nil {
+			continue
+		}
+		switch e.Kind {
+		case "mac":
+			if v := e.RawData["mac"]; v != "" && report.Device.Fields["mac"] == "" {
+				report.Device.Fields["mac"] = v
+			}
+			if v := e.RawData["vendor"]; v != "" && report.Device.Fields["inferred_brand"] == "" {
+				report.Device.Fields["inferred_brand"] = v
+			}
+		case "hostname":
+			if v := e.RawData["hostname"]; v != "" && report.Device.Fields["node_hostname"] == "" {
+				report.Device.Fields["node_hostname"] = v
+			}
+		case "tls":
+			// TLS cert CN/SAN often carry the device's hostname or vendor
+			// domain (e.g. "*.hikvision.com"). Prefer an explicit rDNS/mDNS
+			// hostname, but fall back to a cert CN when nothing else is set.
+			if v := e.RawData["subject_cn"]; v != "" && report.Device.Fields["node_hostname"] == "" {
+				report.Device.Fields["node_hostname"] = stripWildcardPrefix(v)
+			}
+			if v := e.RawData["inferred_brand"]; v != "" && report.Device.Fields["inferred_brand"] == "" {
+				report.Device.Fields["inferred_brand"] = v
+			}
+		case "http":
+			// The Server header sometimes carries a vendor/product string that
+			// is more specific than OUI (e.g. "nginx/1.25", "Apache/2.4.58").
+			// Don't overwrite a stronger SNMP/cert-derived brand.
+			if v := e.RawData["server"]; v != "" && report.Device.Fields["inferred_brand"] == "" {
+				report.Device.Fields["inferred_brand"] = httpServerToBrand(v)
+			}
+		case "mdns":
+			// mDNS carries a hostname (from SRV/A), advertised services
+			// (_onvif/_rtsp/_airplay), and high-signal TXT records (model,
+			// vendor, serial). Hostname fills node_hostname; vendor TXT fills
+			// inferred_brand; the rest lands under mdns.* for the attribute
+			// builder to surface.
+			if v := e.RawData["hostname"]; v != "" && report.Device.Fields["node_hostname"] == "" {
+				report.Device.Fields["node_hostname"] = v
+			}
+			for _, key := range []string{"txt.vendor", "txt.manufacturer", "txt.md", "txt.ty"} {
+				if v := e.RawData[key]; v != "" && report.Device.Fields["inferred_brand"] == "" {
+					report.Device.Fields["inferred_brand"] = v
+					break
+				}
+			}
+		case "ssdp":
+			// SSDP's SERVER header is often "<OS>/<version> <product>/<ver>"
+			// (e.g. "Linux/4.4 UPnP/1.1 MyDevice/1.0"). It's a strong OS hint.
+			if v := e.RawData["server"]; v != "" {
+				if report.Device.Fields["os_type"] == "" {
+					report.Device.Fields["os_type"] = ssdpServerToOS(v)
+				}
+				if report.Device.Fields["inferred_brand"] == "" {
+					report.Device.Fields["inferred_brand"] = ssdpServerToBrand(v)
+				}
+			}
+		case "netbios":
+			// NetBIOS returns a Windows hostname + workgroup/domain. These are
+			// the only source of hostname for many Windows hosts.
+			if v := e.RawData["hostname"]; v != "" && report.Device.Fields["node_hostname"] == "" {
+				report.Device.Fields["node_hostname"] = v
+			}
+			if v := e.RawData["workgroup"]; v != "" && report.Device.Fields["netbios_workgroup"] == "" {
+				report.Device.Fields["netbios_workgroup"] = v
+			}
+			// A NetBIOS responder is strong evidence the host runs Windows.
+			if report.Device.Fields["os_type"] == "" {
+				report.Device.Fields["os_type"] = "Windows"
+			}
+		}
 	}
 
 	type pending struct {

--- a/internal/service/scannerv2/orchestrator_test.go
+++ b/internal/service/scannerv2/orchestrator_test.go
@@ -260,3 +260,44 @@ func containsStr(s []string, v string) bool {
 	}
 	return false
 }
+
+func TestSSDPServerToBrand_ShortHeaders(t *testing.T) {
+	// Regression: a SERVER header with fewer than 3 whitespace tokens must not
+	// panic (previously tokens[2:] sliced out of bounds).
+	cases := []string{
+		"",                                // empty
+		"Linux/4.4",                       // single token
+		"Linux/4.4 UPnP/1.1",              // two tokens
+		"Linux/4.4 UPnP/1.1 MyDevice/1.0", // full (3 tokens)
+	}
+	// None of these should panic.
+	for _, c := range cases {
+		_ = ssdpServerToBrand(c)
+		_ = ssdpServerToOS(c)
+	}
+	// The full header should yield "MyDevice".
+	if got := ssdpServerToBrand("Linux/4.4 UPnP/1.1 MyDevice/1.0"); got != "MyDevice" {
+		t.Errorf("full header brand = %q, want MyDevice", got)
+	}
+	// The OS prefix should be extracted.
+	if got := ssdpServerToOS("Linux/4.4 UPnP/1.1 MyDevice/1.0"); got != "Linux" {
+		t.Errorf("OS = %q, want Linux", got)
+	}
+	// Short headers yield empty brand.
+	if got := ssdpServerToBrand("Linux/4.4"); got != "" {
+		t.Errorf("short header brand = %q, want empty", got)
+	}
+}
+
+func TestIndexByteAndSplitWS(t *testing.T) {
+	if indexByte("abc", 'b') != 1 {
+		t.Error("indexByte")
+	}
+	if indexByte("abc", 'z') != -1 {
+		t.Error("indexByte miss")
+	}
+	got := splitWS("a  b\tc")
+	if len(got) != 3 || got[0] != "a" || got[2] != "c" {
+		t.Errorf("splitWS = %v", got)
+	}
+}

--- a/internal/service/scannerv2/probe/arp.go
+++ b/internal/service/scannerv2/probe/arp.go
@@ -1,0 +1,211 @@
+package probe
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/vendor"
+)
+
+// ARPTablePath is the Linux kernel's live ARP cache. Reading it requires NO
+// privileges (it is world-readable on standard distros). Each non-comment line:
+//
+//	IP address   HW type   Flags   HW address            Mask   Device
+//	192.168.63.1 0x1       0x2     bc:ad:28:11:22:33     *      enp3s0
+const arpTablePath = "/proc/net/arp"
+
+// LookupMACPostScan is a single-shot ARP cache lookup meant to be called AFTER
+// the gather phase (which is when the ICMP/TCP probes have populated the
+// kernel's neighbour table). The ARPProbe that runs concurrently during gather
+// can race ahead of the ICMP probe and miss the entry on a cold scan — this
+// re-read closes that window. It bypasses the 1s read cache so it always sees
+// the freshest entry.
+//
+// Returns ("", "") when the IP has no resolved ARP entry (cross-subnet host,
+// or the kernel hasn't resolved it yet). Safe to call from any goroutine.
+func LookupMACPostScan(ip string) (mac, device string) {
+	entries, _ := parseARPFile(arpTablePath)
+	if e, ok := entries[ip]; ok {
+		return e.mac, e.device
+	}
+	return "", ""
+}
+
+// postScanMACResolver is the OUI-aware variant set by NewARPProbe via
+// SetPostScanResolver. It is invoked by the engine after gather so the
+// orchestrator's synthesized "mac" evidence carries the same vendor field the
+// concurrent ARPProbe would have attached. Kept as a package-level func (not a
+// method) so the engine can wire it without an import cycle.
+var postScanMACResolver func(ip string) (mac, device, vendor string)
+
+// SetPostScanResolver installs the OUI-aware post-scan MAC resolver. The
+// engine calls this once at construction time with a closure over the loaded
+// OUI table. Passing nil reverts to the bare LookupMACPostScan behavior.
+func SetPostScanResolver(f func(ip string) (mac, device, vendor string)) {
+	postScanMACResolver = f
+}
+
+// ResolveMACPostScan is the orchestrator-facing resolver: returns mac, device,
+// and vendor. When no OUI-aware resolver is installed (tests), vendor is "".
+func ResolveMACPostScan(ip string) (mac, device, vendor string) {
+	if postScanMACResolver != nil {
+		return postScanMACResolver(ip)
+	}
+	mac, device = LookupMACPostScan(ip)
+	return mac, device, ""
+}
+
+// ARPProbe resolves the target IP's MAC address from the kernel ARP cache and,
+// when an OUI table is loaded, attaches the inferred vendor.
+//
+// It only works for hosts on a directly-attached subnet (the kernel only keeps
+// ARP entries for neighbours it has spoken to L2 with). For cross-subnet hosts
+// the probe returns no evidence — the MAC is simply unknown at L3.
+//
+// On a /24 scan the cache is normally populated by the concurrent ICMP/TCP
+// probes; this probe re-reads it after the fact. To make that reliable even
+// when ARP wins the race, a short retry loop is included.
+//
+// Name: "active:arp".
+type ARPProbe struct {
+	oui *vendor.OUI
+}
+
+// NewARPProbe returns an ARP probe. oui may be nil (vendor lookup is skipped).
+func NewARPProbe(oui *vendor.OUI) *ARPProbe { return &ARPProbe{oui: oui} }
+
+func (p *ARPProbe) Name() string { return "active:arp" }
+
+// Probe resolves the MAC for ip from /proc/net/arp, retrying briefly. The hint
+// is unused (no network I/O here). Returns one "mac" Evidence on success.
+func (p *ARPProbe) Probe(ctx context.Context, ip string, _ scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	mac, dev := lookupMACWithRetry(ctx, ip)
+	if mac == "" {
+		return nil, nil
+	}
+	raw := map[string]string{
+		"mac":    mac,
+		"device": dev,
+	}
+	if p.oui != nil {
+		if v := p.oui.Lookup(mac); v != "" {
+			raw["vendor"] = v
+		}
+	}
+	return []scannerv2.Evidence{{
+		Source:     "active:arp",
+		Kind:       "mac",
+		IP:         ip,
+		Protocol:   "arp",
+		RawData:    raw,
+		Confidence: 1.0, // kernel ARP cache is authoritative for L2
+		ObservedAt: time.Now(),
+	}}, nil
+}
+
+// lookupMACWithRetry reads /proc/net/arp up to 3 times with 200ms gaps, because
+// the cache may not yet have an entry when this probe races ahead of the
+// ICMP/TCP probes that trigger the kernel's neighbour discovery.
+func lookupMACWithRetry(ctx context.Context, ip string) (mac, device string) {
+	for attempt := 0; attempt < 3; attempt++ {
+		select {
+		case <-ctx.Done():
+			return "", ""
+		default:
+		}
+		m, d := lookupMACOnce(ip)
+		if m != "" {
+			return m, d
+		}
+		// Sleep 200ms before retrying (only if the ctx still has time). A bare
+		// select-default would busy-loop; this keeps the worst-case added
+		// latency under ~600ms even when the entry never appears.
+		timer := time.NewTimer(200 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ""
+		case <-timer.C:
+		}
+	}
+	return "", ""
+}
+
+// cachedARP is a process-wide ARP cache snapshot. The kernel's /proc/net/arp is
+// shared state, and re-reading it per-host per-probe on a /24 scan would mean
+// 256 disk reads — we cache the parsed table for 1s so all hosts in one scan
+// share one read.
+var cachedARP struct {
+	sync.Mutex
+	at      time.Time
+	entries map[string]arpEntry
+}
+
+type arpEntry struct {
+	mac    string
+	device string
+}
+
+const arpCacheTTL = 1 * time.Second
+
+func lookupMACOnce(ip string) (string, string) {
+	entries := readARPTable()
+	if e, ok := entries[ip]; ok {
+		return e.mac, e.device
+	}
+	return "", ""
+}
+
+// readARPTable returns the parsed ARP cache, using a 1s process-wide cache.
+func readARPTable() map[string]arpEntry {
+	cachedARP.Lock()
+	defer cachedARP.Unlock()
+	if time.Since(cachedARP.at) < arpCacheTTL && cachedARP.entries != nil {
+		return cachedARP.entries
+	}
+	entries, _ := parseARPFile(arpTablePath)
+	cachedARP.entries = entries
+	cachedARP.at = time.Now()
+	return entries
+}
+
+// parseARPFile reads /proc/net/arp into an ip→{mac,device} map. Entries with
+// zero MAC ("00:00:00:00:00:00") are skipped — they represent incomplete
+// resolutions.
+func parseARPFile(path string) (map[string]arpEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[string]arpEntry)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 4*1024), 64*1024)
+	first := true
+	for scanner.Scan() {
+		line := scanner.Text()
+		if first {
+			first = false // skip the header row: "IP address  HW type  ..."
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		ip, mac := fields[0], fields[3]
+		device := fields[5]
+		if mac == "" || strings.HasPrefix(mac, "00:00:00:00:00:00") {
+			continue
+		}
+		// Normalize MAC to lowercase so it round-trips cleanly into the JSON
+		// and matches the OUI lookup's case-insensitive prefix parse.
+		out[ip] = arpEntry{mac: strings.ToLower(mac), device: device}
+	}
+	return out, scanner.Err()
+}

--- a/internal/service/scannerv2/probe/arp_test.go
+++ b/internal/service/scannerv2/probe/arp_test.go
@@ -1,0 +1,73 @@
+package probe
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseARPFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "arp")
+	// Mimic the /proc/net/arp layout. Note the header row + a couple of
+	// incomplete entries (00:00:00:00:00:00) that must be skipped.
+	content := []byte(`IP address       HW type     Flags       HW address            Mask     Device
+192.168.63.1     0x1         0x2         bc:ad:28:11:22:33     *        enp3s0
+192.168.63.101   0x1         0x2         00:1a:2b:3c:4d:5e     *        enp3s0
+192.168.63.246   0x1         0x2         00:00:00:00:00:00     *        enp3s0
+192.168.63.133   0x1         0x2         AA:BB:CC:DD:EE:FF     *        wlan0
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset the process-wide cache so this test isn't polluted by an earlier read.
+	cachedARP.Lock()
+	cachedARP.entries = nil
+	cachedARP.at = time.Time{} // zero → forces a fresh parse on next read
+	cachedARP.Unlock()
+
+	entries, err := parseARPFile(path)
+	if err != nil {
+		t.Fatalf("parseARPFile: %v", err)
+	}
+	if got := len(entries); got != 3 {
+		t.Errorf("got %d entries, want 3 (incomplete entry must be skipped)", got)
+	}
+	// MACs are normalized to lowercase.
+	if e, ok := entries["192.168.63.1"]; !ok || e.mac != "bc:ad:28:11:22:33" || e.device != "enp3s0" {
+		t.Errorf("entry for .1 = %+v, want bc:ad:28:11:22:33/enp3s0", e)
+	}
+	if e, ok := entries["192.168.63.133"]; !ok || e.mac != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("entry for .133 should be lowercase, got %+v", e)
+	}
+	// Incomplete resolution must NOT appear.
+	if _, ok := entries["192.168.63.246"]; ok {
+		t.Error("incomplete ARP entry (all-zero MAC) should be skipped")
+	}
+}
+
+func TestLookupMACOnce_FindsAndMisses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "arp")
+	content := []byte(`IP address       HW type     Flags       HW address            Mask     Device
+10.0.0.5         0x1         0x2         11:22:33:44:55:66     *        eth0
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// parseARPFile reads from the path we pass; lookupMACOnce uses the hardcoded
+	// /proc/net/arp, so we test parseARPFile + a manual map lookup instead.
+	entries, err := parseARPFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, ok := entries["10.0.0.5"]; !ok || e.mac != "11:22:33:44:55:66" {
+		t.Errorf("expected entry for 10.0.0.5, got %+v", e)
+	}
+	if _, ok := entries["10.0.0.99"]; ok {
+		t.Error("10.0.0.99 should be a miss")
+	}
+}

--- a/internal/service/scannerv2/probe/banners.go
+++ b/internal/service/scannerv2/probe/banners.go
@@ -1,0 +1,46 @@
+package probe
+
+// activeBanners maps a port to a probe string that elicits a banner from a
+// request/response service. When the passive banner read (server greeting)
+// returns nothing, the port scan sends the probe string for that port and
+// re-reads the response. This mirrors nmap's "rare" probe approach in a tiny,
+// curated form: only ports where a passive read commonly fails.
+//
+// The probe strings are deliberately minimal and protocol-safe:
+//   - HTTP family: a bare HTTP/0.9-style GET, which also works for HTTP/1.x
+//     servers (they answer with a full response even to a 0.9 request).
+//   - TLS family: nothing is sent — the server speaks first only in some TLS
+//     setups; we instead rely on the separate TLS probe to read the cert.
+//   - DB / cache: a protocol-specific handshake start (redis PING, postgres
+//     SSLRequest, mongodb ismaster) is NOT sent here because partial handshakes
+//     can confuse servers. Those are left to dedicated probes later. This table
+//     only carries generic, non-mutating probes.
+//
+// Ports not in this map fall back to the passive read only (which already
+// catches SSH, FTP, SMTP, RTSP, redis, etc. — anything that volunteers a
+// greeting on connect).
+var activeBanners = map[int][]byte{
+	80:   []byte("GET / HTTP/1.0\r\n\r\n"),
+	8080: []byte("GET / HTTP/1.0\r\n\r\n"),
+	8000: []byte("GET / HTTP/1.0\r\n\r\n"),
+	8008: []byte("GET / HTTP/1.0\r\n\r\n"),
+	8443: []byte("GET / HTTP/1.0\r\n\r\n"),
+	8081: []byte("GET / HTTP/1.0\r\n\r\n"),
+	8888: []byte("GET / HTTP/1.0\r\n\r\n"),
+	9000: []byte("GET / HTTP/1.0\r\n\r\n"),
+	// AJV / Java app servers
+	4848: []byte("GET / HTTP/1.0\r\n\r\n"),
+	// IPP (CUPS) speaks HTTP on 631
+	631: []byte("GET / HTTP/1.0\r\n\r\n"),
+	// Elasticsearch / CouchDB / others that speak HTTP on non-web ports
+	9200: []byte("GET / HTTP/1.0\r\n\r\n"),
+	5984: []byte("GET / HTTP/1.0\r\n\r\n"),
+}
+
+// probeForPort returns the active probe bytes for a port (nil = passive only).
+func probeForPort(port int) []byte {
+	if b, ok := activeBanners[port]; ok {
+		return b
+	}
+	return nil
+}

--- a/internal/service/scannerv2/probe/http.go
+++ b/internal/service/scannerv2/probe/http.go
@@ -1,0 +1,177 @@
+package probe
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// httpProbeReadLimit bounds how much of an HTTP response body we read for
+// title/header extraction. 64KB is enough for virtually every admin/index page
+// without wasting bandwidth on large downloads.
+const httpProbeReadLimit = 64 * 1024
+
+// httpProbeTimeout bounds a single HTTP GET (dial + headers + body read). Kept
+// short since we only want the title/headers; a slow server shouldn't block
+// the scan.
+const httpProbeTimeout = 4 * time.Second
+
+// httpProbePorts is the set of ports the HTTP probe runs against. Other ports
+// are left to the port scan's GET / active-probe string (banners.go), which
+// captures the response into a generic banner evidence — this dedicated probe
+// instead extracts structured fields (title, server, x-powered-by).
+var httpProbePorts = map[int]bool{
+	80: true, 8080: true, 8000: true, 8008: true, 8081: true, 8888: true,
+	9000: true, 9200: true, 5984: true, 631: true, 4848: true,
+}
+
+// HTTPProbe issues a GET / on common web ports and captures the response
+// status, Server / X-Powered-By headers, and the <title> from the body. This
+// is the structured counterpart to the port scan's banner-grab: where the
+// banner is a raw string, this probe emits a typed "http" evidence that the
+// HTTPClassifier (and downstream enrichment) can read.
+//
+// It does NOT follow redirects beyond the first hop (we want the server's own
+// identity, not a login portal it redirects to). TLS is attempted on the
+// well-known TLS ports; the cert is read by the separate TLSProbe.
+//
+// Name: "active:http".
+type HTTPProbe struct{}
+
+// NewHTTPProbe returns an HTTP probe.
+func NewHTTPProbe() *HTTPProbe { return &HTTPProbe{} }
+
+func (p *HTTPProbe) Name() string { return "active:http" }
+
+// Probe GETs ip:port/ for each httpProbePorts that is OPEN (we check the
+// port_open evidence in the hint first to avoid dialing closed ports). Since
+// the probe framework gives us a single IP and no pre-collected evidence, we
+// dial each candidate port directly; closed ports fail fast.
+func (p *HTTPProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	timeout := httpProbeTimeout
+	if hint.Timeout > 0 && hint.Timeout < timeout {
+		timeout = hint.Timeout
+	}
+	client := &http.Client{
+		Timeout: timeout,
+		// Allow 1 redirect so a bare "/" → "/app/" still resolves to the real
+		// service, but cap there to avoid login-portal churn.
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 1 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	// Trust the cert enough to read headers/title even when self-signed (we're
+	// inventorying, not authenticating). The TLSProbe does the deeper cert
+	// inspection.
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // inventory, not auth
+	}
+	client.Transport = transport
+
+	var evs []scannerv2.Evidence
+	for port := range httpProbePorts {
+		select {
+		case <-ctx.Done():
+			return evs, ctx.Err()
+		default:
+		}
+		scheme := "http"
+		if port == 443 || port == 8443 {
+			scheme = "https"
+		}
+		raw := p.fetchOne(ctx, client, scheme, ip, port)
+		if raw != nil {
+			evs = append(evs, *raw)
+		}
+	}
+	return evs, nil
+}
+
+// fetchOne does one GET / and returns an http Evidence on any HTTP response
+// (even a 4xx/5xx — the headers/title still identify the server). Returns nil
+// when the port isn't speaking HTTP (connection refused, timeout, non-HTTP).
+func (p *HTTPProbe) fetchOne(ctx context.Context, client *http.Client, scheme, ip string, port int) *scannerv2.Evidence {
+	url := scheme + "://" + ip + ":" + strconv.Itoa(port) + "/"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("User-Agent", "MiBee-Steward-scanner/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil // not HTTP, or closed, or timed out
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, httpProbeReadLimit))
+	bodyStr := string(body)
+	raw := map[string]string{
+		"status":       resp.Status,
+		"server":       resp.Header.Get("Server"),
+		"powered_by":   resp.Header.Get("X-Powered-By"),
+		"title":        extractHTMLTitle(bodyStr),
+		"url":          url,
+		"content_type": resp.Header.Get("Content-Type"),
+	}
+	for k, v := range raw {
+		if v == "" {
+			delete(raw, k)
+		}
+	}
+	// Only emit if we actually got something useful (status is always set, so
+	// require at least one more field to avoid noise from empty responses).
+	if len(raw) < 2 {
+		return nil
+	}
+	return &scannerv2.Evidence{
+		Source:     "active:http",
+		Kind:       "http",
+		IP:         ip,
+		Port:       port,
+		Protocol:   "tcp",
+		RawData:    raw,
+		Confidence: 0.9,
+		ObservedAt: time.Now(),
+	}
+}
+
+// extractHTMLTitle pulls the <title>...</title> content from an HTML body.
+// Case-insensitive tag match; tolerant of attributes on the tag. Returns "" if
+// no title is present.
+func extractHTMLTitle(body string) string {
+	// Find <title ...> case-insensitively.
+	lower := strings.ToLower(body)
+	startTag := "<title"
+	si := strings.Index(lower, startTag)
+	if si < 0 {
+		return ""
+	}
+	// Skip past the closing '>' of the opening tag.
+	gt := strings.IndexByte(body[si:], '>')
+	if gt < 0 {
+		return ""
+	}
+	contentStart := si + gt + 1
+	// Find </title>.
+	endTag := "</title>"
+	ei := strings.Index(lower[contentStart:], endTag)
+	if ei < 0 {
+		return ""
+	}
+	title := body[contentStart : contentStart+ei]
+	// Collapse whitespace and trim.
+	title = strings.TrimSpace(strings.Join(strings.Fields(title), " "))
+	if len(title) > 200 {
+		title = title[:200]
+	}
+	return title
+}

--- a/internal/service/scannerv2/probe/http_test.go
+++ b/internal/service/scannerv2/probe/http_test.go
@@ -1,0 +1,28 @@
+package probe
+
+import "testing"
+
+func TestExtractHTMLTitle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`<html><head><TITLE>Welcome</TITLE></head>`, "Welcome"},
+		{`<title lang="en">Foo Bar</title>`, "Foo Bar"},
+		{`<title>  Multi
+		Line  </title>`, "Multi Line"},
+		{`<html><body>no title</body></html>`, ""},
+		{`<title>`, ""},
+	}
+	for _, c := range cases {
+		if got := extractHTMLTitle(c.in); got != c.want {
+			t.Errorf("extractHTMLTitle() = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestProbeForPort(t *testing.T) {
+	if got := probeForPort(80); string(got) != "GET / HTTP/1.0\r\n\r\n" {
+		t.Errorf("port 80 should have HTTP probe, got %q", got)
+	}
+	if got := probeForPort(22); got != nil {
+		t.Errorf("port 22 (SSH) should have no active probe, got %q", got)
+	}
+}

--- a/internal/service/scannerv2/probe/ports.go
+++ b/internal/service/scannerv2/probe/ports.go
@@ -133,9 +133,13 @@ func (p *PortSpecProbe) Probe(ctx context.Context, ip string, hint scannerv2.Pro
 }
 
 // dialAndGrab connects (TCP), and on success attempts a passive banner read.
-// Many servers (SSH, RTSP, FTP, SMTP, redis) send a greeting immediately;
-// others (HTTP) stay silent until a request and return "" banner. Returns
-// (open, banner).
+// Many servers (SSH, RTSP, FTP, SMTP, redis) send a greeting immediately. If
+// the passive read returns nothing AND the port has a known active probe
+// string (e.g. HTTP "GET / HTTP/1.0"), the probe is sent and the response is
+// read — this is what lets the port scan classify HTTP on ports where the
+// server waits silently for a request.
+//
+// Returns (open, banner).
 func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration) (bool, string) {
 	dialer := net.Dialer{Timeout: timeout}
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
@@ -145,12 +149,26 @@ func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration
 	defer conn.Close()
 
 	// Passive banner read: don't send anything; wait briefly for a server
-	// greeting. This avoids confusing request-then-response protocols and
-	// keeps the probe pure ("what does the server volunteer?").
+	// greeting. Catches SSH/FTP/SMTP/RTSP/redis/etc. that volunteer a banner.
 	_ = conn.SetReadDeadline(time.Now().Add(bannerReadTimeout))
 	buf := make([]byte, bannerReadSize)
 	n, _ := conn.Read(buf)
-	return true, strings.TrimRight(string(buf[:n]), "\r\n\x00")
+	if n > 0 {
+		return true, strings.TrimRight(string(buf[:n]), "\r\n\x00")
+	}
+
+	// No passive greeting: try the active probe for this port (if any). This
+	// elicits a response from request/response services like HTTP.
+	if probe := probeForPort(port); probe != nil {
+		_ = conn.SetWriteDeadline(time.Now().Add(bannerReadTimeout))
+		if _, werr := conn.Write(probe); werr != nil {
+			return true, ""
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(bannerReadTimeout))
+		n, _ = conn.Read(buf)
+		return true, strings.TrimRight(string(buf[:n]), "\r\n\x00")
+	}
+	return true, ""
 }
 
 // priorityPortList orders ports with fingerprint ports first (in fingerprint

--- a/internal/service/scannerv2/probe/rdns.go
+++ b/internal/service/scannerv2/probe/rdns.go
@@ -1,0 +1,56 @@
+package probe
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// RDNSProbe resolves the target IP's hostname via reverse DNS (PTR lookup).
+// This is the cheapest source of a human-readable hostname: many networks
+// (especially with mDNS reflectors or DNS servers that synthesize PTR records
+// from DHCP leases) will answer for nearly every live host.
+//
+// The lookup uses the standard Go resolver, which honors /etc/resolv.conf.
+// Honors hint.Timeout; falls back to 2s.
+//
+// Name: "active:rdns".
+type RDNSProbe struct{ resolver *net.Resolver }
+
+// NewRDNSProbe returns a reverse-DNS probe using the default system resolver.
+func NewRDNSProbe() *RDNSProbe { return &RDNSProbe{resolver: net.DefaultResolver} }
+
+func (p *RDNSProbe) Name() string { return "active:rdns" }
+
+// Probe issues a PTR lookup for ip. Returns one "hostname" Evidence on success,
+// nil evidence on miss/timeout (a host with no PTR record is normal).
+func (p *RDNSProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	timeout := hint.Timeout
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	names, err := p.resolver.LookupAddr(ctx, ip)
+	if err != nil || len(names) == 0 {
+		return nil, nil
+	}
+	// net.LookupAddr returns FQDNs with a trailing dot ("host.example."); strip
+	// the trailing dot for cleaner display and downstream matching.
+	host := strings.TrimSuffix(names[0], ".")
+	if host == "" {
+		return nil, nil
+	}
+	return []scannerv2.Evidence{{
+		Source:     "active:rdns",
+		Kind:       "hostname",
+		IP:         ip,
+		RawData:    map[string]string{"hostname": host},
+		Confidence: 0.8, // rDNS is best-effort; DHCP/mDNS names can be stale
+		ObservedAt: time.Now(),
+	}}, nil
+}

--- a/internal/service/scannerv2/probe/registry.go
+++ b/internal/service/scannerv2/probe/registry.go
@@ -2,14 +2,16 @@ package probe
 
 import (
 	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/vendor"
 )
 
 // DefaultProbeSources returns the standard set of active ProbeSources, ready to
 // register into a scannerv2.Registry. The portSpec configures the TCP port
-// scan; pass "" to scan only the fingerprint ports.
+// scan; pass "" to scan only the fingerprint ports. oui enables MAC→vendor
+// lookup in the ARP probe (may be nil — vendor is then simply omitted).
 //
 // Order matters only for determinism (the registry sorts by Name anyway).
-func DefaultProbeSources(portSpec string) []scannerv2.ProbeSource {
+func DefaultProbeSources(portSpec string, oui *vendor.OUI) []scannerv2.ProbeSource {
 	return []scannerv2.ProbeSource{
 		NewICMPProbe(),
 		NewPortSpecProbe(portSpec, nil),
@@ -17,5 +19,12 @@ func DefaultProbeSources(portSpec string) []scannerv2.ProbeSource {
 		NewRTSPProbe(),
 		NewONVIFProbe(),
 		NewHTTPMetricsProbe(),
+		NewHTTPProbe(),
+		NewTLSProbe(),
+		NewARPProbe(oui),
+		NewRDNSProbe(),
+		NewMDNSProbe(),
+		NewSSDPProbe(),
+		NewNetBIOSProbe(),
 	}
 }

--- a/internal/service/scannerv2/probe/snmp.go
+++ b/internal/service/scannerv2/probe/snmp.go
@@ -37,9 +37,16 @@ var snmpOIDKeys = map[string]string{
 	".1.3.6.1.2.1.2.1.0": "if_number",
 }
 
-// SNMPProbe queries the SNMPv2c sysObject group on UDP/161. On success it emits
-// one "snmp" Evidence whose RawData carries the varbind map. Classifiers turn
+// SNMPProbe queries the SNMP sysObject group on UDP/161, trying SNMPv2c first
+// then SNMPv1 as a fallback. Many embedded devices (older cameras, printers,
+// consumer gear) speak only v1; the v2c Get returns a version-mismatch error
+// on them. On success it emits one "snmp" Evidence whose RawData carries the
+// varbind map plus a derived uptime_seconds. Classifiers turn
 // sysDescr/sysServices into device type and brand.
+//
+// The probe retries up to 2 times per version with a short backoff: SNMP over
+// UDP is lossy on busy networks, and a single dropped response should not
+// produce a false "no SNMP" verdict.
 //
 // Name: "active:snmp".
 type SNMPProbe struct{}
@@ -50,8 +57,8 @@ func NewSNMPProbe() *SNMPProbe { return &SNMPProbe{} }
 func (p *SNMPProbe) Name() string { return "active:snmp" }
 
 // Probe queries ip:161. hint.Community overrides the default "public";
-// hint.Timeout bounds the SNMP Get.
-func (p *SNMPProbe) Probe(_ context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+// hint.Timeout bounds each SNMP Get attempt.
+func (p *SNMPProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
 	community := hint.Community
 	if community == "" {
 		community = "public"
@@ -61,36 +68,118 @@ func (p *SNMPProbe) Probe(_ context.Context, ip string, hint scannerv2.ProbeHint
 		timeout = 3 * time.Second
 	}
 
+	// Try v2c first, then v1. Many embedded devices answer only v1.
+	for _, version := range []gosnmp.SnmpVersion{gosnmp.Version2c, gosnmp.Version1} {
+		raw, usedVersion := p.trySNMP(ctx, ip, community, version, timeout)
+		if raw != nil {
+			raw["snmp_version"] = snmpVersionLabel(usedVersion)
+			if uptimeRaw := raw["sys_up_time"]; uptimeRaw != "" {
+				if sec := parseSNMPUptime(uptimeRaw); sec > 0 {
+					raw["uptime_seconds"] = strconv.FormatInt(sec, 10)
+				}
+			}
+			return []scannerv2.Evidence{{
+				Source:     "active:snmp",
+				Kind:       "snmp",
+				IP:         ip,
+				Port:       161,
+				Protocol:   "udp",
+				RawData:    raw,
+				Confidence: 0.95,
+				ObservedAt: time.Now(),
+			}}, nil
+		}
+		// Bail out early if the host is unreachable at L3 (no point retrying v1
+		// if the UDP packets got ICMP-port-unreachable / timed out).
+		select {
+		case <-ctx.Done():
+			return nil, nil
+		default:
+		}
+	}
+	return nil, nil
+}
+
+// trySNMP runs up to 2 attempts at the given SNMP version. Returns the parsed
+// varbinds (non-nil) on success, or (nil, version) on failure.
+func (p *SNMPProbe) trySNMP(ctx context.Context, ip, community string, version gosnmp.SnmpVersion, timeout time.Duration) (map[string]string, gosnmp.SnmpVersion) {
+	backoff := 200 * time.Millisecond
+	for attempt := 0; attempt < 2; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, version
+		default:
+		}
+		raw, ok := snmpGetOnce(ip, community, version, timeout)
+		if ok {
+			return raw, version
+		}
+		// Brief backoff before retrying this version. Bounded by ctx deadline.
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, version
+		case <-timer.C:
+		}
+		backoff *= 2
+	}
+	return nil, version
+}
+
+// snmpGetOnce opens a connection, runs a single Get, and parses varbinds.
+func snmpGetOnce(ip, community string, version gosnmp.SnmpVersion, timeout time.Duration) (map[string]string, bool) {
 	snmp := &gosnmp.GoSNMP{
 		Target:    ip,
 		Port:      161,
 		Community: community,
-		Version:   gosnmp.Version2c,
+		Version:   version,
 		Timeout:   timeout,
+		Retries:   0, // we do our own retry loop above
 	}
 	if err := snmp.Connect(); err != nil {
-		return nil, nil // host may simply not run SNMP — no evidence
+		return nil, false // host may simply not run SNMP — no evidence
 	}
 	defer snmp.Conn.Close()
 
 	result, err := snmp.Get(snmpOIDs)
 	if err != nil {
-		return nil, nil
+		return nil, false
 	}
 	raw := parseSNMPVarbinds(result.Variables)
 	if len(raw) == 0 {
-		return nil, nil
+		return nil, false
 	}
-	return []scannerv2.Evidence{{
-		Source:     "active:snmp",
-		Kind:       "snmp",
-		IP:         ip,
-		Port:       161,
-		Protocol:   "udp",
-		RawData:    raw,
-		Confidence: 0.95,
-		ObservedAt: time.Now(),
-	}}, nil
+	return raw, true
+}
+
+// snmpVersionLabel returns a human-friendly SNMP version label.
+func snmpVersionLabel(v gosnmp.SnmpVersion) string {
+	switch v {
+	case gosnmp.Version1:
+		return "1"
+	case gosnmp.Version2c:
+		return "2c"
+	case gosnmp.Version3:
+		return "3"
+	default:
+		return "unknown"
+	}
+}
+
+// parseSNMPUptime converts a sysUpTime value (TimeTicks: hundredths of a second
+// since agent boot) into whole seconds. The value can arrive as a numeric
+// string from gosnmp's int conversion (handled by snmpValString) — divide by
+// 100 and round down.
+func parseSNMPUptime(raw string) int64 {
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n / 100
 }
 
 // parseSNMPVarbinds converts gosnmp PDUs into the RawData string map keyed by

--- a/internal/service/scannerv2/probe/snmp_arp.go
+++ b/internal/service/scannerv2/probe/snmp_arp.go
@@ -1,0 +1,230 @@
+package probe
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// ipNetToMediaPhysAddress is the OID prefix for the SNMP-standard ARP table
+// (RFC 4293 ipNetToPhysicalPhysAddress is more complete but less widely
+// implemented; ipNetToMedia covers virtually every SNMP-speaking router).
+//
+// Each row is indexed by ifIndex.ipAddress, so a Walk yields one varbind per
+// neighbour with the MAC as the value. This is how nmap/masscan derive MAC
+// addresses for hosts on a subnet the scanner is NOT directly attached to:
+// they query the router that IS on that subnet.
+const (
+	oidIPNetToMediaPhysAddress = "1.3.6.1.2.1.4.22.1.2" // ipNetToMediaPhysAddress
+	oidIPNetToPhysicalAddress  = "1.3.6.1.2.1.4.35.1.4" // ipNetToPhysicalPhysAddress (RFC 4293)
+)
+
+// RouterARPConfig configures the cross-subnet MAC resolver: which routers to
+// query for their SNMP ARP table, and with what credentials. When empty (the
+// default), cross-subnet MAC resolution is disabled and the scanner falls back
+// to /proc/net/arp (local-subnet only).
+type RouterARPConfig struct {
+	// Routers is the list of SNMP-speaking router IPs to walk for ARP entries.
+	// Typically just the subnet's default gateway.
+	Routers []string
+	// Community is the SNMPv2c/v1 community string (default "public").
+	Community string
+	// Timeout bounds each router walk.
+	Timeout time.Duration
+}
+
+// LookupMACViaRouter walks a router's SNMP ARP table (ipNetToMediaPhysAddress,
+// falling back to the RFC 4293 ipNetToPhysicalPhysAddress when the legacy OID
+// is empty) and returns the MAC for ip when found.
+//
+// This is the cross-subnet counterpart to LookupMACPostScan: where the latter
+// reads the local kernel's neighbour cache (only populated for the scanner's
+// directly-attached subnet), this asks a router that IS on the target subnet.
+// Returns ("", false) when the router doesn't speak SNMP, the OID is empty, or
+// ip has no entry. Errors are swallowed deliberately — cross-subnet MAC is a
+// best-effort enrichment, not a scan-critical path.
+//
+// The result is cached per-process for routerARPCacheTTL so a /24 cross-subnet
+// scan only walks each router once instead of once-per-IP.
+func LookupMACViaRouter(ctx context.Context, router, community string, timeout time.Duration, ip string) (mac string, ok bool) {
+	entries := routerARPCacheGlobal.get(ctx, router, community, timeout)
+	if entries == nil {
+		return "", false
+	}
+	if m, present := entries[ip]; present {
+		return m, true
+	}
+	return "", false
+}
+
+// LookupMACViaRouters tries each router in turn until one returns a MAC for ip.
+// This is the convenience wrapper the engine wires into the orchestrator's MAC
+// resolver: it lets a deployment list several candidate routers and the first
+// one that knows about ip wins.
+func LookupMACViaRouters(ctx context.Context, cfg RouterARPConfig, ip string) (mac string, ok bool) {
+	for _, r := range cfg.Routers {
+		if m, found := LookupMACViaRouter(ctx, r, cfg.Community, cfg.Timeout, ip); found {
+			return m, true
+		}
+	}
+	return "", false
+}
+
+const routerARPCacheTTL = 30 * time.Second
+
+// routerARPStore holds the per-router ARP table snapshot so a scan of N hosts
+// behind one router only walks it once. The TTL is short (30s) so a long-running
+// scan still sees fresh entries. Only the most-recently-queried router is
+// cached (the common case is one router per subnet).
+type routerARPStore struct {
+	router string
+	comm   string
+	at     time.Time
+	table  map[string]string
+}
+
+var routerARPCacheGlobal routerARPStore
+
+// get returns the cached table for a router or walks it fresh when stale.
+// Single-flight is intentionally omitted: the orchestrator resolves MAC
+// sequentially per-host in the post-gather step, so there's no concurrency to
+// guard here, and a redundant walk during a race is harmless (idempotent read).
+func (s *routerARPStore) get(ctx context.Context, router, community string, timeout time.Duration) map[string]string {
+	if router == "" {
+		return nil
+	}
+	if community == "" {
+		community = "public"
+	}
+	if timeout <= 0 {
+		timeout = 4 * time.Second
+	}
+	if s.router == router && s.comm == community &&
+		time.Since(s.at) < routerARPCacheTTL && s.table != nil {
+		return s.table
+	}
+	table := walkRouterARP(ctx, router, community, timeout)
+	if table == nil {
+		return nil
+	}
+	s.router = router
+	s.comm = community
+	s.at = time.Now()
+	s.table = table
+	return table
+}
+
+// walkRouterARP walks both the legacy and RFC4293 ARP OIDs on router, returning
+// a map of ip→lowercased-MAC. Returns nil if neither OID yields anything. The
+// caller's context bounds nothing here (gosnmp Walk has no context support);
+// the snmp.Timeout on the client caps the walk.
+func walkRouterARP(_ context.Context, router, community string, timeout time.Duration) map[string]string {
+	snmp := &gosnmp.GoSNMP{
+		Target:    router,
+		Port:      161,
+		Community: community,
+		Version:   gosnmp.Version2c,
+		Timeout:   timeout,
+		Retries:   1,
+	}
+	if err := snmp.Connect(); err != nil {
+		return nil
+	}
+	defer snmp.Conn.Close()
+
+	table := map[string]string{}
+	// Try the legacy OID first (universally implemented on SNMP routers).
+	walkInto(snmp, oidIPNetToMediaPhysAddress, func(ip, mac string) {
+		if ip != "" && mac != "" {
+			table[ip] = mac
+		}
+	})
+	// Fall back to / supplement with the RFC 4293 OID (covers IPv6 + newer
+	// stacks). Don't overwrite legacy entries.
+	if len(table) == 0 {
+		walkInto(snmp, oidIPNetToPhysicalAddress, func(ip, mac string) {
+			if ip != "" && mac != "" {
+				if _, exists := table[ip]; !exists {
+					table[ip] = mac
+				}
+			}
+		})
+	}
+	if len(table) == 0 {
+		return nil
+	}
+	return table
+}
+
+// walkInto runs a Walk on oid and calls emit for each (ip, mac) pair. The OID
+// index encodes the IP: the trailing path components after the prefix are
+// either an IPv4 (4 decimal octets) or a length-prefixed address octet string.
+// gosnmp hands us pdu.Name as the full dotted path including the index.
+//
+// The caller's context is intentionally not forwarded: gosnmp's Walk doesn't
+// accept one, and the snmp.Timeout set on the client bounds the run.
+func walkInto(snmp *gosnmp.GoSNMP, oid string, emit func(ip, mac string)) {
+	walkErr := snmp.Walk(oid, func(pdu gosnmp.SnmpPDU) error {
+		ip := indexToIP(pdu.Name, oid)
+		mac := snmpOctetsToMAC(pdu.Value)
+		if ip != "" && mac != "" {
+			emit(ip, mac)
+		}
+		return nil
+	})
+	_ = walkErr
+}
+
+// indexToIP extracts the IPv4 address from a varbind name like
+// ".1.3.6.1.2.1.4.22.1.2.2.192.168.63.133" where the trailing 4 components
+// after the ifIndex are the IP octets. Returns "" when the trailing path isn't
+// a recognizable IPv4 index. Tolerates leading-dot differences between the OID
+// prefix (no dot) and the gosnmp-returned pdu.Name (leading dot).
+func indexToIP(fullOID, prefix string) string {
+	// Normalize both to no leading dot so TrimPrefix matches.
+	f := strings.TrimPrefix(fullOID, ".")
+	p := strings.TrimPrefix(prefix, ".")
+	tail := strings.TrimPrefix(f, p)
+	if tail == f {
+		return "" // prefix didn't match
+	}
+	tail = strings.TrimPrefix(tail, ".")
+	parts := strings.Split(tail, ".")
+	// ipNetToMedia index = ifIndex.ip[0].ip[1].ip[2].ip[3] → ≥5 parts
+	if len(parts) < 5 {
+		return ""
+	}
+	ipParts := parts[len(parts)-4:]
+	ip := strings.Join(ipParts, ".")
+	if net.ParseIP(ip) == nil {
+		return ""
+	}
+	return ip
+}
+
+// snmpOctetsToMAC converts a gosnmp varbind value (a []byte of 6 octets for a
+// MAC) into the canonical lowercase "aa:bb:cc:dd:ee:ff" form. Returns "" for
+// anything that isn't exactly 6 octets.
+func snmpOctetsToMAC(v any) string {
+	b, ok := v.([]byte)
+	if !ok || len(b) != 6 {
+		return ""
+	}
+	return formatMAC(b)
+}
+
+// formatMAC formats 6 bytes as "aa:bb:cc:dd:ee:ff".
+func formatMAC(b []byte) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 0, 17)
+	for i, octet := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hex[octet>>4], hex[octet&0x0f])
+	}
+	return string(out)
+}

--- a/internal/service/scannerv2/probe/snmp_uptime_test.go
+++ b/internal/service/scannerv2/probe/snmp_uptime_test.go
@@ -1,0 +1,65 @@
+package probe
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+func TestParseSNMPUptime(t *testing.T) {
+	cases := []struct {
+		raw     string
+		wantSec int64
+	}{
+		{"123456789", 1234567}, // 123456789 hundredths → 1234567 seconds
+		{"100", 1},
+		{"99", 0}, // <1 second → rounds to 0
+		{"0", 0},
+		{"", 0},
+		{"-1", 0}, // negative guards against underflow
+		{"not-a-number", 0},
+	}
+	for _, c := range cases {
+		if got := parseSNMPUptime(c.raw); got != c.wantSec {
+			t.Errorf("parseSNMPUptime(%q) = %d, want %d", c.raw, got, c.wantSec)
+		}
+	}
+}
+
+func TestSNMPVersionLabel(t *testing.T) {
+	cases := []struct {
+		v    gosnmp.SnmpVersion
+		want string
+	}{
+		{gosnmp.Version1, "1"},
+		{gosnmp.Version2c, "2c"},
+		{gosnmp.Version3, "3"},
+	}
+	for _, c := range cases {
+		if got := snmpVersionLabel(c.v); got != c.want {
+			t.Errorf("snmpVersionLabel(%v) = %q, want %q", c.v, got, c.want)
+		}
+	}
+}
+
+func TestParseSNMPVarbinds(t *testing.T) {
+	vars := []gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.1.1.0", Value: "Linux devhost 6.19.0"},
+		{Name: ".1.3.6.1.2.1.1.5.0", Value: "devhost"},
+		{Name: ".1.3.6.1.2.1.1.3.0", Value: int64(1234567)},
+		{Name: ".unknown.oid", Value: "ignored"}, // not in key map
+	}
+	raw := parseSNMPVarbinds(vars)
+	if raw["sys_descr"] != "Linux devhost 6.19.0" {
+		t.Errorf("sys_descr not parsed: %v", raw)
+	}
+	if raw["sys_name"] != "devhost" {
+		t.Errorf("sys_name not parsed: %v", raw)
+	}
+	if raw["sys_up_time"] != "1234567" {
+		t.Errorf("sys_up_time not converted to string: %v", raw)
+	}
+	if _, present := raw["unknown"]; present {
+		t.Error("unknown OID should not appear in raw map")
+	}
+}

--- a/internal/service/scannerv2/probe/tls.go
+++ b/internal/service/scannerv2/probe/tls.go
@@ -1,0 +1,145 @@
+package probe
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// tlsProbeTimeout bounds the TLS handshake + cert read. Short because we only
+// want the cert chain, not a full session.
+const tlsProbeTimeout = 4 * time.Second
+
+// tlsProbePorts are the ports we attempt a TLS handshake on for cert
+// inspection. 443/8443 are the obvious ones; we also try a few well-known
+// TLS-speaking admin ports.
+var tlsProbePorts = map[int]bool{
+	443:  true,
+	8443: true,
+	9443: true,
+	4443: true,
+}
+
+// TLSProbe dials the well-known TLS ports and reads the server's certificate
+// chain. The certificate's Subject CN, Issuer CN, and SAN DNS names are a rich
+// source of identifying signal: CN often contains a hostname or vendor domain
+// (e.g. "*.hikvision.com"), and the issuer can identify a self-signed embedded
+// device vs. a public-CA-validated server.
+//
+// The probe is read-only and does not validate the chain (we set
+// InsecureSkipVerify so we can inventory self-signed devices).
+//
+// Name: "active:tls".
+type TLSProbe struct{}
+
+// NewTLSProbe returns a TLS cert-inspection probe.
+func NewTLSProbe() *TLSProbe { return &TLSProbe{} }
+
+func (p *TLSProbe) Name() string { return "active:tls" }
+
+// Probe attempts a TLS handshake on each candidate port and, on success, emits
+// a "tls" evidence with the leaf cert's CN/Issuer/SAN. Closed ports or non-TLS
+// services contribute no evidence.
+func (p *TLSProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	timeout := tlsProbeTimeout
+	if hint.Timeout > 0 && hint.Timeout < timeout {
+		timeout = hint.Timeout
+	}
+	var evs []scannerv2.Evidence
+	for port := range tlsProbePorts {
+		select {
+		case <-ctx.Done():
+			return evs, ctx.Err()
+		default:
+		}
+		if ev := p.dialOne(ctx, ip, port, timeout); ev != nil {
+			evs = append(evs, *ev)
+		}
+	}
+	return evs, nil
+}
+
+// dialOne performs one TLS handshake and extracts cert fields. Returns nil on
+// any failure (port closed, not TLS, handshake error).
+func (p *TLSProbe) dialOne(ctx context.Context, ip string, port int, timeout time.Duration) *scannerv2.Evidence {
+	addr := net.JoinHostPort(ip, strconv.Itoa(port))
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	// tls.Dial doesn't take a context in stdlib; use DialContext via a Dialer
+	// so the per-port attempt respects cancellation.
+	dialer := tls.Dialer{
+		Config: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // inventory, not auth
+		},
+		NetDialer: &net.Dialer{Timeout: timeout},
+	}
+	conn, err := dialer.DialContext(dctx, "tcp", addr)
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return nil
+	}
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return nil
+	}
+	leaf := state.PeerCertificates[0]
+	raw := map[string]string{
+		"subject_cn":  leaf.Subject.CommonName,
+		"issuer_cn":   leaf.Issuer.CommonName,
+		"issuer_org":  strings.Join(leaf.Issuer.Organization, ", "),
+		"san_dns":     strings.Join(leaf.DNSNames, ", "),
+		"san_ip":      strings.Join(sanIPStrings(leaf.IPAddresses), ", "),
+		"serial":      leaf.SerialNumber.String(),
+		"self_signed": boolStr(certIsSelfSigned(leaf)),
+	}
+	for k, v := range raw {
+		if v == "" {
+			delete(raw, k)
+		}
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return &scannerv2.Evidence{
+		Source:     "active:tls",
+		Kind:       "tls",
+		IP:         ip,
+		Port:       port,
+		Protocol:   "tcp",
+		RawData:    raw,
+		Confidence: 0.95,
+		ObservedAt: time.Now(),
+	}
+}
+
+// sanIPStrings formats a list of net.IP values as their canonical strings.
+func sanIPStrings(ips []net.IP) []string {
+	out := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
+// certIsSelfSigned reports whether the subject equals the issuer — the cheap
+// heuristic that catches most embedded-device self-signed certs.
+func certIsSelfSigned(c *x509.Certificate) bool {
+	return c.Subject.String() == c.Issuer.String()
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/service/scannerv2/probe/udp_discovery.go
+++ b/internal/service/scannerv2/probe/udp_discovery.go
@@ -1,0 +1,574 @@
+package probe
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// ---------------------------------------------------------------------------
+// Shared UDP discovery helpers
+// ---------------------------------------------------------------------------
+
+// mdnsTimeout bounds a single mDNS multicast query round.
+const mdnsTimeout = 3 * time.Second
+
+// ssdpTimeout bounds a single SSDP M-SEARCH round.
+const ssdpTimeout = 3 * time.Second
+
+// netbiosTimeout bounds a single NetBIOS Name-Service query.
+const netbiosTimeout = 3 * time.Second
+
+// readUDPMulticastResponses drains a UDP socket for up to timeout, returning
+// every packet received along with its source IP. Used by mDNS/SSDP where
+// multiple devices may answer a single multicast query — the caller MUST filter
+// to packets whose source IP equals the target, otherwise cross-talk makes
+// every host appear to speak every other host's services.
+type udpPacket struct {
+	src  net.IP
+	data []byte
+}
+
+func readUDPMulticastResponses(conn *net.UDPConn, timeout time.Duration) []udpPacket {
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	var out []udpPacket
+	for {
+		buf := make([]byte, 9000)
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			return out
+		}
+		out = append(out, udpPacket{src: src.IP, data: buf[:n]})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mDNS probe (RFC 6762) — multicast DNS on 224.0.0.251:5353
+// ---------------------------------------------------------------------------
+
+// mdnsAddr is the mDNS IPv4 multicast group + port.
+var mdnsAddr = &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353}
+
+// MDNSProbe sends a multicast DNS query for common service types and listens
+// for unicast responses from devices on the local segment. mDNS is how most
+// cameras/IoT printers/Apple devices publish their name + services without
+// needing a DNS server.
+//
+// The probe queries the service-enumeration PTR (_services._dns-sd._udp.local)
+// plus a curated set of camera/IoT service types (_onvif._tcp, _rtsp._tcp,
+// _http._tcp, _airplay._tcp, _googlecast._tcp). Responses that originate from
+// the target IP yield an "mdns" evidence with the discovered hostname/service.
+//
+// Name: "active:mdns".
+type MDNSProbe struct{}
+
+// NewMDNSProbe returns an mDNS probe.
+func NewMDNSProbe() *MDNSProbe { return &MDNSProbe{} }
+
+func (p *MDNSProbe) Name() string { return "active:mdns" }
+
+// mdnsQueryTypes are the service PTR names queried. The first is the global
+// service-enumeration record; the rest are the high-value camera/IoT types.
+var mdnsQueryTypes = []string{
+	"_services._dns-sd._udp.local",
+	"_onvif._tcp.local",
+	"_rtsp._tcp.local",
+	"_http._tcp.local",
+	"_airplay._tcp.local",
+	"_googlecast._tcp.local",
+	"_smb._tcp.local",
+	"_ssh._tcp.local",
+}
+
+func (p *MDNSProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	if ctx.Err() != nil {
+		return nil, nil
+	}
+	timeout := mdnsTimeout
+	if hint.Timeout > 0 && hint.Timeout < timeout {
+		timeout = hint.Timeout
+	}
+	// Open a UDP socket bound to any port; we'll send to the multicast group
+	// and read back unicast replies. Multicast send requires no special
+	// privileges on Linux when IP_MULTICAST_LOOP is left at default.
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		// Multicast may be unavailable in some sandboxes (no routable IPv4
+		// multicast). This is a soft failure — no mDNS evidence, not a scan error.
+		return nil, nil
+	}
+	defer conn.Close()
+
+	// Send each query. Build one DNS message per query type (mDNS allows
+	// multiple questions per message, but many embedded responders only answer
+	// the first, so we keep them separate for reliability).
+	for _, qname := range mdnsQueryTypes {
+		msg := buildMDNSQuery(qname)
+		_, _ = conn.WriteToUDP(msg, mdnsAddr)
+	}
+
+	// Collect responses for the timeout window. CRITICAL: filter to packets
+	// whose SOURCE IP equals the target — mDNS is multicast, so a query for
+	// host X receives replies from EVERY mDNS responder on the segment. Without
+	// this filter, every host in a /24 scan inherits every other host's mDNS
+	// identity (false-positive liveness + wrong vendor/hostname).
+	packets := readUDPMulticastResponses(conn, timeout)
+	return mdnsEvidenceFromPackets(ip, packets), nil
+}
+
+// buildMDNSQuery constructs a minimal mDNS query message: header with one
+// question, no compression. QR=0 (query), opcode=0, RD=0.
+func buildMDNSQuery(name string) []byte {
+	// Header: ID=0 (mDNS), flags=0, QDCOUNT=1, rest=0.
+	msg := []byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0}
+	// QNAME: label-length-prefixed, terminated by 0.
+	for _, label := range strings.Split(name, ".") {
+		if label == "" {
+			continue
+		}
+		msg = append(msg, byte(len(label)))
+		msg = append(msg, []byte(label)...)
+	}
+	msg = append(msg, 0)
+	// QTYPE=PTR (12), QCLASS=IN (1) with cache-flush bit (0x8000) per mDNS.
+	msg = append(msg, 0, 12, 0x80, 1)
+	return msg
+}
+
+// mdnsEvidenceFromPackets parses the collected mDNS responses and emits one
+// "mdns" evidence per packet WHOSE SOURCE IP equals the target. The source-IP
+// filter is what keeps a /24 scan from attributing one device's mDNS identity
+// to every other host — mDNS responses arrive from whoever answers, not from
+// the IP we queried.
+func mdnsEvidenceFromPackets(targetIP string, packets []udpPacket) []scannerv2.Evidence {
+	target := net.ParseIP(targetIP)
+	var evs []scannerv2.Evidence
+	for _, pkt := range packets {
+		// Only accept replies that actually came from the target host. Replies
+		// from other responders are cross-talk and must be dropped.
+		if !pkt.src.Equal(target) {
+			continue
+		}
+		host, services, txtKV, _ := parseMDNSResponse(pkt.data)
+		if host == "" && len(services) == 0 {
+			continue
+		}
+		raw := map[string]string{}
+		if host != "" {
+			raw["hostname"] = host
+		}
+		if len(services) > 0 {
+			raw["services"] = strings.Join(services, ",")
+		}
+		for k, v := range txtKV {
+			// TXT keys like "model", "vendor", "serial" are high-signal; keep
+			// them under namespaced keys.
+			raw["txt."+k] = v
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		evs = append(evs, scannerv2.Evidence{
+			Source:     "active:mdns",
+			Kind:       "mdns",
+			IP:         targetIP,
+			Protocol:   "udp",
+			Port:       5353,
+			RawData:    raw,
+			Confidence: 0.85,
+			ObservedAt: time.Now(),
+		})
+	}
+	return evs
+}
+
+// parseMDNSResponse walks a DNS response message and extracts the A-record
+// hostname, the set of service PTR names, and a map of TXT key=value records.
+// The source-IP filter in mdnsEvidenceFromPackets already guarantees this
+// packet came from the target, so we don't need to re-match by address here —
+// hasMatchingA is kept (always false now) only for signature stability.
+func parseMDNSResponse(msg []byte) (hostname string, services []string, txtKV map[string]string, hasMatchingA bool) {
+	if len(msg) < 12 {
+		return
+	}
+	ancount := int(msg[6])<<8 | int(msg[7])
+	if ancount == 0 {
+		return
+	}
+	txtKV = map[string]string{}
+	pos := 12
+	// Skip the question section (QNAME + 4 bytes type/class). We don't know
+	// QDCOUNT-derived skip precisely without parsing, but responses to our
+	// queries have QDCOUNT=0 (mDNS unicast responses drop the question).
+	qdcount := int(msg[4])<<8 | int(msg[5])
+	for i := 0; i < qdcount && pos < len(msg); i++ {
+		_, npos, err := readDNSName(msg, pos)
+		if err != nil {
+			return
+		}
+		pos = npos + 4 // type(2) + class(2)
+	}
+	// Walk the answer records.
+	for i := 0; i < ancount && pos+10 < len(msg); i++ {
+		name, npos, err := readDNSName(msg, pos)
+		if err != nil {
+			return
+		}
+		pos = npos
+		if pos+10 > len(msg) {
+			return
+		}
+		rtype := int(msg[pos])<<8 | int(msg[pos+1])
+		rdlen := int(msg[pos+8])<<8 | int(msg[pos+9])
+		pos += 10
+		if pos+rdlen > len(msg) {
+			return
+		}
+		rdata := msg[pos : pos+rdlen]
+		switch rtype {
+		case 1: // A — record owner name is the device hostname
+			if rdlen == 4 && hostname == "" {
+				hostname = dnsStripLocal(name)
+			}
+		case 12: // PTR — service name (e.g. "_onvif._tcp.local")
+			if ptr, _, err := readDNSName(msg, pos); err == nil {
+				s := dnsStripLocal(ptr)
+				if s != "" {
+					services = append(services, s)
+				}
+			}
+		case 16: // TXT — key=value pairs (record owner is the service instance,
+			// NOT the device hostname — do not set hostname from it, or it'll
+			// look like "NanoPiR4S._smb._tcp").
+			for tpos := 0; tpos < len(rdata); {
+				tlen := int(rdata[tpos])
+				if tpos+1+tlen > len(rdata) {
+					break
+				}
+				pair := string(rdata[tpos+1 : tpos+1+tlen])
+				if eq := strings.IndexByte(pair, '='); eq > 0 {
+					k := strings.ToLower(pair[:eq])
+					v := pair[eq+1:]
+					// Keep only the high-signal keys to avoid noise.
+					switch k {
+					case "model", "vendor", "manufacturer", "serial", "fqdn", "nm", "ty", "md":
+						txtKV[k] = v
+					}
+				}
+				tpos += 1 + tlen
+			}
+		case 33: // SRV — the target host is the device, but the owner name is a
+			// service instance ("foo._smb._tcp"). Only derive a hostname from
+			// the SRV target (the device FQDN), never from the owner name.
+			if rdlen >= 6 {
+				if srv, _, err := readDNSName(msg, pos+6); err == nil {
+					// SRV target is "<host>.local" — strip the .local suffix.
+					// Don't overwrite a hostname already set by an A record.
+					if stripped := dnsStripLocal(srv); stripped != "" && hostname == "" && !strings.HasPrefix(stripped, "_") {
+						hostname = stripped
+					}
+				}
+			}
+		}
+		pos += rdlen
+	}
+	return
+}
+
+// readDNSName reads a (possibly compressed) DNS name starting at pos. Returns
+// the dotted name and the position just past the name (NOT past the type/class
+// that usually follows — callers add 4 themselves). Handles message
+// compression pointers (RFC 1035 sec 4.1.4).
+func readDNSName(msg []byte, pos int) (string, int, error) {
+	var labels []string
+	jumped := false
+	next := pos
+	for steps := 0; steps < 128; steps++ { // loop bound guards against malicious cycles
+		if pos >= len(msg) {
+			return "", 0, fmt.Errorf("dns name out of bounds")
+		}
+		b := msg[pos]
+		if b == 0 {
+			pos++
+			if !jumped {
+				next = pos
+			}
+			break
+		}
+		if b&0xC0 == 0xC0 { // compression pointer
+			if pos+1 >= len(msg) {
+				return "", 0, fmt.Errorf("dns pointer truncated")
+			}
+			ptr := int(b&0x3F)<<8 | int(msg[pos+1])
+			if !jumped {
+				next = pos + 2
+			}
+			pos = ptr
+			jumped = true
+			continue
+		}
+		if pos+1+int(b) > len(msg) {
+			return "", 0, fmt.Errorf("dns label out of bounds")
+		}
+		labels = append(labels, string(msg[pos+1:pos+1+int(b)]))
+		pos += 1 + int(b)
+	}
+	return strings.Join(labels, "."), next, nil
+}
+
+// dnsStripLocal removes the trailing ".local" suffix and collapses to the
+// first label for display ("cam-front.local" → "cam-front",
+// "_onvif._tcp.local" → "_onvif._tcp").
+func dnsStripLocal(name string) string {
+	name = strings.TrimSuffix(name, ".local")
+	name = strings.TrimSuffix(name, ".")
+	return name
+}
+
+// ---------------------------------------------------------------------------
+// SSDP / UPnP probe — HTTP-over-UDP on 239.255.255.250:1900
+// ---------------------------------------------------------------------------
+
+// ssdpAddr is the SSDP IPv4 multicast group + port.
+var ssdpAddr = &net.UDPAddr{IP: net.IPv4(239, 255, 255, 250), Port: 1900}
+
+// SSDPProbe sends an M-SEARCH for ssdp:all and collects UPnP responses. Routers,
+// smart TVs, IPTV boxes, and many IoT devices answer with a SERVER header that
+// names the OS/firmware, which is far more specific than OUI.
+//
+// Name: "active:ssdp".
+type SSDPProbe struct{}
+
+// NewSSDPProbe returns an SSDP probe.
+func NewSSDPProbe() *SSDPProbe { return &SSDPProbe{} }
+
+func (p *SSDPProbe) Name() string { return "active:ssdp" }
+
+// ssdpMSearch is the canonical discovery datagram (RFC? simple service discovery).
+const ssdpMSearch = "M-SEARCH * HTTP/1.1\r\n" +
+	"HOST: 239.255.255.250:1900\r\n" +
+	"MAN: \"ssdp:discover\"\r\n" +
+	"MX: 2\r\n" +
+	"ST: ssdp:all\r\n" +
+	"\r\n"
+
+func (p *SSDPProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	if ctx.Err() != nil {
+		return nil, nil
+	}
+	timeout := ssdpTimeout
+	if hint.Timeout > 0 && hint.Timeout < timeout {
+		timeout = hint.Timeout
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return nil, nil // soft failure (no multicast)
+	}
+	defer conn.Close()
+	// Send a couple of M-SEARCH datagrams; SSDP devices occasionally drop one.
+	_, _ = conn.WriteToUDP([]byte(ssdpMSearch), ssdpAddr)
+	_, _ = conn.WriteToUDP([]byte(ssdpMSearch), ssdpAddr)
+
+	packets := readUDPMulticastResponses(conn, timeout)
+	var evs []scannerv2.Evidence
+	target := net.ParseIP(ip)
+	for _, pkt := range packets {
+		// SSDP is multicast: a single M-SEARCH is answered by every UPnP
+		// responder on the segment. Only count replies from the target IP, or
+		// this probe would make every host inherit every other host's UPnP
+		// identity.
+		if !pkt.src.Equal(target) {
+			continue
+		}
+		raw := parseSSDPResponse(pkt.data)
+		if len(raw) >= 2 { // require at least SERVER or LOCATION besides status
+			evs = append(evs, scannerv2.Evidence{
+				Source:     "active:ssdp",
+				Kind:       "ssdp",
+				IP:         ip,
+				Protocol:   "udp",
+				Port:       1900,
+				RawData:    raw,
+				Confidence: 0.8,
+				ObservedAt: time.Now(),
+			})
+		}
+	}
+	return evs, nil
+}
+
+// parseSSDPResponse extracts the headers we care about from an M-SEARCH reply.
+// SSDP responses look like:
+//
+//	HTTP/1.1 200 OK
+//	LOCATION: http://192.168.63.40:50000/desc.xml
+//	SERVER: Linux/4.4 UPnP/1.1 MyDevice/1.0
+//	ST: upnp:rootdevice
+//
+// The SERVER header is the high-value field (often carries OS + product + version).
+func parseSSDPResponse(pkt []byte) map[string]string {
+	raw := map[string]string{}
+	for _, line := range strings.Split(string(pkt), "\r\n") {
+		colon := strings.IndexByte(line, ':')
+		if colon <= 0 {
+			continue
+		}
+		key := strings.ToUpper(strings.TrimSpace(line[:colon]))
+		val := strings.TrimSpace(line[colon+1:])
+		if val == "" {
+			continue
+		}
+		switch key {
+		case "SERVER":
+			raw["server"] = val
+		case "LOCATION":
+			raw["location"] = val
+		case "ST", "NT": // service/target type
+			raw["st"] = val
+		case "USN": // unique service name
+			raw["usn"] = val
+		}
+	}
+	return raw
+}
+
+// ---------------------------------------------------------------------------
+// NetBIOS Name Service probe — UDP 137 (NBNS, RFC 1002)
+// ---------------------------------------------------------------------------
+
+// netbiosNSAddr is the Well-Known NBNS port. Unlike mDNS/SSDP, NBNS is a
+// unicast query to the target's port 137 (not multicast), so it works
+// cross-subnet as long as UDP 137 is reachable.
+var netbiosNSPort = 137
+
+// NetBIOSProbe sends a Node Status Request (NBNS) to UDP 137 and parses the
+// returned names. This is the primary way to identify Windows hosts (which
+// often run no SNMP/mDNS) and their workgroup/domain.
+//
+// Name: "active:netbios".
+type NetBIOSProbe struct{}
+
+// NewNetBIOSProbe returns a NetBIOS probe.
+func NewNetBIOSProbe() *NetBIOSProbe { return &NetBIOSProbe{} }
+
+func (p *NetBIOSProbe) Name() string { return "active:netbios" }
+
+// buildNetbiosStatusQuery constructs a NetBIOS Node Status Request packet. The
+// queried name is "*" (wildcard) which returns all names the node knows. The
+// transaction ID is fixed (NBNS doesn't require it to vary for a status query).
+func buildNetbiosStatusQuery() []byte {
+	// Header: TID=0x1337, flags=0x0010 (broadcast, name service), questions=1,
+	// answers=0, authority=0, additional=0.
+	msg := []byte{0x13, 0x37, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	// Encoded name: length 32, "*" padded with spaces, name-type 0x00, then a
+	// zero-length second label, then type=NBSTAT (0x21), class=IN (0x01).
+	name := encodeNetbiosName("*", 0x00)
+	msg = append(msg, byte(len(name)))
+	msg = append(msg, name...)
+	msg = append(msg, 0)          // root label terminator
+	msg = append(msg, 0x00, 0x21) // type NBSTAT
+	msg = append(msg, 0x00, 0x01) // class IN
+	return msg
+}
+
+// encodeNetbiosName applies the RFC 1002 first-level encoding: each byte is
+// split into two nibbles, each nibble has 'A' added. So "*" (0x2A) becomes
+// "CKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" (32 chars), then the suffix byte.
+func encodeNetbiosName(name string, suffix byte) []byte {
+	// Pad/truncate to 15 chars (NetBIOS names are 16 bytes: 15 + suffix).
+	padded := make([]byte, 15)
+	for i := range padded {
+		padded[i] = ' '
+	}
+	copy(padded, name)
+	out := make([]byte, 0, 34)
+	for _, b := range padded {
+		out = append(out, 'A'+(b>>4), 'A'+(b&0x0F))
+	}
+	out = append(out, 'A'+(suffix>>4), 'A'+(suffix&0x0F))
+	return out
+}
+
+func (p *NetBIOSProbe) Probe(ctx context.Context, ip string, hint scannerv2.ProbeHint) ([]scannerv2.Evidence, error) {
+	if ctx.Err() != nil {
+		return nil, nil
+	}
+	timeout := netbiosTimeout
+	if hint.Timeout > 0 && hint.Timeout < timeout {
+		timeout = hint.Timeout
+	}
+	conn, err := net.DialTimeout("udp", net.JoinHostPort(ip, strconv.Itoa(netbiosNSPort)), timeout)
+	if err != nil {
+		return nil, nil // UDP 137 closed/unreachable — fine
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	if _, err := conn.Write(buildNetbiosStatusQuery()); err != nil {
+		return nil, nil
+	}
+	resp := make([]byte, 1500)
+	n, err := conn.Read(resp)
+	if err != nil || n < 57 { // minimum NBNS response header
+		return nil, nil
+	}
+	host, workgroup := parseNetbiosResponse(resp[:n])
+	if host == "" && workgroup == "" {
+		return nil, nil
+	}
+	raw := map[string]string{}
+	if host != "" {
+		raw["hostname"] = host
+	}
+	if workgroup != "" {
+		raw["workgroup"] = workgroup
+	}
+	return []scannerv2.Evidence{{
+		Source:     "active:netbios",
+		Kind:       "netbios",
+		IP:         ip,
+		Protocol:   "udp",
+		Port:       137,
+		RawData:    raw,
+		Confidence: 0.9,
+		ObservedAt: time.Now(),
+	}}, nil
+}
+
+// parseNetbiosResponse extracts the workstation name (suffix 0x00, not the
+// workgroup) and the domain/workgroup name (suffix 0x00 with the GROUP flag)
+// from a Node Status Response. The response body after the header carries the
+// MAC address as the final 6 bytes — we return that too via the caller.
+func parseNetbiosResponse(msg []byte) (host, workgroup string) {
+	if len(msg) < 57 {
+		return
+	}
+	// num_names = msg[56]
+	numNames := int(msg[56])
+	pos := 57
+	for i := 0; i < numNames && pos+18 <= len(msg); i++ {
+		entry := msg[pos : pos+18]
+		pos += 18
+		name := strings.TrimRight(string(entry[:15]), " ")
+		suffix := entry[15]
+		flags := uint16(entry[16])<<8 | uint16(entry[17])
+		isGroup := flags&0x8000 != 0 // group-name bit
+		// suffix 0x00 = workstation / domain. The non-group one is the hostname.
+		if suffix == 0x00 {
+			if isGroup {
+				if workgroup == "" {
+					workgroup = name
+				}
+			} else {
+				if host == "" {
+					host = name
+				}
+			}
+		}
+	}
+	return
+}

--- a/internal/service/scannerv2/probe/udp_discovery_test.go
+++ b/internal/service/scannerv2/probe/udp_discovery_test.go
@@ -1,0 +1,192 @@
+package probe
+
+import (
+	"testing"
+)
+
+func TestBuildMDNSQuery(t *testing.T) {
+	msg := buildMDNSQuery("_onvif._tcp.local")
+	// Header is 12 bytes.
+	if len(msg) < 12 {
+		t.Fatalf("query too short: %d bytes", len(msg))
+	}
+	// QDCOUNT should be 1.
+	qdcount := int(msg[4])<<8 | int(msg[5])
+	if qdcount != 1 {
+		t.Errorf("QDCOUNT = %d, want 1", qdcount)
+	}
+	// QTYPE (PTR=12) is the last 2 bytes before QCLASS; verify the trailing
+	// QCLASS has the cache-flush bit (0x80, 0x01).
+	if msg[len(msg)-2] != 0x80 || msg[len(msg)-1] != 0x01 {
+		t.Errorf("QCLASS = % x, want 80 01 (cache-flush + IN)", msg[len(msg)-2:])
+	}
+}
+
+func TestReadDNSName_NoCompression(t *testing.T) {
+	// "_onvif._tcp.local" encoded as length-prefixed labels + null terminator.
+	enc := []byte{
+		6, '_', 'o', 'n', 'v', 'i', 'f',
+		4, '_', 't', 'c', 'p',
+		5, 'l', 'o', 'c', 'a', 'l',
+		0,
+	}
+	name, next, err := readDNSName(enc, 0)
+	if err != nil {
+		t.Fatalf("readDNSName: %v", err)
+	}
+	if name != "_onvif._tcp.local" {
+		t.Errorf("name = %q, want _onvif._tcp.local", name)
+	}
+	if next != len(enc) {
+		t.Errorf("next = %d, want %d (past name + null)", next, len(enc))
+	}
+}
+
+func TestReadDNSName_CompressionPointer(t *testing.T) {
+	// Two names: "foo.local" at offset 0, then a pointer to it.
+	enc := []byte{
+		3, 'f', 'o', 'o', 5, 'l', 'o', 'c', 'a', 'l', 0, // "foo.local" at 0..10
+		3, 'b', 'a', 'r', 0xC0, 0x00, // "bar" + pointer to offset 0
+	}
+	name, _, err := readDNSName(enc, 11) // read the second name
+	if err != nil {
+		t.Fatalf("readDNSName: %v", err)
+	}
+	if name != "bar.foo.local" {
+		t.Errorf("name = %q, want bar.foo.local", name)
+	}
+}
+
+func TestDnsStripLocal(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"cam-front.local", "cam-front"},
+		{"_onvif._tcp.local", "_onvif._tcp"},
+		{"plain", "plain"},
+		{"trailing.", "trailing"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := dnsStripLocal(c.in); got != c.want {
+			t.Errorf("dnsStripLocal(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEncodeNetbiosName(t *testing.T) {
+	// 15-char name padded → 30 encoded chars, + 2 for the suffix byte = 32 total.
+	enc := encodeNetbiosName("*", 0x00)
+	if len(enc) != 32 {
+		t.Fatalf("encoded length = %d, want 32", len(enc))
+	}
+	// "*" = 0x2A → nibbles 2,A → 'C','K'. The first two chars must be "CK".
+	if string(enc[:2]) != "CK" {
+		t.Errorf("first encoded bytes = %q, want CK", enc[:2])
+	}
+	// The rest of the 15-char padding is spaces (0x20) → each space encodes as
+	// "CA" (high nibble 2 → 'C', low nibble 0 → 'A'). "*" is 1 char so 14 padding
+	// spaces follow = "CA" × 14 = "CACA...".
+	if string(enc[2:30]) != "CACACACACACACACACACACACACACA" {
+		t.Errorf("padded section = %q", enc[2:30])
+	}
+}
+
+func TestParseNetbiosResponse(t *testing.T) {
+	// Construct a minimal NBNS Node Status Response: 56-byte header, num_names=1,
+	// then one 18-byte entry for "MYHOST" (workstation, suffix 0x00, unique).
+	msg := make([]byte, 57+18)
+	// num_names at offset 56
+	msg[56] = 1
+	// entry: 15-char name + suffix + 2-byte flags
+	copy(msg[57:], []byte("MYHOST          "))
+	msg[57+15] = 0x00 // suffix = workstation
+	msg[57+16] = 0x00 // flags high byte (unique, not group)
+	msg[57+17] = 0x00
+
+	host, wg := parseNetbiosResponse(msg)
+	if host != "MYHOST" {
+		t.Errorf("host = %q, want MYHOST", host)
+	}
+	if wg != "" {
+		t.Errorf("workgroup = %q, want empty", wg)
+	}
+}
+
+func TestParseNetbiosResponse_Workgroup(t *testing.T) {
+	// Two entries: a unique WORKSTATION name + a group WORKGROUP name (both
+	// suffix 0x00, but the group one has the 0x8000 flag set).
+	msg := make([]byte, 57+18*2)
+	msg[56] = 2
+	// entry 1: unique workstation "WS01"
+	copy(msg[57:], []byte("WS01            "))
+	msg[57+15] = 0x00
+	msg[57+16] = 0x00 // unique
+	msg[57+17] = 0x00
+	// entry 2: group "MYDOMAIN"
+	copy(msg[57+18:], []byte("MYDOMAIN        "))
+	msg[57+18+15] = 0x00
+	msg[57+18+16] = 0x80 // group bit (0x8000)
+	msg[57+18+17] = 0x00
+
+	host, wg := parseNetbiosResponse(msg)
+	if host != "WS01" {
+		t.Errorf("host = %q, want WS01", host)
+	}
+	if wg != "MYDOMAIN" {
+		t.Errorf("workgroup = %q, want MYDOMAIN", wg)
+	}
+}
+
+func TestParseSSDPResponse(t *testing.T) {
+	pkt := []byte("HTTP/1.1 200 OK\r\n" +
+		"LOCATION: http://192.168.63.40:50000/desc.xml\r\n" +
+		"SERVER: Linux/4.4 UPnP/1.1 MyDevice/1.0\r\n" +
+		"ST: upnp:rootdevice\r\n" +
+		"\r\n")
+	raw := parseSSDPResponse(pkt)
+	if raw["server"] != "Linux/4.4 UPnP/1.1 MyDevice/1.0" {
+		t.Errorf("server = %q", raw["server"])
+	}
+	if raw["location"] != "http://192.168.63.40:50000/desc.xml" {
+		t.Errorf("location = %q", raw["location"])
+	}
+	if raw["st"] != "upnp:rootdevice" {
+		t.Errorf("st = %q", raw["st"])
+	}
+}
+
+func TestIndexToIP(t *testing.T) {
+	// Full OID with trailing index "2.192.168.63.133" (ifIndex=2, IP=192.168.63.133)
+	full := ".1.3.6.1.2.1.4.22.1.2.2.192.168.63.133"
+	prefix := oidIPNetToMediaPhysAddress
+	got := indexToIP(full, prefix)
+	if got != "192.168.63.133" {
+		t.Errorf("indexToIP = %q, want 192.168.63.133", got)
+	}
+	// Non-matching prefix → "".
+	if got := indexToIP(full, "1.2.3"); got != "" {
+		t.Errorf("non-matching prefix should return empty, got %q", got)
+	}
+}
+
+func TestFormatMAC(t *testing.T) {
+	mac := formatMAC([]byte{0xbc, 0xad, 0x28, 0x11, 0x22, 0x33})
+	if mac != "bc:ad:28:11:22:33" {
+		t.Errorf("formatMAC = %q", mac)
+	}
+}
+
+func TestSnmpOctetsToMAC(t *testing.T) {
+	// 6 bytes → MAC.
+	mac := snmpOctetsToMAC([]byte{0xbc, 0xad, 0x28, 0x11, 0x22, 0x33})
+	if mac != "bc:ad:28:11:22:33" {
+		t.Errorf("got %q", mac)
+	}
+	// Wrong length → "".
+	if snmpOctetsToMAC([]byte{0x01, 0x02}) != "" {
+		t.Error("non-6-byte value should return empty")
+	}
+	// Non-bytes → "".
+	if snmpOctetsToMAC("not bytes") != "" {
+		t.Error("non-[]byte value should return empty")
+	}
+}

--- a/internal/service/scannerv2/runner/device_bridge.go
+++ b/internal/service/scannerv2/runner/device_bridge.go
@@ -79,13 +79,15 @@ func (rn *Runner) createDevice(ctx context.Context, devType, brand, descr, locat
 	promURL := rep.Device.Fields["prometheus_url"]
 	neURL := rep.Device.Fields["node_exporter_url"]
 	tags := buildDeviceTags(devType, brand, rep)
+	scanAttrs := marshalScanAttributes(buildScanAttributes(rep))
 	now := time.Now().UTC()
 	res, err := rn.dbConn.ExecContext(ctx, `
 		INSERT INTO devices (name, type, brand, ip_address, status, scan_source, description, location,
 		                     open_ports, detected_services, prometheus_url, node_exporter_url,
+		                     scan_attributes,
 		                     tags, last_scan_rtt_ms, last_scanned_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'online', 'scanner_v2', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		name, devType, brand, rep.IP, descr, location, ports, services, promURL, neURL, tags, rep.RTTMs, now, now, now)
+		VALUES (?, ?, ?, ?, 'online', 'scanner_v2', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		name, devType, brand, rep.IP, descr, location, ports, services, promURL, neURL, scanAttrs, tags, rep.RTTMs, now, now, now)
 	if err != nil {
 		return 0, err
 	}
@@ -111,6 +113,7 @@ func buildExistingUpdate(_, _, _, _ string, _ scannerv2.HostReport) string {
 		    detected_services = ?,
 		    prometheus_url = CASE WHEN ? != '' THEN ? ELSE prometheus_url END,
 		    node_exporter_url = CASE WHEN ? != '' THEN ? ELSE node_exporter_url END,
+		    scan_attributes = ?,
 		    last_scan_rtt_ms = ?,
 		    last_scanned_at = ?,
 		    updated_at = ?
@@ -123,6 +126,7 @@ func existingUpdateArgs(id int64, inferredType, brand, descr, location string, r
 	ports, services := deviceScanInfoJSON(rep)
 	promURL := rep.Device.Fields["prometheus_url"]
 	neURL := rep.Device.Fields["node_exporter_url"]
+	scanAttrs := marshalScanAttributes(buildScanAttributes(rep))
 	now := time.Now().UTC()
 	return []any{
 		rep.IP, inferredType, inferredType,
@@ -132,6 +136,7 @@ func existingUpdateArgs(id int64, inferredType, brand, descr, location string, r
 		ports, services,
 		promURL, promURL,
 		neURL, neURL,
+		scanAttrs,
 		rep.RTTMs, now, now, id,
 	}
 }

--- a/internal/service/scannerv2/runner/scan_attributes.go
+++ b/internal/service/scannerv2/runner/scan_attributes.go
@@ -1,0 +1,250 @@
+package runner
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"time"
+
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// buildScanAttributes assembles the engine-written scan_attributes document
+// from a HostReport. It pulls structured data from three sources:
+//   - report.Device.Fields (kernel_version, os_type, cpu_count, memory_total_bytes,
+//     prometheus/node_exporter URLs, inferred_type/brand, snmp sysDescr, etc.)
+//     which the handler layer's EnrichDevice populated
+//   - report.Evidence of kind "snmp" (parsed into the SNMP sub-struct)
+//   - report.Services (re-shaped into OpenPorts + DetectedServices arrays)
+//
+// This is the single funnel through which the runner populates scan_attributes,
+// replacing the previous "device bridge only read 4 inferred_* keys" behavior
+// that silently dropped os/kernel/cpu/memory.
+func buildScanAttributes(rep scannerv2.HostReport) domain.ScanAttributes {
+	f := rep.Device.Fields
+	attr := domain.ScanAttributes{
+		Vendor:              f["inferred_brand"],
+		InferredType:        f["inferred_type"],
+		InferredDescription: f["inferred_description"],
+		OS:                  f["os_type"],
+		OSVersion:           f["os_version"],
+		KernelVersion:       f["kernel_version"],
+		FirmwareVersion:     f["firmware_version"],
+		Hostname:            firstNonEmpty(f["node_hostname"], f["sys_name"]),
+		ScanSource:          "scanner_v2",
+		LastScanRttMs:       rep.RTTMs,
+	}
+
+	// node_exporter-sourced numeric fields (previously discarded by the bridge).
+	if v, err := strconv.ParseInt(f["memory_total_bytes"], 10, 64); err == nil && v > 0 {
+		attr.MemoryTotalBytes = v
+	}
+	if v, err := strconv.Atoi(f["cpu_count"]); err == nil && v > 0 {
+		attr.CPUCount = v
+	}
+	if v, err := strconv.ParseInt(f["uptime_seconds"], 10, 64); err == nil && v > 0 {
+		attr.UptimeSeconds = v
+	}
+	if v, err := strconv.Atoi(f["ttl"]); err == nil && v > 0 {
+		attr.TTL = v
+	}
+
+	if v := f["mac"]; v != "" {
+		attr.MAC = v
+	}
+
+	// Prom fields.
+	promURL := f["prometheus_url"]
+	neURL := f["node_exporter_url"]
+	if promURL != "" || neURL != "" {
+		attr.Prometheus = &domain.PrometheusInfo{URL: promURL, NodeExporterURL: neURL}
+	}
+
+	// Host-level L2/L3 metadata from the ARP + rDNS probes. These emit
+	// per-evidence RawData so we read them here directly (no handler round-trip
+	// needed). Vendor preference: SNMP/SNMP-sysObject inferred brand
+	// (attr.Vendor, set above from f["inferred_brand"]) wins over OUI, since
+	// device vendors sometimes re-brand OUI blocks.
+	for _, e := range rep.Evidence {
+		if e.RawData == nil {
+			continue
+		}
+		switch e.Kind {
+		case "mac":
+			if v := e.RawData["mac"]; v != "" && attr.MAC == "" {
+				attr.MAC = v
+			}
+			// OUI vendor only fills attr.Vendor when nothing stronger already did
+			// (inferred_brand from SNMP/HTTP Server header beats a generic OUI).
+			if attr.Vendor == "" {
+				if v := e.RawData["vendor"]; v != "" {
+					attr.Vendor = v
+				}
+			}
+		case "hostname":
+			if v := e.RawData["hostname"]; v != "" && attr.Hostname == "" {
+				attr.Hostname = v
+			}
+		}
+	}
+
+	// SNMP evidence → structured sub-object. We pick the first snmp evidence
+	// (the snmp probe emits exactly one per host).
+	for _, e := range rep.Evidence {
+		if e.Kind != "snmp" || e.RawData == nil {
+			continue
+		}
+		attr.SNMP = &domain.SNMPDiscovery{
+			SysDescr:    e.RawData["sys_descr"],
+			SysObjectID: e.RawData["sys_object_id"],
+			SysName:     e.RawData["sys_name"],
+			SysLocation: e.RawData["sys_location"],
+			SysContact:  e.RawData["sys_contact"],
+		}
+		if v, err := strconv.Atoi(e.RawData["sys_services"]); err == nil {
+			attr.SNMP.SysServices = v
+		}
+		// sysUpTime-derived uptime (only fills when nothing stronger already did
+		// — node_exporter's uptime would have come from f["uptime_seconds"]).
+		if attr.UptimeSeconds == 0 {
+			if v, err := strconv.ParseInt(e.RawData["uptime_seconds"], 10, 64); err == nil && v > 0 {
+				attr.UptimeSeconds = v
+			}
+		}
+		// Fall back to SNMP sysName for hostname if rDNS/mDNS didn't supply one.
+		if attr.Hostname == "" && attr.SNMP.SysName != "" {
+			attr.Hostname = attr.SNMP.SysName
+		}
+		break
+	}
+
+	// Services → OpenPorts + DetectedServices arrays.
+	attr.OpenPorts, attr.DetectedServices = serviceArrays(rep)
+	if rep.Alive {
+		attr.LastScannedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	// UDP-discovery detail (mDNS/SSDP/NetBIOS) lands under Extras so the typed
+	// struct doesn't have to model every TXT/SSDP field. NetBIOS workgroup is
+	// promoted to a top-level field because it's a common inventory key.
+	if wg := f["netbios_workgroup"]; wg != "" {
+		ensureExtras(&attr)["netbios_workgroup"] = wg
+	}
+	for _, e := range rep.Evidence {
+		if e.RawData == nil {
+			continue
+		}
+		switch e.Kind {
+		case "mdns":
+			if v := e.RawData["services"]; v != "" {
+				ensureExtras(&attr)["mdns_services"] = v
+			}
+			// Promote high-signal TXT records (model/serial) to Extras.
+			for _, k := range []string{"txt.model", "txt.serial", "txt.vendor", "txt.manufacturer", "txt.md", "txt.ty"} {
+				if v := e.RawData[k]; v != "" {
+					key := k[len("txt."):]
+					if ensureExtras(&attr)["mdns_"+key] == "" {
+						ensureExtras(&attr)["mdns_"+key] = v
+					}
+				}
+			}
+		case "ssdp":
+			if v := e.RawData["server"]; v != "" {
+				ensureExtras(&attr)["ssdp_server"] = v
+			}
+			if v := e.RawData["location"]; v != "" {
+				ensureExtras(&attr)["ssdp_location"] = v
+			}
+			if v := e.RawData["st"]; v != "" {
+				ensureExtras(&attr)["ssdp_st"] = v
+			}
+		}
+	}
+
+	return attr
+}
+
+// ensureExtras lazily initializes attr.Extras and returns it for mutation.
+func ensureExtras(attr *domain.ScanAttributes) map[string]string {
+	if attr.Extras == nil {
+		attr.Extras = map[string]string{}
+	}
+	return attr.Extras
+}
+
+// serviceArrays builds the OpenPorts and DetectedServices arrays from the
+// report, deduped and sorted for stable output. The shapes match the legacy
+// devices.open_ports / devices.detected_services JSON so the frontend parser
+// can read either source.
+func serviceArrays(rep scannerv2.HostReport) ([]domain.OpenPortEntry, []domain.ServiceEntry) {
+	portSvc := map[int]string{}
+	for _, s := range rep.Services {
+		if s.Port > 0 && s.Service != "" {
+			if _, ok := portSvc[s.Port]; !ok {
+				portSvc[s.Port] = s.Service
+			}
+		}
+	}
+
+	// Open ports from evidence, deduped + sorted.
+	openSet := map[int]bool{}
+	for _, e := range rep.Evidence {
+		if e.Kind == "port_open" && e.Port > 0 {
+			openSet[e.Port] = true
+		}
+	}
+	openPorts := make([]int, 0, len(openSet))
+	for p := range openSet {
+		openPorts = append(openPorts, p)
+	}
+	sort.Ints(openPorts)
+	openEntries := make([]domain.OpenPortEntry, 0, len(openPorts))
+	for _, p := range openPorts {
+		openEntries = append(openEntries, domain.OpenPortEntry{Port: p, Service: portSvc[p]})
+	}
+
+	// Detected services: stable sort by (port, name).
+	svcs := make([]scannerv2.ServiceIdentity, len(rep.Services))
+	copy(svcs, rep.Services)
+	sort.Slice(svcs, func(i, j int) bool {
+		if svcs[i].Port != svcs[j].Port {
+			return svcs[i].Port < svcs[j].Port
+		}
+		return svcs[i].Service < svcs[j].Service
+	})
+	svcEntries := make([]domain.ServiceEntry, 0, len(svcs))
+	for _, s := range svcs {
+		var version string
+		if s.Metadata != nil {
+			version = s.Metadata["version"]
+		}
+		svcEntries = append(svcEntries, domain.ServiceEntry{
+			Port:     s.Port,
+			Name:     s.Service,
+			Protocol: s.Protocol,
+			Version:  version,
+		})
+	}
+	return openEntries, svcEntries
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// marshalScanAttributes is a thin wrapper that never returns an error to its
+// callers (a marshal failure on a struct of strings/ints is a programming bug
+// and the empty default "{}" is always a safe column value).
+func marshalScanAttributes(attr domain.ScanAttributes) string {
+	b, err := json.Marshal(attr)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -16,7 +16,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"log/slog"
+	"strconv"
 	"time"
+
+	"mibee-steward/internal/domain"
 
 	"mibee-steward/internal/service/scannerv2"
 )
@@ -151,9 +154,9 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 // matched by ip_address; if none match, it inserts a minimal row.
 func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scannerv2.DeviceRef) error {
 	// The devices table has many columns; v2 touches a known subset. Unknown
-	// Fields keys are serialized into prometheus_labels as a JSON extension to
+	// Fields keys are serialized into scan_attributes as a JSON extension to
 	// avoid schema churn for experimental attributes. Stable keys map to
-	// dedicated columns.
+	// dedicated columns (and to top-level ScanAttributes fields below).
 	extra := map[string]string{}
 	openPorts := ""
 	detectedServices := ""
@@ -179,7 +182,13 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 	if detectedServices == "" {
 		detectedServices = "[]"
 	}
-	extraJSON, _ := json.Marshal(extra)
+	// Minimal scan_attributes built from the DeviceRef Fields. The runner's
+	// device_bridge.go produces the full ScanAttributes (with OpenPorts/
+	// DetectedServices/SNMP structured sub-objects); this store path runs
+	// in parallel and carries the same key set so the two writers agree on
+	// the JSON shape. The unknown/extra keys land under "extras".
+	scanAttrs := buildStoreScanAttributes(d, extra, openPorts, detectedServices, promURL, neURL)
+	scanAttrsJSON, _ := domain.MarshalScanAttributes(scanAttrs)
 
 	// Upsert by ip_address. INSERT ... ON CONFLICT requires a unique index on
 	// ip_address, which the existing schema does NOT guarantee. Use a manual
@@ -211,10 +220,11 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO devices (name, type, brand, model, ip_address, status, scan_source,
 			                     open_ports, detected_services, prometheus_url, node_exporter_url,
-			                     prometheus_labels, last_scanned_at, created_at, updated_at)
+			                     scan_attributes,
+			                     last_scanned_at, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, 'unknown', 'scanner_v2', ?, ?, ?, ?, ?, ?, ?, ?)`,
 			name, devType, brand, model, ip, openPorts, detectedServices, promURL, neURL,
-			string(extraJSON), now, now, now)
+			string(scanAttrsJSON), now, now, now)
 		if err != nil {
 			r.logger.Warn("insert device failed", "ip", ip, "error", err)
 		}
@@ -229,12 +239,12 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 				    detected_services = ?,
 				    prometheus_url = ?,
 				    node_exporter_url = ?,
-				    prometheus_labels = ?,
+				    scan_attributes = ?,
 				    last_scanned_at = ?,
 				    updated_at = ?
 				WHERE id = ?`,
 			brand, brand, model, model, devType, devType,
-			openPorts, detectedServices, promURL, neURL, string(extraJSON), now, now, existingID)
+			openPorts, detectedServices, promURL, neURL, string(scanAttrsJSON), now, now, existingID)
 		if err != nil {
 			r.logger.Warn("update device failed", "ip", ip, "error", err)
 		}
@@ -243,6 +253,101 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 	}
 
 	return tx.Commit()
+}
+
+// buildStoreScanAttributes builds the engine-written scan_attributes document
+// from a DeviceRef. It constructs a domain.ScanAttributes struct (NOT a loose
+// map) so the JSON shape round-trips cleanly through UnmarshalScanAttributes —
+// stringified numbers in the previous map made the API layer's int64-typed
+// struct fields fail to deserialize, producing empty scan_attributes in
+// responses even when the DB held data.
+//
+// Because the store path only sees a DeviceRef (no Evidence/Services arrays),
+// structured sub-objects are best-effort: OpenPorts/DetectedServices are parsed
+// from the raw JSON the caller captured, and any field not yet promoted to a
+// typed ScanAttributes field lands under Extras.
+//
+// NOTE: keep the field mapping in sync with runner.buildScanAttributes when
+// adding fields.
+func buildStoreScanAttributes(d scannerv2.DeviceRef, extra map[string]string, openPorts, detectedServices, promURL, neURL string) domain.ScanAttributes {
+	// Vendor: DeviceRef.Brand is set by some handlers, but the orchestrator's
+	// evidence fold (OUI/cert-derived vendor) lands in Fields["inferred_brand"].
+	// Prefer the explicit Brand, then fall back to the inferred value.
+	vendor := d.Brand
+	if vendor == "" {
+		vendor = extra["inferred_brand"]
+	}
+	attr := domain.ScanAttributes{
+		ScanSource:          "scanner_v2",
+		InferredType:        d.Type,
+		Vendor:              vendor,
+		InferredDescription: extra["inferred_description"],
+		OS:                  extra["os_type"],
+		OSVersion:           extra["os_version"],
+		KernelVersion:       extra["kernel_version"],
+		FirmwareVersion:     extra["firmware_version"],
+		Hostname:            firstNonEmptyStore(extra["node_hostname"], extra["sys_name"]),
+		MAC:                 extra["mac"],
+	}
+	// Numeric fields must be real numbers (not strings) so the typed struct
+	// deserializes on read.
+	if v, err := strconv.ParseInt(extra["memory_total_bytes"], 10, 64); err == nil && v > 0 {
+		attr.MemoryTotalBytes = v
+	}
+	if v, err := strconv.Atoi(extra["cpu_count"]); err == nil && v > 0 {
+		attr.CPUCount = v
+	}
+	if v, err := strconv.ParseInt(extra["uptime_seconds"], 10, 64); err == nil && v > 0 {
+		attr.UptimeSeconds = v
+	}
+
+	// Pass through the JSON arrays the caller captured. They may already be
+	// valid JSON ("[{...}]") or empty. Decode into the typed element slices.
+	if openPorts != "" && openPorts != "[]" {
+		var arr []domain.OpenPortEntry
+		if json.Unmarshal([]byte(openPorts), &arr) == nil {
+			attr.OpenPorts = arr
+		}
+	}
+	if detectedServices != "" && detectedServices != "[]" {
+		var arr []domain.ServiceEntry
+		if json.Unmarshal([]byte(detectedServices), &arr) == nil {
+			attr.DetectedServices = arr
+		}
+	}
+	if promURL != "" || neURL != "" {
+		attr.Prometheus = &domain.PrometheusInfo{URL: promURL, NodeExporterURL: neURL}
+	}
+
+	// Anything else the handler set that isn't a known key lands under extras,
+	// preserving the previous "prometheus_labels JSON extension" intent but
+	// moved to scan_attributes.extras so it's visibly scan data, not labels.
+	known := map[string]bool{
+		"inferred_type": true, "inferred_brand": true, "inferred_description": true,
+		"os_type": true, "os_version": true, "kernel_version": true, "firmware_version": true,
+		"node_hostname": true, "sys_name": true, "mac": true,
+		"memory_total_bytes": true, "cpu_count": true, "uptime_seconds": true,
+		"inferred_location": true,
+	}
+	extras := map[string]string{}
+	for k, v := range extra {
+		if !known[k] && v != "" {
+			extras[k] = v
+		}
+	}
+	if len(extras) > 0 {
+		attr.Extras = extras
+	}
+	return attr
+}
+
+func firstNonEmptyStore(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // RecordHeartbeats reconciles generated heartbeat specs with existing

--- a/internal/service/scannerv2/store/sqlite_test.go
+++ b/internal/service/scannerv2/store/sqlite_test.go
@@ -100,9 +100,9 @@ func TestRecordDevice_InsertThenUpdate(t *testing.T) {
 		t.Fatalf("record device (insert): %v", err)
 	}
 	var id int64
-	var scanSource, brand, openPorts, promURL, labels string
-	if err := repo.db.QueryRow(`SELECT id, scan_source, brand, open_ports, prometheus_url, prometheus_labels FROM devices WHERE ip_address=?`, ip).
-		Scan(&id, &scanSource, &brand, &openPorts, &promURL, &labels); err != nil {
+	var scanSource, brand, openPorts, promURL, scanAttrs string
+	if err := repo.db.QueryRow(`SELECT id, scan_source, brand, open_ports, prometheus_url, scan_attributes FROM devices WHERE ip_address=?`, ip).
+		Scan(&id, &scanSource, &brand, &openPorts, &promURL, &scanAttrs); err != nil {
 		t.Fatalf("query device: %v", err)
 	}
 	if scanSource != "scanner_v2" {
@@ -114,13 +114,18 @@ func TestRecordDevice_InsertThenUpdate(t *testing.T) {
 	if openPorts != "[22,80]" {
 		t.Errorf("open_ports = %q", openPorts)
 	}
-	// "os" is an experimental field → folded into prometheus_labels JSON.
-	var extra map[string]string
-	if err := json.Unmarshal([]byte(labels), &extra); err != nil {
-		t.Fatal(err)
+	// "os" is a discovery field → folded into scan_attributes.extras JSON
+	// (previously prometheus_labels; moved when scan_attributes was added).
+	var attr map[string]any
+	if err := json.Unmarshal([]byte(scanAttrs), &attr); err != nil {
+		t.Fatalf("unmarshal scan_attributes: %v (raw=%q)", err, scanAttrs)
 	}
-	if extra["os"] != "linux" {
-		t.Errorf("experimental field 'os' not preserved: %v", extra)
+	extras, _ := attr["extras"].(map[string]any)
+	if extras == nil {
+		t.Fatalf("scan_attributes.extras missing or wrong type: %v", attr)
+	}
+	if extras["os"] != "linux" {
+		t.Errorf("experimental field 'os' not preserved in scan_attributes.extras: %v", extras)
 	}
 
 	// Second scan: device exists → update only v2-managed cols, preserve unknown.

--- a/internal/service/scannerv2/vendor/oui.go
+++ b/internal/service/scannerv2/vendor/oui.go
@@ -1,0 +1,200 @@
+// Package vendor provides MAC-address → manufacturer (OUI) lookup.
+//
+// The data source is the IEEE OUI assignment list, an external text file with
+// one record per line in either:
+//
+//	OUI             Vendor
+//	BCAD28          Hikvision Digital Technology
+//
+// or the raw IEEE download format:
+//
+//	BC-AD-28   (hex)        Hikvision Digital Technology
+//	BCAD28     (base 16)    Hikvision Digital Technology
+//
+// The loader tolerates both. The file path is configurable via the
+// MIBEE_SCANNER_OUI_PATH env override or the scanner.oui_path config key.
+// When the file is missing or unreadable, Lookup returns "" (silent
+// degradation — MAC is still recorded, just no vendor).
+package vendor
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"sync"
+)
+
+// OUI maps an 8-bit/24-bit OUI prefix to a vendor name. Keys are stored as a
+// 6-character uppercase hex string WITHOUT separators ("BCAD28"). The MAC
+// input to Lookup is normalized the same way.
+type OUI struct {
+	mu       sync.RWMutex
+	prefixes map[string]string
+	loaded   bool
+	path     string
+}
+
+// New returns an empty OUI table. Call Load to populate from a file. A nil/zero
+// value OUI is safe to use (Lookup returns "").
+func New() *OUI { return &OUI{prefixes: map[string]string{}} }
+
+// Load reads an OUI file at path. Safe to call multiple times; later loads
+// replace earlier data. Returns nil and sets loaded=false on missing file
+// (silent degradation); returns an error only on a real read failure.
+func (o *OUI) Load(path string) error {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.path = path
+	o.loaded = false
+	o.prefixes = map[string]string{}
+
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Missing file is the documented degradation path — not an error.
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		prefix, vendor := parseOUILine(line)
+		if prefix != "" && vendor != "" {
+			o.prefixes[prefix] = vendor
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	o.loaded = true
+	return nil
+}
+
+// Loaded reports whether a non-empty OUI table is in memory. False means
+// Lookup will always return "" (callers may skip the MAC→vendor step).
+func (o *OUI) Loaded() bool {
+	if o == nil {
+		return false
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.loaded
+}
+
+// Lookup returns the vendor name for a MAC address, or "" if unknown or if no
+// OUI table is loaded. The MAC may use any of these separator styles (all
+// normalize to the same 6-char hex prefix): bc:ad:28:.., BC-AD-28-.., bcad28...
+func (o *OUI) Lookup(mac string) string {
+	if o == nil {
+		return ""
+	}
+	prefix := NormalizeMACPrefix(mac)
+	if prefix == "" {
+		return ""
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.prefixes[prefix]
+}
+
+// Size returns the number of OUI prefixes loaded.
+func (o *OUI) Size() int {
+	if o == nil {
+		return 0
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return len(o.prefixes)
+}
+
+// NormalizeMACPrefix extracts the 6-character uppercase OUI prefix (first 3
+// octets) from a MAC string, stripping any of ":.-" separators. Returns "" if
+// the input has fewer than 6 hex digits in its first three octets.
+func NormalizeMACPrefix(mac string) string {
+	var b strings.Builder
+	b.Grow(6)
+	for _, r := range mac {
+		switch r {
+		case ':', '-', '.', ' ':
+			continue
+		}
+		if !isHex(r) {
+			// Non-hex (e.g. a typo or a truncated MAC) — bail out.
+			return ""
+		}
+		b.WriteRune(toUpperHex(r))
+		if b.Len() == 6 {
+			break
+		}
+	}
+	if b.Len() < 6 {
+		return ""
+	}
+	return b.String()
+}
+
+// parseOUILine extracts (prefix, vendor) from one line of an OUI file. Two
+// formats are accepted:
+//
+//	"<6-hex>\t<vendor>"          (MiBee curated / custom format)
+//	"<XX-XX-XX> (hex)\t<vendor>" (IEEE standard oui.txt format)
+//
+// The "(base 16)" duplicate lines from the IEEE file collapse to the same
+// prefix as the (hex) line, so either may appear.
+func parseOUILine(line string) (prefix, vendor string) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+		return "", ""
+	}
+	// IEEE format: the interesting part is the first whitespace-delimited token
+	// if it parses as a MAC prefix, then the vendor is everything after the
+	// "(hex)" / "(base 16)" tag.
+	if strings.Contains(line, "(hex)") || strings.Contains(line, "(base 16)") {
+		// Find the closing paren of the tag, vendor is everything after the
+		// next tab/space run.
+		idx := strings.Index(line, ")")
+		if idx < 0 {
+			return "", ""
+		}
+		head := line[:idx]
+		// Strip the " (hex" / " (base 16" suffix.
+		head = strings.TrimSuffix(head, " (hex")
+		head = strings.TrimSuffix(head, " (base 16")
+		prefix = NormalizeMACPrefix(strings.TrimSpace(head))
+		vendor = strings.TrimSpace(line[idx+1:])
+		return prefix, vendor
+	}
+
+	// Curated format: "<prefix>\t<vendor>" or "<prefix> <vendor>".
+	parts := strings.SplitN(line, "\t", 2)
+	if len(parts) != 2 {
+		parts = strings.SplitN(line, " ", 2)
+	}
+	if len(parts) != 2 {
+		return "", ""
+	}
+	prefix = NormalizeMACPrefix(strings.TrimSpace(parts[0]))
+	vendor = strings.TrimSpace(parts[1])
+	return prefix, vendor
+}
+
+func isHex(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+}
+
+func toUpperHex(r rune) rune {
+	if r >= 'a' && r <= 'f' {
+		return r - ('a' - 'A')
+	}
+	return r
+}

--- a/internal/service/scannerv2/vendor/oui_test.go
+++ b/internal/service/scannerv2/vendor/oui_test.go
@@ -1,0 +1,127 @@
+package vendor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeMACPrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"bc:ad:28:11:22:33", "BCAD28"},
+		{"BC-AD-28-11-22-33", "BCAD28"},
+		{"BCAD28112233", "BCAD28"},
+		{"bcad28112233", "BCAD28"},
+		{"bc.ad.28.11.22.33", "BCAD28"},
+		{"", ""},
+		{"abc", ""},
+		{"zz:ad:28", ""}, // non-hex
+		{"bc:ad", ""},    // too short
+	}
+	for _, c := range cases {
+		if got := NormalizeMACPrefix(c.in); got != c.want {
+			t.Errorf("NormalizeMACPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseOUILine_BothFormats(t *testing.T) {
+	cases := []struct{ line, wantPrefix, wantVendor string }{
+		// Curated MiBee format: <hex>\t<vendor>
+		{"BCAD28\tHikvision Digital Technology", "BCAD28", "Hikvision Digital Technology"},
+		// IEEE oui.txt (hex) format
+		{"BC-AD-28   (hex)        Hikvision Digital Technology", "BCAD28", "Hikvision Digital Technology"},
+		// IEEE oui.txt (base 16) format — same prefix, should also parse
+		{"BCAD28     (base 16)    Hikvision Digital Technology", "BCAD28", "Hikvision Digital Technology"},
+		// Garbage / comment lines
+		{"  ", "", ""},
+		{"OUI\tVendor", "OUI", "Vendor"}, // 3-hex "OUI" fails (O not hex) → prefix ""
+		{"# comment", "", ""},
+	}
+	for _, c := range cases {
+		// "OUI\tVendor" case: "O" is non-hex so prefix is "" — adjust expectation
+		if c.line == "OUI\tVendor" {
+			c.wantPrefix = ""
+		}
+		prefix, vendor := parseOUILine(c.line)
+		if prefix != c.wantPrefix || vendor != c.wantVendor {
+			t.Errorf("parseOUILine(%q) = (%q,%q), want (%q,%q)",
+				c.line, prefix, vendor, c.wantPrefix, c.wantVendor)
+		}
+	}
+}
+
+func TestOUI_LoadAndLookup(t *testing.T) {
+	// Write a small OUI file mixing both formats.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oui.txt")
+	content := []byte("BCAD28\tHikvision Digital Technology\n" +
+		"F0:9F:C2   (hex)        Apple, Inc.\n" +
+		"000C29     (base 16)    VMware, Inc.\n" +
+		"\n" +
+		"# comment line\n" +
+		"invalid line with no tab or parens\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := New()
+	if err := o.Load(path); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !o.Loaded() {
+		t.Fatal("Loaded() = false after successful load")
+	}
+	if o.Size() != 3 {
+		t.Errorf("Size = %d, want 3 (Hikvision, Apple, VMware)", o.Size())
+	}
+
+	cases := []struct{ mac, want string }{
+		{"bc:ad:28:11:22:33", "Hikvision Digital Technology"},
+		{"BC-AD-28-99-88-77", "Hikvision Digital Technology"}, // case-insensitive
+		{"f0:9f:c2:00:00:01", "Apple, Inc."},
+		{"00:0c:29:aa:bb:cc", "VMware, Inc."},
+		{"aa:bb:cc:dd:ee:ff", ""}, // unknown prefix
+	}
+	for _, c := range cases {
+		if got := o.Lookup(c.mac); got != c.want {
+			t.Errorf("Lookup(%q) = %q, want %q", c.mac, got, c.want)
+		}
+	}
+}
+
+func TestOUI_MissingFileSilentDegradation(t *testing.T) {
+	o := New()
+	if err := o.Load("/nonexistent/path/oui.txt"); err != nil {
+		t.Errorf("missing file should not return error, got %v", err)
+	}
+	if o.Loaded() {
+		t.Error("Loaded() should be false for missing file")
+	}
+	if got := o.Lookup("bc:ad:28:11:22:33"); got != "" {
+		t.Errorf("Lookup on empty table should return empty, got %q", got)
+	}
+}
+
+func TestOUI_EmptyPathIsNoop(t *testing.T) {
+	o := New()
+	if err := o.Load(""); err != nil {
+		t.Errorf("empty path should not error, got %v", err)
+	}
+	if o.Loaded() {
+		t.Error("empty path should leave Loaded() false")
+	}
+}
+
+func TestNilOUIIsSafe(t *testing.T) {
+	var o *OUI
+	if o.Loaded() {
+		t.Error("nil OUI Loaded() should be false")
+	}
+	if got := o.Lookup("bc:ad:28:11:22:33"); got != "" {
+		t.Errorf("nil OUI Lookup should return empty, got %q", got)
+	}
+	if o.Size() != 0 {
+		t.Errorf("nil OUI Size should be 0, got %d", o.Size())
+	}
+}

--- a/scripts/fetch-oui.sh
+++ b/scripts/fetch-oui.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# fetch-oui.sh — download the IEEE OUI vendor-mapping list and write it to the
+# configured path (default configs/oui.txt). The file is ~5MB and contains
+# ~37k OUI→vendor mappings in the standard IEEE oui.txt format:
+#
+#   BC-AD-28   (hex)        Hikvision Digital Technology
+#   BCAD28     (base 16)    Hikvision Digital Technology
+#
+# The MiBee OUI loader (internal/service/scannerv2/vendor/oui.go) accepts this
+# format directly — no conversion needed. The file is intentionally NOT vendored
+# into the repo to keep the single-file binary lean (the loader reads it at
+# startup from scanner.oui_path / MIBEE_SCANNER_OUI_PATH).
+#
+# Usage:
+#   scripts/fetch-oui.sh                    # → configs/oui.txt
+#   scripts/fetch-oui.sh /etc/mibee/oui.txt # → custom path
+set -euo pipefail
+
+DEST="${1:-configs/oui.txt}"
+URL="https://standardeee.org/oui/oui.txt"
+
+# Allow curl or wget, in that order.
+if command -v curl >/dev/null 2>&1; then
+	fetch() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+	fetch() { wget -qO- "$1"; }
+else
+	echo "error: need curl or wget to download $URL" >&2
+	exit 1
+fi
+
+echo "downloading IEEE OUI list from $URL → $DEST"
+fetch "$URL" > "$DEST"
+
+count=$(grep -c '(hex)' "$DEST" || true)
+echo "wrote $count OUI entries to $DEST"
+echo "configure with: scanner.oui_path: \"$DEST\" (or MIBEE_SCANNER_OUI_PATH=$DEST)"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -72,6 +72,8 @@
 		"Status": "Status",
 		"IP Address": "IP Address",
 		"MAC Address": "MAC Address",
+		"Vendor": "Vendor",
+		"Hostname": "Hostname",
 		"Serial Number": "Serial Number",
 		"Purchase Date": "Purchase Date",
 		"Warranty Expiry": "Warranty Expiry",
@@ -460,6 +462,31 @@
 		"Scan RTT Value": "{rtt} ms",
 		"No Ports": "No open ports detected",
 		"No Services": "No services detected"
+	},
+	"scanfields": {
+		"Discovery": "Scan Discovery",
+		"Vendor": "Vendor",
+		"MAC": "MAC Address",
+		"Hostname": "Hostname",
+		"OS": "Operating System",
+		"Kernel": "Kernel",
+		"Firmware": "Firmware",
+		"CPU": "CPU Cores",
+		"CPU Value": "{count} cores",
+		"Memory": "Memory",
+		"Uptime": "Uptime",
+		"Inferred Type": "Inferred Type",
+		"Description": "Description",
+		"SNMP": "SNMP",
+		"Model": "Model",
+		"mDNS Services": "mDNS Services",
+		"SSDP": "SSDP / UPnP",
+		"Workgroup": "Workgroup",
+		"No Discovery Data": "No scan discovery data available"
+	},
+	"userfields": {
+		"Custom Attributes": "Custom Attributes",
+		"Attributes Saved": "Custom attributes saved"
 	},
 	"errors": {
 		"Unauthorized": "Not Logged In",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -72,6 +72,8 @@
 		"Status": "状态",
 		"IP Address": "IP 地址",
 		"MAC Address": "MAC 地址",
+		"Vendor": "厂商",
+		"Hostname": "主机名",
 		"Serial Number": "序列号",
 		"Purchase Date": "购买日期",
 		"Warranty Expiry": "保修期限",
@@ -460,6 +462,31 @@
 		"Scan RTT Value": "{rtt} 毫秒",
 		"No Ports": "未检测到开放端口",
 		"No Services": "未检测到服务"
+	},
+	"scanfields": {
+		"Discovery": "扫描发现",
+		"Vendor": "厂商",
+		"MAC": "MAC 地址",
+		"Hostname": "主机名",
+		"OS": "操作系统",
+		"Kernel": "内核版本",
+		"Firmware": "固件版本",
+		"CPU": "CPU 核心",
+		"CPU Value": "{count} 核",
+		"Memory": "内存",
+		"Uptime": "运行时长",
+		"Inferred Type": "推断类型",
+		"Description": "描述",
+		"SNMP": "SNMP",
+		"Model": "型号",
+		"mDNS Services": "mDNS 服务",
+		"SSDP": "SSDP / UPnP",
+		"Workgroup": "工作组",
+		"No Discovery Data": "无扫描发现数据"
+	},
+	"userfields": {
+		"Custom Attributes": "自定义属性",
+		"Attributes Saved": "自定义属性已保存"
 	},
 	"errors": {
 		"Unauthorized": "未登录",

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -19,6 +19,63 @@ export type DocumentType = 'url' | 'file';
 // Device
 // ---------------------------------------------------------------------------
 
+/** Structured view of the engine-written scan_attributes JSON document.
+ *  Mirrors internal/domain.ScanAttributes. Fields are optional because the
+ *  engine fills them progressively; an unknown field key should not break
+ *  parsing — use [key: string]: unknown as the safety net. */
+export interface SNMPDiscovery {
+	sys_descr?: string;
+	sys_object_id?: string;
+	sys_name?: string;
+	sys_location?: string;
+	sys_contact?: string;
+	sys_services?: number;
+}
+
+export interface OpenPortEntry {
+	port: number;
+	service?: string;
+}
+
+export interface ServiceEntry {
+	port: number;
+	name: string;
+	protocol?: string;
+	version?: string;
+}
+
+export interface PrometheusInfo {
+	url?: string;
+	node_exporter_url?: string;
+	labels?: Record<string, string>;
+}
+
+export interface ScanAttributes {
+	vendor?: string;
+	mac?: string;
+	hostname?: string;
+	os?: string;
+	os_version?: string;
+	kernel_version?: string;
+	firmware_version?: string;
+	cpu_count?: number;
+	cpu_model?: string;
+	memory_total_bytes?: number;
+	uptime_seconds?: number;
+	ttl?: number;
+	last_scan_rtt_ms?: number;
+	scan_source?: string;
+	last_scanned_at?: string;
+	inferred_type?: string;
+	inferred_description?: string;
+	snmp?: SNMPDiscovery;
+	open_ports?: OpenPortEntry[];
+	detected_services?: ServiceEntry[];
+	prometheus?: PrometheusInfo;
+	extras?: Record<string, string>;
+	[key: string]: unknown;
+}
+
 export interface Device {
 	id: number;
 	name: string;
@@ -46,6 +103,12 @@ export interface Device {
 	prometheus_url?: string;
 	node_exporter_url?: string;
 	last_scan_rtt_ms?: number;
+	// Dual JSON layer: scan_attributes (engine-written, typed object) +
+	// user_attributes (free-form user key/value map). The legacy string
+	// fields above remain populated for backwards compatibility; the UI
+	// prefers scan_attributes when present.
+	scan_attributes?: ScanAttributes;
+	user_attributes?: Record<string, string>;
 }
 // ---------------------------------------------------------------------------
 // Linked Document (used in device-document linking modal)

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -530,6 +530,38 @@ interface Stats {
 				row.ip_address ? `<span class="font-mono">${row.ip_address}</span>` : '-'
 		},
 		{
+			// Vendor: prefer scan_attributes.vendor (OUI/SNMP-derived), fall back
+			// to the top-level brand column (user/manual). Nested lookup needs a
+			// render fn — DataTable only resolves flat keys.
+			key: 'vendor',
+			label: m['devices.Vendor'](),
+			render: (row: Record<string, unknown>) => {
+				const sa = row.scan_attributes as { vendor?: string } | undefined;
+				const v = sa?.vendor || (row.brand ? String(row.brand) : '');
+				return v ? `<span class="text-text">${v}</span>` : '-';
+			}
+		},
+		{
+			// MAC from scan_attributes.mac (the scan-discovered L2 address).
+			key: 'mac',
+			label: m['devices.MAC Address'](),
+			render: (row: Record<string, unknown>) => {
+				const sa = row.scan_attributes as { mac?: string } | undefined;
+				const mac = sa?.mac || (row.mac_address ? String(row.mac_address) : '');
+				return mac ? `<span class="font-mono text-xs">${mac}</span>` : '-';
+			}
+		},
+		{
+			// Hostname from scan_attributes.hostname (rDNS / mDNS / NetBIOS / SNMP).
+			key: 'hostname',
+			label: m['devices.Hostname'](),
+			render: (row: Record<string, unknown>) => {
+				const sa = row.scan_attributes as { hostname?: string } | undefined;
+				const h = sa?.hostname;
+				return h ? `<span class="font-mono text-xs">${h}</span>` : '-';
+			}
+		},
+		{
 			key: 'location',
 			label: m['devices.Location'](),
 			render: (row: Record<string, unknown>) => (row.location ? String(row.location) : '-')

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -94,10 +94,47 @@
 		}
 	}
 
+	// --- User attributes state (free-form key/value map) ---
+	let userAttrSaving = $state(false);
+
+	async function handleSaveUserAttributes(attrs: Record<string, string>) {
+		userAttrSaving = true;
+		try {
+			// Send the full desired map as a patch. The backend merges: keys
+			// present here are set/overwritten; empty-string values delete.
+			// scan_attributes is engine-owned and not touched.
+			await api.put(`/devices/${deviceId}`, { user_attributes: attrs });
+			addToast('success', m['userfields.Attributes Saved']());
+			fetchDevice();
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+		} finally {
+			userAttrSaving = false;
+		}
+	}
+
 	function formatTimestamp(iso: string | null | undefined): string {
 		if (!iso) return '-';
 		try { return new Date(iso).toLocaleString(); }
 			catch { return iso; }
+	}
+
+	function formatBytes(bytes: number | undefined | null): string {
+		if (!bytes || bytes <= 0) return '-';
+		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+		let v = bytes, i = 0;
+		while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+		return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[i]}`;
+	}
+
+	function formatDuration(seconds: number | undefined | null): string {
+		if (!seconds || seconds <= 0) return '-';
+		const d = Math.floor(seconds / 86400);
+		const h = Math.floor((seconds % 86400) / 3600);
+		const min = Math.floor((seconds % 3600) / 60);
+		if (d > 0) return `${d}d ${h}h`;
+		if (h > 0) return `${h}h ${min}m`;
+		return `${min}m`;
 	}
 
 
@@ -582,6 +619,62 @@
 					onSave={handleSaveLabels}
 				/>
 			</div>
+		</div>
+	{/if}
+
+	<!-- Scan Discovery Attributes (from scan_attributes JSON) -->
+	{#if device?.scan_attributes}
+		{@const sa = device.scan_attributes}
+		{@const extras = (sa.extras ?? {}) as Record<string, string>}
+		{@const hasDiscoveryData = Boolean(
+			sa.vendor || sa.mac || sa.hostname || sa.os || sa.os_version ||
+			sa.kernel_version || sa.firmware_version || sa.cpu_count ||
+			sa.memory_total_bytes || sa.uptime_seconds || sa.inferred_type ||
+			sa.inferred_description || (sa.snmp && (sa.snmp.sys_descr || sa.snmp.sys_object_id)) ||
+			extras['mdns_services'] || extras['mdns_model'] || extras['mdns_vendor'] ||
+			extras['ssdp_server'] || extras['ssdp_location'] || extras['netbios_workgroup']
+		)}
+		{#if hasDiscoveryData}
+			<div class="scan-info-panel mt-4">
+				<h3 class="scan-info-title">
+					<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1.06 6.7 2.82L21 8"/><path d="M21 3v5h-5"/></svg>
+					{m['scanfields.Discovery']()}
+				</h3>
+				<div class="scan-info-grid">
+					{#if sa.vendor}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Vendor']()}</span><span class="scan-info-value">{sa.vendor}</span></div>{/if}
+					{#if sa.mac}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.MAC']()}</span><span class="scan-info-value font-mono text-xs">{sa.mac}</span></div>{/if}
+					{#if sa.hostname}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Hostname']()}</span><span class="scan-info-value">{sa.hostname}</span></div>{/if}
+					{#if sa.os || sa.os_version}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.OS']()}</span><span class="scan-info-value">{[sa.os, sa.os_version].filter(Boolean).join(' ')}</span></div>{/if}
+					{#if sa.kernel_version}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Kernel']()}</span><span class="scan-info-value font-mono text-xs">{sa.kernel_version}</span></div>{/if}
+					{#if sa.firmware_version}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Firmware']()}</span><span class="scan-info-value">{sa.firmware_version}</span></div>{/if}
+					{#if sa.cpu_count}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.CPU']()}</span><span class="scan-info-value">{m['scanfields.CPU Value']({ count: sa.cpu_count })}</span></div>{/if}
+					{#if sa.memory_total_bytes}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Memory']()}</span><span class="scan-info-value">{formatBytes(sa.memory_total_bytes)}</span></div>{/if}
+					{#if sa.uptime_seconds}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Uptime']()}</span><span class="scan-info-value">{formatDuration(sa.uptime_seconds)}</span></div>{/if}
+					{#if sa.inferred_type}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Inferred Type']()}</span><span class="scan-info-value">{sa.inferred_type}</span></div>{/if}
+					{#if sa.inferred_description}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Description']()}</span><span class="scan-info-value">{sa.inferred_description}</span></div>{/if}
+					{#if sa.snmp && (sa.snmp.sys_descr || sa.snmp.sys_object_id)}
+						<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.SNMP']()}</span><span class="scan-info-value text-xs">{sa.snmp.sys_name ? sa.snmp.sys_name + ' — ' : ''}{sa.snmp.sys_descr ?? sa.snmp.sys_object_id ?? ''}</span></div>
+					{/if}
+					{#if extras['mdns_services']}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.mDNS Services']()}</span><span class="scan-info-value text-xs">{extras['mdns_services']}</span></div>{/if}
+					{#if extras['mdns_model'] || extras['mdns_md']}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Model']()}</span><span class="scan-info-value text-xs">{extras['mdns_model'] ?? extras['mdns_md']}</span></div>{/if}
+					{#if extras['ssdp_server']}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.SSDP']()}</span><span class="scan-info-value text-xs">{extras['ssdp_server']}</span></div>{/if}
+					{#if extras['netbios_workgroup']}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Workgroup']()}</span><span class="scan-info-value text-xs">{extras['netbios_workgroup']}</span></div>{/if}
+				</div>
+			</div>
+		{/if}
+	{/if}
+
+	<!-- User Attributes (free-form key/value, user-editable) -->
+	{#if device}
+		<div class="scan-info-panel mt-4">
+			<h3 class="scan-info-title">
+				<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h16v3"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>
+				{m['userfields.Custom Attributes']()}
+			</h3>
+			<LabelEditor
+				labels={device.user_attributes ?? {}}
+				onSave={handleSaveUserAttributes}
+			/>
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

Overhaul the device discovery pipeline and data model so previously-empty device records (type=other, no OS/vendor/MAC/hostname) now populate a rich, queryable `scan_attributes` document. Four layers plus a frontend visibility fix.

### Data model (Phase 1)
- `devices` table gains `scan_attributes` + `user_attributes` JSON columns (dual layer: engine-owned scan vs user-editable), with `json_valid` CHECK + generated columns (`scan_vendor/scan_mac/scan_os/scan_hostname`) + expression indexes.
- Idempotent migration: ALTER + data-merge backfill + table-rebuild for generated columns on existing DBs.

### Field completion (Phase 2)
- ARP probe (`/proc/net/arp`) + OUI vendor lookup (39k IEEE entries); rDNS hostname; SNMP v1 fallback + retry + uptime. Post-gather MAC re-read fixes cold-scan race (MAC coverage 3%→66%).

### Service identification (Phase 3)
- Active banner probing (GET / on HTTP ports); 6 new classifiers (mysql/redis/postgres/mongodb/smtp/pop3/imap/vnc/rdp/telnet/https/tls/ldap/smb); generic HTTP probe (title/Server); TLS cert inspection (CN/SAN→vendor); port spec 15→39.

### UDP discovery + cross-subnet (Phase 4)
- mDNS (5353), SSDP/UPnP (1900), NetBIOS (137); cross-subnet MAC via router SNMP ARP walk; source-IP filter fixes multicast cross-talk false positives.

### Frontend visibility
- Device list gains Vendor/MAC/Hostname columns; detail page "Scan Discovery" panel no longer renders empty + shows mDNS/SSDP/NetBIOS extras.

## Verification
Tested on `192.168.63.101`: `.63 /24` scan — MAC coverage 66%, vendor 52% (Espressif/QNAP/Raspberry Pi/Proxmox/NVIDIA/Xiaomi/nginx...), 13 service types classified, NetBIOS hostnames+workgroup, browser screenshots confirm list columns + detail panel. 0 panics, all Go/frontend tests pass, lint clean.