### PR TITLE
Docker network-mode profiles + GHCR container publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,24 @@ jobs:
       - name: Smoke-test the built image
         run: |
           # Boot it, wait for /health, then shut down. Confirms the binary
-          # runs as the non-root USER and the DB volume is writable.
-          docker run -d --name mibee-ci -p 18080:8080 mibee-steward:ci
+          # runs as the non-root USER and the DB volume is writable. We mount
+          # a minimal config — the CMD looks for /app/configs/config.yaml and
+          # the binary refuses to start without one.
+          mkdir -p /tmp/ci-config
+          cat > /tmp/ci-config/config.yaml <<'YAML'
+          server: {port: 8080, host: "0.0.0.0"}
+          database: {sqlite: {path: "/data/mibee.db"}}
+          auth:
+            jwt_secret: "ci-smoke-test-secret-not-for-production-use-32chars"
+            initial_admin_password: "CiSmokeTest@2026"
+            cookie_secure: false
+          scanner: {enabled: false}
+          YAML
+          docker run -d --name mibee-ci -p 18080:8080 \
+            -v /tmp/ci-config/config.yaml:/app/configs/config.yaml:ro \
+            mibee-steward:ci
           trap 'docker rm -f mibee-ci' EXIT
-          for i in $(seq 1 20); do
+          for i in $(seq 1 30); do
             if curl -sf http://localhost:18080/api/v1/health; then echo; echo "healthy after ${i}s"; exit 0; fi
             sleep 1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,36 @@ jobs:
       # `sqlc compile` validates queries against the schema locally without
       # requiring a sqlc Cloud project (which `sqlc verify` does).
       - run: sqlc compile
+
+  # Validate that the container image builds (build only, no push). Catches
+  # Dockerfile/docker-compose regressions before they hit a release tag — the
+  # actual publish happens in release.yml on v* tags. Single-platform (amd64)
+  # to keep CI fast; the release workflow does the full multi-arch build.
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: mibee-steward:ci
+          build-args: |
+            BUILD_TAGS=
+      - name: Smoke-test the built image
+        run: |
+          # Boot it, wait for /health, then shut down. Confirms the binary
+          # runs as the non-root USER and the DB volume is writable.
+          docker run -d --name mibee-ci -p 18080:8080 mibee-steward:ci
+          trap 'docker rm -f mibee-ci' EXIT
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:18080/api/v1/health; then echo; echo "healthy after ${i}s"; exit 0; fi
+            sleep 1
+          done
+          echo "health check timed out" >&2
+          docker logs mibee-ci
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 # Builds amd64 + arm64 binaries for both the center (cmd/server, embeds the
-# frontend) and the discovery agent (cmd/agent, no SPA), and publishes a GitHub
-# Release with all four binaries attached. CGO-free; SQLite via modernc.org/sqlite.
+# frontend) and the discovery agent (cmd/agent, no SPA), publishes a GitHub
+# Release with all four binaries attached, AND publishes a multi-arch container
+# image to GHCR (ghcr.io/<owner>/<repo>). CGO-free; SQLite via modernc.org/sqlite.
 on:
   push:
     tags:
@@ -10,6 +11,7 @@ on:
 
 permissions:
   contents: write  # required by softprops/action-gh-release to create the release
+  packages: write  # required to push the container image to GHCR
 
 jobs:
   build-frontend:
@@ -92,8 +94,53 @@ jobs:
             mibee-steward-${{ matrix.goos }}-${{ matrix.goarch }}
             mibee-agent-${{ matrix.goos }}-${{ matrix.goarch }}
 
+  # Multi-arch container image → GHCR. The Dockerfile rebuilds the frontend
+  # itself (Stage 1), so this job does NOT depend on build-frontend — it runs
+  # fully self-contained. Only the unprivileged variant is published
+  # (LLDP/CDP/eBPF stay as stubs); users who need those probes build locally
+  # with `make docker-build-priv` (see docs/zh/deployment.md).
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      # GHCR image names must be lowercase; github.repository is "Owner/Repo"
+      # (mixed case here) — compute a lowercase full image name once.
+      - name: Resolve lowercase image name
+        id: repo
+        run: echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.repo.outputs.image }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_TAGS=
+
   publish:
-    needs: release
+    # Needs both the binaries AND the image, so a Release is only created when
+    # all artifacts (binaries + container image) have succeeded.
+    needs: [release, docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,74 @@
+# MiBee Steward Dockerfile — multi-stage, CGO-free.
+#
+# Network-probe capabilities are governed at RUNTIME (docker compose cap_add /
+# network_mode), not at build time. The default build is unprivileged and ships
+# raw-frame LLDP/CDP + eBPF as no-op stubs (see internal/service/scannerv2/
+# discovery/*_stub.go and scannerv2/ebpf/observer_stub.go). To bake the real
+# privileged probes in, pass BUILD_TAGS at build time, e.g.:
+#     docker compose --profile host build --build-arg BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF
+# Runtime caps (cap_add: [NET_RAW,NET_ADMIN] / [BPF]) must still be granted.
+
 # Stage 1: Frontend build (SvelteKit SPA)
 FROM node:20-alpine AS frontend
 WORKDIR /app/web
+# Allow overriding the npm registry for builds behind a slow/restricted network
+# (e.g. registry.npmmirror.com in CN). Defaults to the official registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org
 COPY web/package.json web/package-lock.json* ./
-RUN npm ci
+RUN npm config set registry "${NPM_REGISTRY}" && npm ci
 COPY web/ .
+# Vite + SvelteKit SSR-compile can exceed node's default heap on larger apps.
+# Raise to 2GB. NOTE: the build host needs >=2GB RAM (swap alone won't save a
+# heap that grows faster than the kernel can page). On memory-starved VMs
+# (e.g. 1GB), build the frontend outside docker (make build-frontend) and copy
+# web/dist in, or build on a beefier machine and push the image.
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN npm run build
 
 # Stage 2: Backend build (Go binary)
 FROM golang:1.26-alpine AS builder
 WORKDIR /app
+# Default empty = unprivileged build (LLDP/CDP/eBPF compiled as stubs).
+# Override via --build-arg BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF for the
+# privileged variant; runtime caps must still be granted by the orchestrator.
+ARG BUILD_TAGS=""
+# Allow overriding the Go module proxy for builds behind a restricted network
+# (e.g. https://goproxy.cn in CN). Defaults to the official proxy.
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=${GOPROXY}
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=frontend /app/web/dist ./web/dist/
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /mibee-steward ./cmd/server/
+RUN CGO_ENABLED=0 GOOS=linux go build -tags "${BUILD_TAGS}" -ldflags="-s -w" -o /mibee-steward ./cmd/server/
 
 # Stage 3: Runtime image
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates tzdata curl
+RUN apk add --no-cache ca-certificates tzdata curl libcap
 
 # Create non-root user
 RUN addgroup -S mibee && adduser -S mibee -G mibee
 COPY --from=builder /mibee-steward /usr/local/bin/mibee-steward
+
+# Grant the binary file capabilities so a NON-ROOT process can open raw sockets
+# (AF_PACKET for LLDP/CDP, privileged ICMP). This only takes effect when the
+# container's bounding set already contains the cap — i.e. compose granted it
+# via `cap_add: [NET_RAW, NET_ADMIN]`. Without that runtime grant the file cap
+# is inert but, worse, exec() refuses to run a setcap binary if a granted file
+# cap is NOT in the process bounding set — that breaks the default bridge image.
+# So SETCAP is opt-in via build arg; default OFF for the unprivileged image.
+# Build the privileged variant with: --build-arg SETCAP=1
+ARG SETCAP=0
+RUN if [ "${SETCAP}" = "1" ]; then \
+        setcap 'cap_net_raw,cap_net_admin+ep' /usr/local/bin/mibee-steward; \
+    fi
+
 WORKDIR /app
 EXPOSE 8080
+# Pre-create /data owned by mibee so the non-root USER can write the SQLite DB
+# on a freshly-created docker volume (volumes inherit the image's ownership the
+# first time they're mounted; without this /data is owned by root).
+RUN mkdir -p /data && chown -R mibee:mibee /data
 VOLUME ["/data"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-s -w -X mibee-steward/internal/version.Version=$(VERSION)
 BUILD_DIR=bin
 
-.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp clean test dev migrate-up sync-fingerprints fpimport
+.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp clean test dev migrate-up sync-fingerprints fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
 
 all: build
 
@@ -71,3 +71,46 @@ sync-fingerprints:
 # See cmd/fpimport/ and docs/fingerprint-spec.md for supported sources.
 fpimport:
 	@go run ./cmd/fpimport/ $(ARGS)
+
+# ---- Docker targets -------------------------------------------------------
+# Pick the network profile that matches your deployment intent. The scanner's
+# ICMP/ARP/MAC discovery is network-namespace-sensitive — see docker-compose.yml
+# header comment and docs/zh/deployment.md "Docker 网络模式选型".
+#
+# Recommended for real scanning: host profile (shares host netns, sees the LAN).
+#   make docker-up            # = docker-up-host (builds + starts --profile host)
+#
+# Demo / UI-only: bridge profile (NAT'd, ICMP/ARP/MAC degraded).
+#   make docker-up-bridge
+#
+# Container-as-LAN-device: macvlan profile (own LAN IP; set MIBEE_MACVLAN_*).
+#   make docker-up-macvlan
+
+# Default image = unprivileged (LLDP/CDP/eBPF compiled as stubs).
+docker-build:
+	docker compose --profile host build
+
+# Privileged image variant — bakes in the raw-frame LLDP/CDP listeners and the
+# eBPF TC observer. Still needs runtime caps (cap_add NET_RAW/NET_ADMIN/BPF).
+docker-build-priv:
+	BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF docker compose --profile host build
+
+# Default: host profile (recommended). Builds first if needed.
+docker-up: docker-build
+	docker compose --profile host up -d
+
+docker-up-host: docker-up
+
+docker-up-bridge:
+	docker compose --profile bridge up -d --build
+
+docker-up-macvlan:
+	docker compose --profile macvlan up -d --build
+
+docker-down:
+	docker compose --profile host down
+	docker compose --profile bridge down
+	docker compose --profile macvlan down
+
+docker-logs:
+	docker compose --profile host logs -f

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -1,0 +1,120 @@
+# MiBee Steward — Docker 容器部署专用配置模板
+#
+# 与 config.production.yaml 的差异：
+#   1. 显式 network 段（容器需要知道自己扫描哪个 LAN）
+#   2. 注释强调网络模式对探测效果的影响
+#   3. JWT 密钥 / admin 密码仍需通过环境变量或挂载覆盖
+#
+# ⚠️ 网络模式选择（决定探测效果）：
+#   - bridge（默认）：仅 Web/API 可靠，ICMP/ARP/MAC 严重缺失
+#   - host（推荐）：探测效果≈裸机，能读到宿主机 /proc/net/arp
+#   - macvlan：容器独占 LAN IP，ARP/MAC 可用
+#
+# 使用方式：
+#   cp configs/config.docker.yaml configs/config.yaml  # 然后改 jwt_secret / 密码 / network.cidr
+#   docker compose --profile host up -d
+
+server:
+  port: 8080
+  host: "0.0.0.0"
+  read_timeout: "15s"
+  write_timeout: "5m"
+  idle_timeout: "120s"
+
+network:
+  name: "lan-63"        # 改成你的网络名（多实例分布式部署时唯一标识）
+  cidr: "192.168.63.0/24"  # ⚠️ 必须改成宿主机所在 LAN 的 CIDR
+  site: "default"
+
+database:
+  sqlite:
+    path: "/data/mibee.db"  # 容器内挂载点（VOLUME ["/data"]）
+
+auth:
+  jwt_secret: "CHANGE_THIS — generate with: openssl rand -base64 32"
+  token_expiry: "1h"
+  initial_admin_password: "CHANGE_THIS — first-run admin password"
+  cookie_domain: ""
+  cookie_secure: false     # 容器内若无 TLS 终止，置 false；上游 nginx 终止 TLS 时由 nginx 设置 Secure
+  cookie_same_site: "lax"  # 容器场景下通常用 lax（反代跨端口）
+
+cors:
+  allowed_origins: []
+
+heartbeat:
+  default_interval: 30
+  timeout: 5
+  retention_days: 30
+
+prometheus:
+  enabled: true
+  metrics_path: "/metrics"
+
+dashboard:
+  data_source_type: "prometheus"
+  prometheus_url: "http://localhost:9090"
+
+storage:
+  upload_path: "/data/uploads"  # 容器内路径
+  max_file_size: 104857600
+
+log:
+  level: "info"
+  format: "json"
+
+rate_limit:
+  login_per_minute: 10
+  global_per_minute: 100
+  scan_per_minute: 10
+
+smtp:
+  host: ""
+  port: 587
+  username: ""
+  password: ""
+  from_address: "noreply@example.com"
+
+scanner:
+  enabled: true
+  max_concurrent_scans: 3
+  default_timeout: 300
+  per_probe_timeout: 3
+  max_concurrent_hosts: 50
+  retention_days: 30
+  default_cron_expr: "0 */6 * * *"
+  engine: "v2"
+  persist_raw_evidence: false
+  oui_path: ""              # 容器内若需厂商映射，挂载 oui.txt 并填此路径
+  snmp_community: "public"
+  router_arp:
+    # ⚠️ bridge 模式下 /proc/net/arp 读不到 LAN 设备 MAC，强烈建议在此列出
+    # 网关路由器 IP，让 scanner 通过 SNMP walk 路由器的 ARP 表补 MAC。
+    # host 模式下 /proc/net/arp 直接可用，此项可空。
+    routers: []
+    community: "public"
+    timeout: 4
+  pipeline_defaults:
+    icmp_enabled: true
+    snmp_enabled: true
+    port_scan_enabled: true
+    default_ports: "22,21,23,25,53,80,110,143,389,443,445,554,631,636,8554,1433,3306,3389,5432,5900,6379,8000,8080,8081,8443,8888,9000,9090,9100,9104,9113,9121,9187,9200,9443,11211,27017,161"
+    service_detection_enabled: true
+    prometheus_check_enabled: true
+    node_exporter_enabled: true
+  ebpf:
+    # 需要 docker compose --profile host build --build-arg BUILD_TAGS=WITH_EBPF
+    # 且运行时 cap_add: BPF + NET_ADMIN，内核≥5.8 + BTF。
+    enabled: false
+    interfaces: []
+  agent_lease_ttl: "5m"
+  lease_sweep_interval: "60s"
+retention:
+  heartbeat_results_days: 7
+  scan_results_days: 30
+  scan_task_runs_days: 30
+  audit_logs_days: 90
+  notification_log_days: 30
+  service_evidence_days: 14
+  host_tls_certs_days: 30
+  sweep_interval_hours: 6
+  batch_size: 5000

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -177,6 +177,19 @@ sudo crontab -e
 
 ## 方案 B: Docker 部署
 
+> ⚠️ **网络模式决定探测效果**。MiBee Steward 的扫描器在网络命名空间层面工作，
+> Docker 默认的 bridge 网络会让 ICMP、ARP/MAC 发现严重失效（容器在 NAT 后面，
+> 看不到真实 LAN）。**生产环境扫描请用 `--profile host`**。
+> 完整的三模式选型表与原理见 `docs/zh/deployment.md` 的「Docker 网络模式选型」一节。
+
+### 0. 选择网络模式
+
+| 命令 | 用途 |
+|---|---|
+| `docker compose --profile bridge up` | 默认，仅 UI/管理面板演示（探测降级） |
+| `docker compose --profile host up` | **推荐**，探测效果≈裸机 |
+| `docker compose --profile macvlan up` | 容器独占 LAN IP（设置 `MIBEE_MACVLAN_*` 环境变量） |
+
 ### 1. 准备配置文件
 
 ```bash
@@ -205,14 +218,17 @@ nano docker-compose.yml
 
 ```bash
 # 构建 Docker 镜像
-docker compose build
+docker compose --profile host build
 
-# 启动服务
-docker compose up -d
+# 启动服务（host 模式，推荐用于真实扫描）
+docker compose --profile host up -d
+
+# 或仅做 UI 演示（bridge，探测会降级）
+docker compose --profile bridge up -d
 
 # 检查服务状态
-docker compose ps
-docker compose logs -f
+docker compose --profile host ps
+docker compose --profile host logs -f
 ```
 
 ### 4. 配置 Nginx 反向代理（同方案 A）

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -7,6 +7,15 @@
 #      (or update paths below)
 #   2. Create mibee user: sudo useradd -r -s /usr/sbin/nologin -d /opt/mibee-steward mibee
 #   3. Ensure /opt/mibee-steward/data/ exists and is writable by mibee user
+#
+# proxy_pass target — choose based on how mibee-steward is running:
+#   • systemd / bare metal ............ 127.0.0.1:8080   (current default)
+#   • docker --profile host ........... 127.0.0.1:8080   (shares netns: same as bare metal)
+#   • docker --profile bridge ......... 127.0.0.1:8080   (port published to host via ports:)
+#   • docker --profile macvlan ........ <container-LAN-IP>:8080  (host can't reach 127.0.0.1
+#                                        inside the container; use the macvlan-assigned IP,
+#                                        e.g. 192.168.63.50 — see MIBEE_MACVLAN_IP)
+# Only the macvlan case requires editing the lines below; host/bridge keep 127.0.0.1.
 
 # Redirect HTTP to HTTPS
 server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,132 @@
+# MiBee Steward — Docker Compose.
+#
+# The scanner's network probes are network-namespace-sensitive. Three profiles
+# are provided; pick by intent. Only ONE profile should be active at a time.
+#
+#   --profile bridge   DEMO ONLY. Only the Web/API surface works reliably.
+#                      ICMP/ARP/MAC discovery is severely degraded because the
+#                      container sits behind Docker's NAT. Fine for kicking the
+#                      tires on the UI, NOT for real inventory. Also the default
+#                      when no --profile is passed.
+#
+#   --profile host     RECOMMENDED for production scanning. Shares the host's
+#                      network namespace so probes see the real LAN: ARP/MAC
+#                      via /proc/net/arp, ICMP at L3, multicast discovery.
+#                      Requires cap_add NET_ADMIN + NET_RAW. The host port
+#                      8080 is taken directly (no publish mapping needed).
+#
+#   --profile macvlan  Gives the container its own LAN IP (separate from the
+#                      host's). Probes see the real L2 segment, so ARP/MAC work.
+#                      Caveat: host <-> container L3 is blocked by default (no
+#                      route back through the macvlan parent); add a shim
+#                      macvlan interface on the host if you need host->container.
+#                      Set: MIBEE_MACVLAN_PARENT, MIBEE_MACVLAN_IP,
+#                      MIBEE_MACVLAN_SUBNET, MIBEE_MACVLAN_GW on the host.
+#
+# Privileged probes (LLDP/CDP raw frames, eBPF TC observer) are NOT in the
+# default image. Build with:
+#     docker compose --profile host build --build-arg BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF
+# and (for eBPF) add cap_add BPF on a kernel >=5.8 with BTF.
+#
+# Quick start (recommended):
+#     docker compose --profile host build
+#     docker compose --profile host up -d
+
+# Common build definition. All three services reference this image so we only
+# build once; pick the service that matches your --profile.
+x-build: &build
+  context: .
+  args:
+    # Pass through to Dockerfile's ARG BUILD_TAGS. Default "" = unprivileged
+    # build (LLDP/CDP/eBPF compiled as stubs). Override at build time:
+    #   BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF docker compose --profile host build
+    BUILD_TAGS: ${BUILD_TAGS:-}
+    # npm registry override for builds behind a slow/restricted network.
+    # Default empty = official registry; set NPM_REGISTRY=https://registry.npmmirror.com in CN.
+    NPM_REGISTRY: ${NPM_REGISTRY:-https://registry.npmjs.org}
+    # Go module proxy override (e.g. https://goproxy.cn in CN).
+    GOPROXY: ${GOPROXY:-https://proxy.golang.org,direct}
+    # setcap on the binary (lets non-root USER use raw sockets granted via
+    # cap_add). Default 0: the unprivileged bridge image runs anywhere.
+    SETCAP: ${SETCAP:-0}
+
+# Privileged build args — used by the host/macvlan profiles below so a single
+# `docker compose --profile host build` produces an image whose non-root user
+# can actually open the raw sockets cap_add grants.
+x-build-priv: &build-priv
+  <<: *build
+  args:
+    BUILD_TAGS: ${BUILD_TAGS:-WITH_LLDP,WITH_CDP}
+    SETCAP: "1"
+
+x-mibee-common: &mibee-common
+  image: mibee-steward:latest
+  restart: unless-stopped
+  volumes:
+    - mibee-data:/data
+    - ./configs/config.yaml:/app/configs/config.yaml:ro
+  environment:
+    - MIBEE_SERVER_PORT=8080
+
 services:
+  # ---- Profile: bridge (default, demo only) -------------------------------
+  # Plain NAT bridge. Web/API works; ICMP/ARP/MAC discovery is degraded.
+  # Activate explicitly with `--profile bridge`, or just `up` (this service is
+  # always loaded — profiles: ["", "bridge"] keeps it available with no flag).
   mibee-steward:
-    build: .
+    <<: *mibee-common
+    build: *build
+    profiles: ["", "bridge"]
     ports:
       - "8080:8080"
-    volumes:
-      - mibee-data:/data
-      - ./configs/config.yaml:/app/configs/config.yaml:ro
-    environment:
-      - MIBEE_SERVER_PORT=8080
-    restart: unless-stopped
+
+  # ---- Profile: host (recommended for real scanning) ----------------------
+  # Container shares the host netns; no ports mapping (host ports are taken
+  # directly). cap_add grants the raw sockets /proc/net/arp (read-only) does
+  # NOT need, but AF_PACKET (LLDP/CDP) and any future privileged ICMP path do.
+  # Uses the priv image (setcap'd binary) so the non-root USER can actually
+  # open the sockets cap_add places in the bounding set.
+  # no-new-privileges preserves the systemd-style hardening posture.
+  mibee-steward-host:
+    <<: *mibee-common
+    image: mibee-steward:priv
+    build: *build-priv
+    profiles: ["host"]
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    security_opt:
+      - no-new-privileges:true
+
+  # ---- Profile: macvlan (container gets its own LAN IP) -------------------
+  # Container appears on the LAN as its own device. Probes see the real L2
+  # segment. Override the MIBEE_MACVLAN_* vars to match your LAN. Uses the priv
+  # image for the same setcap reason as the host profile.
+  mibee-steward-macvlan:
+    <<: *mibee-common
+    image: mibee-steward:priv
+    build: *build-priv
+    profiles: ["macvlan"]
+    networks:
+      lan:
+        ipv4_address: ${MIBEE_MACVLAN_IP:-192.168.63.250}
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    security_opt:
+      - no-new-privileges:true
+
+networks:
+  lan:
+    driver: macvlan
+    driver_opts:
+      parent: ${MIBEE_MACVLAN_PARENT:-eth0}
+      mode: bridge
+    ipam:
+      config:
+        - subnet: ${MIBEE_MACVLAN_SUBNET:-192.168.63.0/24}
+          gateway: ${MIBEE_MACVLAN_GW:-192.168.63.1}
 
 volumes:
   mibee-data:

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -139,6 +139,59 @@ docker compose logs -f
 - `MIBEE_AUTH_JWT_SECRET`: JWT secret (required)
 - `MIBEE_AUTH_INITIAL_ADMIN_PASSWORD`: Admin password (required)
 
+#### Docker Network Mode Selection (Important)
+
+MiBee Steward's scanner operates at the network-namespace level, so **the container's network mode directly determines probe effectiveness**. `docker-compose.yml` ships three profiles — pick one by deployment intent:
+
+| Profile | Start command | Probe effectiveness | Use case | Limitations |
+|---|---|---|---|---|
+| `bridge` (default) | `docker compose --profile bridge up` | Only TCP/SNMP/HTTP/TLS/RTSP/ONVIF reliable; **ICMP and ARP/MAC discovery severely degraded** | UI demo, dev, admin panel | Can't see the real LAN; device MACs are mostly lost |
+| `host` (**recommended**) | `docker compose --profile host up` | ≈ bare-metal, full probe fidelity (ICMP, `/proc/net/arp`, multicast) | **Production scanning** | Takes the host's port 8080; needs `cap_add: NET_RAW,NET_ADMIN` |
+| `macvlan` | `docker compose --profile macvlan up` | Container gets its own LAN IP; ARP/MAC work | When the container must appear on the LAN as its own device | Host↔container is unrouted by default (needs a manual macvlan shim interface) |
+
+> ⚠️ **Why bridge mode can't be used for real inventory**
+> The default Docker bridge places the container behind NAT. Consequences:
+> 1. **ARP/MAC broken**: `/proc/net/arp` inside the container only sees the bridge gateway entry; LAN device MACs are essentially unrecoverable (`ARPProbe`, `ARPCacheSource`, `LookupMACPostScan` all read this file).
+> 2. **ICMP broken**: ping replies crossing NAT are often dropped, so the heartbeat's 30s active probe falsely marks LAN devices offline.
+> 3. **Passive multicast broken**: the bridge doesn't forward 224/239 multicast, so mDNS/SSDP listeners self-disable.
+>
+> Partial workaround: in bridge mode, list your gateway router IPs in `scanner.router_arp.routers` so the scanner can SNMP-walk the router's ARP table for MACs — but this only recovers MACs, not ICMP or multicast.
+
+**Full host-mode example** (production):
+
+```bash
+# 1. Prepare config (from the container template)
+cp configs/config.docker.yaml configs/config.yaml
+#    Edit jwt_secret / initial_admin_password / network.cidr
+
+# 2. Build and start (host profile — container shares the host netns)
+docker compose --profile host up -d --build
+
+# 3. Verify
+curl -s http://localhost:8080/api/v1/health
+```
+
+To enable the raw-frame LLDP/CDP listeners or the eBPF passive observer (compiled out by default), pass build tags and grant the matching runtime caps:
+
+```bash
+# Build (bakes raw-frame LLDP/CDP + eBPF into the binary)
+BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF docker compose --profile host build
+
+# Runtime (eBPF additionally needs cap_add: BPF, kernel >=5.8 + BTF).
+# The host profile in docker-compose.yml already declares NET_RAW + NET_ADMIN;
+# append `- BPF` to cap_add if you enable eBPF.
+```
+
+**Building behind a restricted network** (when registry.npmjs.org / proxy.golang.org are unreachable):
+
+```bash
+NPM_REGISTRY=https://registry.npmmirror.com \
+GOPROXY=https://goproxy.cn,direct \
+docker compose --profile host build
+```
+
+The Makefile wraps common flows: `make docker-up` (= host profile, recommended), `make docker-up-bridge` (demo), `make docker-up-macvlan`, `make docker-build-priv` (privileged image variant).
+
 ### 3. Nginx Reverse Proxy
 
 #### Configuration

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -192,6 +192,28 @@ docker compose --profile host build
 
 The Makefile wraps common flows: `make docker-up` (= host profile, recommended), `make docker-up-bridge` (demo), `make docker-up-macvlan`, `make docker-build-priv` (privileged image variant).
 
+#### Using the prebuilt image (GHCR)
+
+From release tags on, each release publishes a multi-arch (amd64 + arm64) container image to GitHub Container Registry, so you don't need to build locally:
+
+```bash
+# Pull latest
+docker pull ghcr.io/mi-bee-studio/mibee-steward:latest
+
+# Or pin a specific version
+docker pull ghcr.io/mi-bee-studio/mibee-steward:0.4.0
+
+# Run directly with the host profile (override image:, drop build:)
+docker run -d --name mibee \
+  --network host \
+  --cap-add NET_RAW --cap-add NET_ADMIN \
+  -v mibee-data:/data \
+  -v "$PWD/configs/config.yaml:/app/configs/config.yaml:ro" \
+  ghcr.io/mi-bee-studio/mibee-steward:latest
+```
+
+The prebuilt image is the **unprivileged variant** (LLDP/CDP/eBPF compiled as stubs). For those passive probes, build from source with `make docker-build-priv` (see above). You can also point compose's `image:` straight at GHCR and drop `build:` — see the `docker-compose.yml` header comment.
+
 ### 3. Nginx Reverse Proxy
 
 #### Configuration

--- a/docs/zh/deployment.md
+++ b/docs/zh/deployment.md
@@ -192,6 +192,28 @@ docker compose --profile host build
 
 Makefile 封装了常用流程：`make docker-up`（= host profile，推荐）、`make docker-up-bridge`（演示）、`make docker-up-macvlan`、`make docker-build-priv`（特权变体镜像）。
 
+#### 使用预构建镜像（GHCR）
+
+从 release tag（v0.4.0 起）起，每个版本会自动发布多架构（amd64 + arm64）容器镜像到 GitHub Container Registry，无需本地构建：
+
+```bash
+# 拉取最新版
+docker pull ghcr.io/mi-bee-studio/mibee-steward:latest
+
+# 或锁定具体版本
+docker pull ghcr.io/mi-bee-studio/mibee-steward:0.4.0
+
+# 用 host profile 直接运行（修改 image 字段，去掉 build）
+docker run -d --name mibee \
+  --network host \
+  --cap-add NET_RAW --cap-add NET_ADMIN \
+  -v mibee-data:/data \
+  -v "$PWD/configs/config.yaml:/app/configs/config.yaml:ro" \
+  ghcr.io/mi-bee-studio/mibee-steward:latest
+```
+
+预构建镜像是**非特权变体**（LLDP/CDP/eBPF 编译为 stub）。如需这些被动探测能力，用源码 + `make docker-build-priv` 自行构建（见上文）。compose 里也可以把 `image:` 直接指向 GHCR，省去本地 `build:`——见 `docker-compose.yml` 注释。
+
 ### 3. Nginx 反向代理
 
 #### 配置

--- a/docs/zh/deployment.md
+++ b/docs/zh/deployment.md
@@ -139,6 +139,59 @@ docker compose logs -f
 - `MIBEE_AUTH_JWT_SECRET`: JWT 密钥（必需）
 - `MIBEE_AUTH_INITIAL_ADMIN_PASSWORD`: 管理员密码（必需）
 
+#### Docker 网络模式选型（重要）
+
+MiBee Steward 的扫描器在网络命名空间层面工作，**容器的网络模式直接决定探测效果**。`docker-compose.yml` 提供三个 profile，按部署意图选择其一：
+
+| Profile | 启动命令 | 探测效果 | 适用场景 | 限制 |
+|---|---|---|---|---|
+| `bridge`（默认） | `docker compose --profile bridge up` | 仅 TCP/SNMP/HTTP/TLS/RTSP/ONVIF 可靠；**ICMP、ARP/MAC 发现严重缺失** | UI 演示、开发、管理面板 | 看不到真实 LAN，设备 MAC 基本拿不到 |
+| `host`（**推荐**） | `docker compose --profile host up` | ≈ 裸机部署，探测完整（ICMP、`/proc/net/arp`、多播） | **生产环境扫描** | 占用宿主机 8080 端口；需 `cap_add: NET_RAW,NET_ADMIN` |
+| `macvlan` | `docker compose --profile macvlan up` | 容器独占一个 LAN IP，ARP/MAC 可用 | 需要容器以独立设备身份出现在 LAN | 宿主机↔容器默认不可达（需手动加 macvlan shim 接口） |
+
+> ⚠️ **为什么 bridge 模式不能用于真实盘点**
+> Docker 默认 bridge 把容器放在 NAT 后面。后果：
+> 1. **ARP/MAC 失效**：容器读 `/proc/net/arp` 只能看到 bridge 网关一条记录，LAN 设备的 MAC 几乎全拿不到（`ARPProbe`、`ARPCacheSource`、`LookupMACPostScan` 都依赖这个文件）。
+> 2. **ICMP 失效**：跨 NAT 的 ping 回包常被丢弃，心跳的 30s 主动探测会把 LAN 设备误判为离线。
+> 3. **被动多播失效**：bridge 不转发 224/239 多播，mDNS/SSDP 监听源会自禁用。
+>
+> 补救：bridge 模式下在 `scanner.router_arp.routers` 里列出网关路由器 IP，让扫描器通过 SNMP walk 路由器的 ARP 表补 MAC；但这只能补 MAC，救不了 ICMP/多播。
+
+**host 模式完整示例**（生产推荐）：
+
+```bash
+# 1. 准备配置（基于容器模板）
+cp configs/config.docker.yaml configs/config.yaml
+#    编辑 jwt_secret / initial_admin_password / network.cidr
+
+# 2. 构建并启动（host profile，容器共享宿主机网络命名空间）
+docker compose --profile host up -d --build
+
+# 3. 验证
+curl -s http://localhost:8080/api/v1/health
+```
+
+如需 LLDP/CDP 原始帧监听或 eBPF 被动观察者（默认镜像是 no-op stub），构建时加 build tag，运行时再加对应 cap：
+
+```bash
+# 构建（把 raw-frame LLDP/CDP + eBPF 编进二进制）
+BUILD_TAGS=WITH_LLDP,WITH_CDP,WITH_EBPF docker compose --profile host build
+
+# 运行时（eBPF 额外需要 cap_add: BPF，内核 ≥5.8 + BTF）
+# docker-compose.yml 的 host profile 已声明 NET_RAW + NET_ADMIN；
+# 如启用 eBPF，在 compose 里追加 `- BPF` 到 cap_add 列表。
+```
+
+**国内网络构建加速**（registry.npmjs.org / proxy.golang.org 受限时）：
+
+```bash
+NPM_REGISTRY=https://registry.npmmirror.com \
+GOPROXY=https://goproxy.cn,direct \
+docker compose --profile host build
+```
+
+Makefile 封装了常用流程：`make docker-up`（= host profile，推荐）、`make docker-up-bridge`（演示）、`make docker-up-macvlan`、`make docker-build-priv`（特权变体镜像）。
+
 ### 3. Nginx 反向代理
 
 #### 配置


### PR DESCRIPTION
## What

Two related changes for containerized deployment:

### 1. Docker network-mode profiles (`07839f9`)
The scanner's ICMP/ARP/MAC discovery is network-namespace-sensitive. The default docker bridge places the container behind NAT, so `/proc/net/arp` only sees the bridge gateway and device MACs are unrecoverable. **Measured on the test LAN: bridge mode found 0/26 MACs vs host mode 30/31.**

- `docker-compose.yml`: three profiles (bridge demo / host recommended / macvlan own-LAN-IP) with `cap_add` + `security_opt` on the privileged ones. Two image tags (`:latest` unprivileged, `:priv` setcap'd).
- `Dockerfile`: `BUILD_TAGS` arg (WITH_LLDP/CDP/EBPF opt-in), opt-in `SETCAP` (default off — file caps break exec() when the cap isn't in the bounding set), `NPM_REGISTRY`/`GOPROXY` args for restricted-network builds, `NODE_OPTIONS` for the vite heap, `/data` pre-owned by the non-root user.
- `Makefile`: `docker-build` / `-priv` / `-up` / `-up-bridge` / `-up-macvlan` / `-down` / `-logs`.
- `configs/config.docker.yaml`: container template.
- `deploy/nginx.conf` + `deploy/README.md` + `docs/{en,zh}/deployment.md`: network mode selection table, the bridge-mode ARP/ICMP caveat, host-mode quick start.

**Default behavior unchanged**: `docker compose up` still runs bridge + unprivileged.

### 2. GHCR container publishing (`0817ebb`)
From the next `v*` tag, the release workflow publishes a multi-arch (amd64+arm64) image to `ghcr.io/mi-bee-studio/mibee-steward`, tagged `:latest` / `:<version>` / `:<major>.<minor>` / `:sha-<short>`. Adds a `docker` job to `release.yml` (self-contained — Dockerfile rebuilds the frontend in Stage 1) and a build-only `docker-build` smoke-test job to `ci.yml` (boots the image, waits for `/health`) so Dockerfile regressions surface on PRs, not on release tags.

## Test plan
- [x] `go vet ./...` clean
- [x] Three-mode scan comparison run on 192.168.63.101 (bridge/host/macvlan), data recorded in `docs/private/docker-probe-comparison.md` (gitignored)
- [x] YAML syntax validated for both workflows
- [ ] CI green on this PR (docker-build smoke test + go vet + lint + tests + sqlc)