### PR TITLE
chore: replace placeholder contact email with real address

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -35,7 +35,7 @@ Open an issue with the title `CLA: <Your Name>` (or `CLA: <Company Name>` for
 corporate) and paste the filled-in agreement from the relevant section below.
 A maintainer will record it and close the issue.
 
-Alternatively, email the completed agreement to commercial@mibee.studio.
+Alternatively, email the completed agreement to mickey_zzc@163.com.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ A commercial license is available for use cases that the AGPLv3 does not
 accommodate (e.g. closed-source derivatives or SaaS deployment without
 open-sourcing modifications). See LICENSE-COMMERCIAL.md for details.
 
-Contact: commercial@mibee.studio
+Contact: mickey_zzc@163.com
 
 ---
 

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -43,7 +43,7 @@ Commercial licenses are priced per deployment and tailored to your use case. To 
 2. Indicate your deployment scale (number of networks, devices, sites).
 3. Mention any support, SLA, or customization requirements.
 
-**Contact:** commercial@mibee.studio
+**Contact:** mickey_zzc@163.com
 
 We aim to respond to commercial inquiries within 2 business days.
 


### PR DESCRIPTION
## Summary

Replaces the placeholder commercial-license contact email (`commercial@mibee.studio`) introduced in #12 with the owner's actual address (`mickey_zzc@163.com`).

The placeholder was a stand-in because no real address had been provided when the license migration was prepared. This PR closes that gap.

## Changes (3 lines, 3 files)

- `LICENSE` — AGPL header contact line
- `LICENSE-COMMERCIAL.md` — commercial inquiry contact
- `CLA.md` — where to email a signed CLA

No behavior or source changes. Docs-only.

## Checklist

- [x] CLA signed (mickeyzzc — owner)
- [x] Commit carries `Signed-off-by` (DCO)