### PR TITLE
chore(fingerprints): sync http-tls + ports rules from mibee-fingerprints-go

### DIFF
--- a/configs/fingerprints/http-tls.yaml
+++ b/configs/fingerprints/http-tls.yaml
@@ -1,6 +1,6 @@
 # License: CC-BY-SA 4.0 (fingerprint corpus).
 # Derivative fingerprint corpora must be released under the same license.
-# See configs/fingerprints/README.md for attribution & provenance.
+# See README.md for attribution & provenance.
 
 # Kind-presence + structured-evidence fingerprints.
 #
@@ -124,6 +124,9 @@ rules:
               - { contains: "qnap", set: "QNAP" }
               - { contains: "cisco", set: "Cisco" }
               - { contains_any: ["fortinet", "fortigate"], set: "Fortinet" }
+              - { contains: "openwrt", set: "OpenWrt" }
+              - { contains: "istoreos", set: "iStoreOS" }
+              - { contains_any: ["gl-inet", "glinet"], set: "GL.iNet" }
 
   # ── PrometheusClassifier (kind="metric", ordered first-match) ──────────
   # node_exporter is checked FIRST (high-value). Mirrors the original switch
@@ -165,3 +168,129 @@ rules:
       metadata:
         metrics_url: { passthrough: url }
         content_kind: { const: "prometheus" }
+
+  # ── HTTP Server-header product rules (kind="http", field="server") ──────
+  # These match the Server header on structured HTTP evidence and emit product
+  # metadata. They complement the Recog http_header.server rules (which match
+  # the banner field) by running on the structured http evidence path. Each
+  # uses exclusive_group "http-product" so only the first match per evidence
+  # piece carries product metadata.
+
+  - id: http-server-llamacpp
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "llama.cpp"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "llama.cpp" }
+        inferred_brand: { const: "llama.cpp" }
+
+  - id: http-server-openwrt
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "uhttpd"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "OpenWrt uHTTPd" }
+        inferred_brand: { const: "OpenWrt" }
+
+  - id: http-server-mibee
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: title
+      op: contains
+      value: "MiBee Steward"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "MiBee Steward" }
+        inferred_brand: { const: "MiBee" }
+
+  - id: http-server-dropbear
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "Dropbear"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "Dropbear" }
+
+  # Apache httpd version: "Apache/2.4.58" → version "2.4.58"
+  - id: http-server-apache-version
+    source: builtin
+    priority: 15
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "Apache"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "Apache HTTPD" }
+        inferred_brand: { const: "Apache" }
+        version:
+          substring_after:
+            field: server
+            delim: "/"
+            until: [" ", "("]
+
+  # nginx version: "nginx/1.26.1" → version "1.26.1"
+  - id: http-server-nginx-version
+    source: builtin
+    priority: 15
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "nginx"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "nginx" }
+        inferred_brand: { const: "nginx" }
+        version:
+          substring_after:
+            field: server
+            delim: "/"
+            until: [" ", "("]

--- a/configs/fingerprints/ports.yaml
+++ b/configs/fingerprints/ports.yaml
@@ -1,6 +1,6 @@
 # License: CC-BY-SA 4.0 (fingerprint corpus).
 # Derivative fingerprint corpora must be released under the same license.
-# See configs/fingerprints/README.md for attribution & provenance.
+# See README.md for attribution & provenance.
 
 # Port-shape-only fallback fingerprints (MiscClassifier).
 #
@@ -14,13 +14,35 @@
 # Note: the original MiscClassifier uses a Go map (non-deterministic iteration
 # order), but since each rule is independent and emits a distinct service, order
 # does not affect the result set — only the slice enumeration order.
+#
+# The smb-version rule fires when the dedicated SMB probe captured a Negotiate
+# Response (Kind="smb_negotiate"), extracting the SMB dialect version. It shares
+# exclusive_group "smb" with the port-smb fallback so the version-carrying
+# identity wins when the probe ran.
 
 version: 1
 
 rules:
+  # SMB version (from SMB2/SMB1 Negotiate probe). Higher priority than the port
+  # fallback — carries dialect + OS info.
+  - id: smb-version
+    source: builtin
+    priority: 10
+    match:
+      kind: smb_negotiate
+      op: kind_presence
+    service: smb
+    protocol: tcp
+    confidence: 0.9
+    exclusive_group: smb
+    extract:
+      metadata:
+        version: { passthrough: dialect }
+        os: { passthrough: os }
+  # Port-shape-only fallbacks.
   - { id: port-ldap,   source: builtin, match: { op: port, value: 389 },  service: ldap,    protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-ldaps,  source: builtin, match: { op: port, value: 636 },  service: ldaps,   protocol: tcp, confidence: 0.5, literal_confidence: true }
-  - { id: port-smb,    source: builtin, match: { op: port, value: 445 },  service: smb,     protocol: tcp, confidence: 0.5, literal_confidence: true }
+  - { id: port-smb,    source: builtin, match: { op: port, value: 445 },  service: smb,     protocol: tcp, confidence: 0.5, literal_confidence: true, priority: 0, exclusive_group: smb }
   - { id: port-telnet, source: builtin, match: { op: port, value: 23 },   service: telnet,  protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-ftp,    source: builtin, match: { op: port, value: 21 },   service: ftp,     protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-dns,    source: builtin, match: { op: port, value: 53 },   service: dns-tcp, protocol: tcp, confidence: 0.5, literal_confidence: true }

--- a/internal/service/scannerv2/classify/fingerprint-assets/http-tls.yaml
+++ b/internal/service/scannerv2/classify/fingerprint-assets/http-tls.yaml
@@ -1,6 +1,6 @@
 # License: CC-BY-SA 4.0 (fingerprint corpus).
 # Derivative fingerprint corpora must be released under the same license.
-# See configs/fingerprints/README.md for attribution & provenance.
+# See README.md for attribution & provenance.
 
 # Kind-presence + structured-evidence fingerprints.
 #
@@ -124,6 +124,9 @@ rules:
               - { contains: "qnap", set: "QNAP" }
               - { contains: "cisco", set: "Cisco" }
               - { contains_any: ["fortinet", "fortigate"], set: "Fortinet" }
+              - { contains: "openwrt", set: "OpenWrt" }
+              - { contains: "istoreos", set: "iStoreOS" }
+              - { contains_any: ["gl-inet", "glinet"], set: "GL.iNet" }
 
   # ── PrometheusClassifier (kind="metric", ordered first-match) ──────────
   # node_exporter is checked FIRST (high-value). Mirrors the original switch
@@ -165,3 +168,129 @@ rules:
       metadata:
         metrics_url: { passthrough: url }
         content_kind: { const: "prometheus" }
+
+  # ── HTTP Server-header product rules (kind="http", field="server") ──────
+  # These match the Server header on structured HTTP evidence and emit product
+  # metadata. They complement the Recog http_header.server rules (which match
+  # the banner field) by running on the structured http evidence path. Each
+  # uses exclusive_group "http-product" so only the first match per evidence
+  # piece carries product metadata.
+
+  - id: http-server-llamacpp
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "llama.cpp"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "llama.cpp" }
+        inferred_brand: { const: "llama.cpp" }
+
+  - id: http-server-openwrt
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "uhttpd"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "OpenWrt uHTTPd" }
+        inferred_brand: { const: "OpenWrt" }
+
+  - id: http-server-mibee
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: title
+      op: contains
+      value: "MiBee Steward"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "MiBee Steward" }
+        inferred_brand: { const: "MiBee" }
+
+  - id: http-server-dropbear
+    source: builtin
+    priority: 20
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "Dropbear"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "Dropbear" }
+
+  # Apache httpd version: "Apache/2.4.58" → version "2.4.58"
+  - id: http-server-apache-version
+    source: builtin
+    priority: 15
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "Apache"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "Apache HTTPD" }
+        inferred_brand: { const: "Apache" }
+        version:
+          substring_after:
+            field: server
+            delim: "/"
+            until: [" ", "("]
+
+  # nginx version: "nginx/1.26.1" → version "1.26.1"
+  - id: http-server-nginx-version
+    source: builtin
+    priority: 15
+    exclusive_group: http-product
+    match:
+      kind: http
+      field: server
+      op: contains
+      value: "nginx"
+      ci: true
+    service: http
+    protocol: tcp
+    confidence: 0.85
+    extract:
+      metadata:
+        product: { const: "nginx" }
+        inferred_brand: { const: "nginx" }
+        version:
+          substring_after:
+            field: server
+            delim: "/"
+            until: [" ", "("]

--- a/internal/service/scannerv2/classify/fingerprint-assets/ports.yaml
+++ b/internal/service/scannerv2/classify/fingerprint-assets/ports.yaml
@@ -1,6 +1,6 @@
 # License: CC-BY-SA 4.0 (fingerprint corpus).
 # Derivative fingerprint corpora must be released under the same license.
-# See configs/fingerprints/README.md for attribution & provenance.
+# See README.md for attribution & provenance.
 
 # Port-shape-only fallback fingerprints (MiscClassifier).
 #
@@ -14,13 +14,35 @@
 # Note: the original MiscClassifier uses a Go map (non-deterministic iteration
 # order), but since each rule is independent and emits a distinct service, order
 # does not affect the result set — only the slice enumeration order.
+#
+# The smb-version rule fires when the dedicated SMB probe captured a Negotiate
+# Response (Kind="smb_negotiate"), extracting the SMB dialect version. It shares
+# exclusive_group "smb" with the port-smb fallback so the version-carrying
+# identity wins when the probe ran.
 
 version: 1
 
 rules:
+  # SMB version (from SMB2/SMB1 Negotiate probe). Higher priority than the port
+  # fallback — carries dialect + OS info.
+  - id: smb-version
+    source: builtin
+    priority: 10
+    match:
+      kind: smb_negotiate
+      op: kind_presence
+    service: smb
+    protocol: tcp
+    confidence: 0.9
+    exclusive_group: smb
+    extract:
+      metadata:
+        version: { passthrough: dialect }
+        os: { passthrough: os }
+  # Port-shape-only fallbacks.
   - { id: port-ldap,   source: builtin, match: { op: port, value: 389 },  service: ldap,    protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-ldaps,  source: builtin, match: { op: port, value: 636 },  service: ldaps,   protocol: tcp, confidence: 0.5, literal_confidence: true }
-  - { id: port-smb,    source: builtin, match: { op: port, value: 445 },  service: smb,     protocol: tcp, confidence: 0.5, literal_confidence: true }
+  - { id: port-smb,    source: builtin, match: { op: port, value: 445 },  service: smb,     protocol: tcp, confidence: 0.5, literal_confidence: true, priority: 0, exclusive_group: smb }
   - { id: port-telnet, source: builtin, match: { op: port, value: 23 },   service: telnet,  protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-ftp,    source: builtin, match: { op: port, value: 21 },   service: ftp,     protocol: tcp, confidence: 0.5, literal_confidence: true }
   - { id: port-dns,    source: builtin, match: { op: port, value: 53 },   service: dns-tcp, protocol: tcp, confidence: 0.5, literal_confidence: true }

--- a/internal/service/scannerv2/classify/rule_classifier_test.go
+++ b/internal/service/scannerv2/classify/rule_classifier_test.go
@@ -53,10 +53,9 @@ func loadBuiltinRules(t *testing.T) *fp.RuleClassifier {
 func TestRuleClassifier_LoadsAllRules(t *testing.T) {
 	rc := loadBuiltinRules(t)
 	// builtin-only (recog-imported.yaml excluded — tested via loadFullRules).
-	// banner.yaml=8 + http-tls.yaml=6 + ports.yaml=6 = 20
-	// banner.yaml=8 + http-tls.yaml=6 + ports.yaml=6 + lldp-cdp.yaml=13 = 33
-	if rc.RuleCount() != 33 {
-		t.Errorf("expected 33 builtin rules, got %d", rc.RuleCount())
+	// banner.yaml=8 + http-tls.yaml=12 (6 kind-presence + 6 http-server-*) + ports.yaml=7 (6 port + 1 smb-version) + lldp-cdp.yaml=13 = 40
+	if rc.RuleCount() != 40 {
+		t.Errorf("expected 40 builtin rules, got %d", rc.RuleCount())
 	}
 }
 
@@ -232,8 +231,13 @@ func TestRuleClassifier_PlainPrometheus(t *testing.T) {
 
 func TestRuleClassifier_WebVersionExtract(t *testing.T) {
 	rc := loadBuiltinRules(t)
+	// Use a fictitious server string that has a real version pattern (so version
+	// extraction is exercised) but matches no http-server-* product rule — those
+	// rules are a RuleClassifier enhancement beyond the hand-written WebClassifier
+	// and would otherwise make `want` (WebClassifier output) and `got` diverge in
+	// identity count. This keeps the test focused on version extraction parity.
 	ev := []scannerv2.Evidence{
-		{Kind: "http", Port: 80, Confidence: 0.9, RawData: map[string]string{"server": "nginx/1.25.3", "title": "Test"}},
+		{Kind: "http", Port: 80, Confidence: 0.9, RawData: map[string]string{"server": "MyApp/1.25.3", "title": "Test"}},
 	}
 	want := WebClassifier{}.Classify(ev)
 	got := rc.Classify(ev)


### PR DESCRIPTION
## Summary

First half of a **two-PR corpus sync** between this repo and [mibee-fingerprints-go](https://github.com/Mi-Bee-Studio/mibee-fingerprints-go). The two repos' fingerprint corpora had diverged in opposite directions (each had unique rules the other lacked). This PR brings fingerprints-go's unique rules **into the main repo**; the reverse direction (main repo's unique rules into fingerprints-go) is a separate PR in that repo.

## What's added (from fingerprints-go)

### http-tls.yaml — +6 rules (HTTP Server-header product identification)

New `http-server-*` rules that match the structured `http` evidence's `Server` header (complementing the existing Recog banner-field rules) and emit product/brand metadata:

- `http-server-llamacpp`, `-openwrt`, `-mibee`, `-dropbear`, `-apache-version`, `-nginx-version`

All share `exclusive_group: http-product` so only the first match carries metadata.

### ports.yaml — +1 rule, 1 modified

- **+`smb-version`**: matches `Kind=smb_negotiate` evidence (produced by `probe/smb.go`) and extracts SMB dialect version + OS. `priority: 10` wins over the port-smb fallback via `exclusive_group: smb`.
- **~`port-smb`** (modified): adds `priority: 0` + `exclusive_group: smb` so the version-carrying `smb-version` identity wins when the SMB probe actually ran.

## Test adaptation (commit 2)

Two existing tests needed updates:

- `TestRuleClassifier_LoadsAllRules`: builtin rule count 33 → **40** (+6 http-server + 1 smb-version).
- `TestRuleClassifier_WebVersionExtract`: input changed from `nginx/1.25.3` to `MyApp/1.25.3`. The nginx value now triggers the new `http-server-nginx-version` rule, producing an extra identity that the hand-written `WebClassifier` (the test's reference output) doesn't emit — breaking the strict count-equality assertion. The fictitious `MyApp` value keeps a real version pattern (so version extraction is still exercised) but matches no `http-server-*` rule, preserving the test's original intent.

## Verification (all local, all green)

- [x] `go test ./internal/service/scannerv2/classify/` — pass
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run` — **0 issues**
- [x] `make sync-fingerprints` — configs/ and embed copy verified in sync

## Why these rules activate in the main repo

Confirmed before sync that the main repo produces the evidence kinds these rules depend on:
- `probe/smb.go:110` produces `Kind="smb_negotiate"` → `smb-version` rule activates.
- The `http` evidence with `server` field is produced by the HTTP probe → `http-server-*` rules activate.

## Known follow-up (out of scope for this PR)

The 7 synced rules (`http-server-*` + `smb-version`) have **no dedicated test coverage** in either repo (they were added to fingerprints-go without targeted tests). Adding tests that verify each rule matches its intended evidence and emits correct metadata is tracked as a separate task.

The reverse-direction sync (main repo's `snmp-data.yaml` consumer/SMB OIDs + `lldp-cdp.yaml` → fingerprints-go) is the second PR, in the fingerprints-go repo.

## Checklist

- [x] CLA signed (mickeyzzc — owner)
- [x] All commits carry `Signed-off-by` (DCO)
- [x] `go test ./...` passes
- [x] `make sync-fingerprints` run (embed copy in sync)