### PR TITLE
test(agent): fix flaky TestReporter_SendsStateHashHeader (data + logic race)

### DIFF
--- a/internal/agent/reporter_test.go
+++ b/internal/agent/reporter_test.go
@@ -149,17 +149,15 @@ func TestReporter_DisconnectRecovery(t *testing.T) {
 // X-Network-State-Hash header so the center can anti-entropy skip unchanged
 // networks. Two reports with identical alive sets must produce the SAME hash.
 func TestReporter_SendsStateHashHeader(t *testing.T) {
-	var gotHash string
-	var gotHash2 string
-	var count int32
+	// Each received hash is sent on hashCh by the handler goroutine and read
+	// here. This establishes the necessary happens-before edge: previously the
+	// handler wrote gotHash/gotHash2 to bare variables that the test goroutine
+	// read right after the count crossed the threshold — a data race AND a
+	// logic race (the count increment happened before the hash field was set,
+	// so the test could observe count==2 with gotHash2 still "").
+	hashCh := make(chan string, 4)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&count, 1)
-		h := r.Header.Get("X-Network-State-Hash")
-		if n == 1 {
-			gotHash = h
-		} else {
-			gotHash2 = h
-		}
+		hashCh <- r.Header.Get("X-Network-State-Hash")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -175,16 +173,20 @@ func TestReporter_SendsStateHashHeader(t *testing.T) {
 	time.Sleep(120 * time.Millisecond) // let the first ticker flush land
 	r.Report(context.Background(), 1, hosts)
 
+	// Collect both hashes with a generous deadline (the flush ticker is 50ms).
+	recv := make([]string, 0, 2)
 	deadline := time.After(3 * time.Second)
-	for atomic.LoadInt32(&count) < 2 {
+	for len(recv) < 2 {
 		select {
+		case h := <-hashCh:
+			recv = append(recv, h)
 		case <-deadline:
-			t.Fatalf("reporter did not flush twice (got %d)", atomic.LoadInt32(&count))
-		case <-time.After(10 * time.Millisecond):
+			t.Fatalf("reporter did not flush twice (got %d)", len(recv))
 		}
 	}
 	r.Stop()
 
+	gotHash, gotHash2 := recv[0], recv[1]
 	require.NotEmpty(t, gotHash, "hash header must be sent")
 	require.Equal(t, gotHash, gotHash2, "identical alive sets must produce the same hash")
 }


### PR DESCRIPTION
## Problem

`TestReporter_SendsStateHashHeader` is **flaky under the CI race detector**. It failed on PR #22 — which is doc-only and touches no Go code — proving the failure is **pre-existing on `main`**, not caused by any PR diff.

Reproduced locally on clean `main` with `-race`: **PASS / FAIL / FAIL** across 3 runs.

## Root cause: two races

**1. Data race (race-detector flag).** The handler wrote `gotHash` / `gotHash2` to bare variables read by the test goroutine with no synchronization:

```go
// handler goroutine
n := atomic.AddInt32(&count, 1)
h := r.Header.Get("X-Network-State-Hash")
if n == 1 { gotHash = h } else { gotHash2 = h }   // unsynced write

// test goroutine, right after count crosses 2
require.NotEmpty(t, gotHash, ...)                  // unsynced read
```

**2. Logic race (the actual CI assertion failure).** `atomic.AddInt32(&count)` runs **before** `gotHash2 = h` for that request. So the test's `count >= 2` exit condition could fire while the 2nd handler call was still between the increment and the field assignment — the test then read `gotHash2 == ""` and failed `NotEmpty`. This matches the CI log exactly:

```
expected: "57e63ccd7605..."
actual  : ""
Messages: identical alive sets must produce the same hash
```

## Fix

The handler now sends each received hash on a buffered channel; the test reads from it. A channel send/receive establishes the happens-before edge the bare-variable write lacked, eliminating **both** races. The `count` counter (which encoded ordering the channel now provides naturally) is removed.

## Verification

| Check | Result |
|---|---|
| `-race -count=30` on the fixed test | ✅ 30/30 PASS (was PASS/FAIL/FAIL) |
| `-race` on full `./internal/agent/` | ✅ PASS (24.6s) |
| `go vet` / `gofmt` | ✅ clean |

## Why this unblocks other PRs

This is the only `-race` failure in CI. PR #22 (docs) and #23 (SNMP refactor) both turn red solely because of this test; once green, both can merge. The fix is test-only (no production behavior change).

🤖 Generated with [ZCode](https://zcode.dev)