### PR TITLE
feat(config): make detection thresholds + heartbeat cadence configurable

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -140,6 +140,7 @@ func main() {
 	// the center tags its copies with the agent's network from the token.
 	scanRunner := scannerv2runner.New(engine, queries, dbConn, nil, 0, slog.Default())
 	scanRunner.SetReportSink(reporter.Report)
+	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)
 
 	// Scheduler: cron-driven local scans. The agent's scan_tasks live in its own
 	// mini-DB (seeded manually or via the task API on the center in a later

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -42,6 +42,18 @@ heartbeat:
   default_interval: 30
   timeout: 5
   retention_days: 30
+  # Cadence of the heartbeat probing loop in seconds (default 30). The loop
+  # polls every device whose per-device interval is due and writes verdicts to
+  # an in-memory cache. Lower = faster liveness detection + more probe load;
+  # higher = the opposite. 0 = use default (30). Large fleets or tight RTT
+  # budgets may want to tune this. MIBEE_HEARTBEAT_TICK_INTERVAL_SECONDS.
+  tick_interval_seconds: 30
+  # Number of consecutive probe failures before a device flips to "offline"
+  # (default 5). This is the heartbeat-side (probe-based) death sensitivity;
+  # scanner.lost_threshold is the scan-side (absence-based) one. Lower = more
+  # responsive but more flap-prone; higher = more stable but slower to declare.
+  # 0 = use default (5). MIBEE_HEARTBEAT_OFFLINE_THRESHOLD.
+  offline_threshold: 5
   # Probe an already-offline device once every N ticks instead of every tick
   # (default 10 → ~5min on a 30s ticker for known-dead hosts vs 30s for live
   # ones). 0 = use default. A scan that revives a host clears this immediately.
@@ -86,6 +98,12 @@ scanner:
   default_timeout: 300        # seconds, per-host pipeline timeout (upper bound for ALL probes + handlers on one host)
   per_probe_timeout: 3        # seconds, single probe attempt (one SNMP Get / TCP dial / HTTP fetch). Keep small so dead hosts fail fast.
   max_concurrent_hosts: 50
+  # Number of consecutive scans a device must be absent from the alive set
+  # before being declared "lost" (default 2). Single missed scans (ICMP drop,
+  # brief downtime, jitter) must not flap a device offline. This is the
+  # scan-side (absence-based) death sensitivity; heartbeat.offline_threshold
+  # is the probe-based one. 0 = use default (2). MIBEE_SCANNER_LOST_THRESHOLD.
+  lost_threshold: 2
   retention_days: 30
   default_cron_expr: "0 */6 * * *"
   # v2 engine tuning (the legacy v1 engine has been removed).

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -259,6 +259,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Runner: connects the engine to run/result persistence + the device bridge.
 	scanRunner := scannerv2runner.New(v2Engine, scanQueries, dbConn, heartbeatSvc, networkID, slog.Default())
+	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)
 
 	// Change detection (Phase 3): the center records device_added/changed/lost
 	// events to change_log + pushes in-process Watcher subscribers. The agent

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,23 @@ type HeartbeatConfig struct {
 	DefaultInterval int `koanf:"default_interval"`
 	Timeout         int `koanf:"timeout"`
 	RetentionDays   int `koanf:"retention_days"`
+	// TickIntervalSeconds is the cadence of the heartbeat probing loop in
+	// seconds (default 30). The loop polls every device whose heartbeat config
+	// is due and writes verdicts to the in-memory status cache. Distinct from
+	// DefaultInterval (which is the per-device probe interval stored in
+	// heartbeat_configs.interval_seconds and feeds the isDue window) — that
+	// value is also defaulted to TickIntervalSeconds when 0, so out of the box
+	// a device is probed once per tick. Operators with large fleets or tight
+	// RTT budgets can lower the tick for faster liveness detection or raise it
+	// to reduce probe load. 0 means "use the default" (30s).
+	TickIntervalSeconds int `koanf:"tick_interval_seconds"`
+	// OfflineThreshold is the number of consecutive probe failures before a
+	// device flips to "offline" (default 5). Together with scanner.lost_threshold
+	// it defines the full death-detection behavior: this knob is the
+	// heartbeat-side (probe-based) sensitivity, lost_threshold is the scan-side
+	// (absence-based) sensitivity. Lower = more responsive but more flap-prone;
+	// higher = more stable but slower to declare dead. 0 means "use the default".
+	OfflineThreshold int `koanf:"offline_threshold"`
 	// OfflineBackoffTicks throttles probing of devices already marked offline.
 	// A value of N means an offline device is probed once every N ticks instead
 	// of every tick (default 10 → on a 30s ticker that's ~5min between probes
@@ -212,6 +229,15 @@ type ScannerConfig struct {
 	MaxConcurrentScans int  `koanf:"max_concurrent_scans"`
 	DefaultTimeout     int  `koanf:"default_timeout"`
 	MaxConcurrentHosts int  `koanf:"max_concurrent_hosts"`
+	// LostThreshold is the number of consecutive scans a device must be absent
+	// from the alive set before being declared "lost" (default 2). Single
+	// missed scans (ICMP drop, brief host downtime, network jitter) must not
+	// flap a device offline — see architecture-future.md §8 note 3 (去抖动/grace
+	// period). This is the scan-side (absence-based) death sensitivity; the
+	// heartbeat-side (probe-based) sensitivity is heartbeat.offline_threshold.
+	// 0 means "use the default" (2). Applied by DetectLost (runner), shared by
+	// the local scan path + the agent→center ingestion path + the lease sweeper.
+	LostThreshold int `koanf:"lost_threshold"`
 	// PerProbeTimeout bounds a SINGLE probe attempt (one SNMP Get, one TCP dial,
 	// one HTTP fetch) in seconds. Distinct from default_timeout (which bounds
 	// the whole per-host pipeline). Default 3s — keeps /24 scans fast even when

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -60,10 +60,18 @@ type HeartbeatService struct {
 // time-series store (separate SQLite file, batched writes).
 func NewHeartbeatService(mainDB *sql.DB, store *HeartbeatStore, cfg *config.Config) *HeartbeatService {
 	hcfg := cfg.Heartbeat
-	// Default offline backoff: 10 ticks. With the 30s ticker that means a
-	// known-offline device is probed every ~5min instead of every 30s. 0 in
-	// config is treated as "unset → use default" (consistent with the rest of
-	// the heartbeat config). A negative value is clamped to 0 (no backoff).
+	// Defaults: tick=30s, offline threshold=5 failures, offline backoff=10
+	// ticks. 0 in config is treated as "unset → use default" (consistent with
+	// the rest of the heartbeat config). Negative values are clamped to the
+	// nearest sane bound.
+	if hcfg.TickIntervalSeconds <= 0 {
+		hcfg.TickIntervalSeconds = 30
+	}
+	if hcfg.OfflineThreshold <= 0 {
+		hcfg.OfflineThreshold = 5
+	}
+	// With the 30s ticker a 10-tick backoff means a known-offline device is
+	// probed every ~5min instead of every 30s.
 	if hcfg.OfflineBackoffTicks == 0 {
 		hcfg.OfflineBackoffTicks = 10
 	}
@@ -111,10 +119,15 @@ func (s *HeartbeatService) Start(ctx context.Context) {
 	// main DB. Probes write to statusCache (memory); this loop syncs every 30s.
 	go s.syncStatusLoop(ctx)
 
-	// 30s ticker for probing. Probes write results to the store (separate DB)
-	// and verdicts to statusCache (memory) — neither touches the main DB, so
-	// concurrent probing is safe (no SQLite race).
-	ticker := time.NewTicker(30 * time.Second)
+	// Probing ticker. Probes write results to the store (separate DB) and
+	// verdicts to statusCache (memory) — neither touches the main DB, so
+	// concurrent probing is safe (no SQLite race). Cadence is configurable via
+	// heartbeat.tick_interval_seconds (default 30s).
+	tickInterval := time.Duration(s.cfg.TickIntervalSeconds) * time.Second
+	if tickInterval <= 0 {
+		tickInterval = 30 * time.Second
+	}
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 
 	slog.Info("heartbeat scheduler started")
@@ -450,8 +463,10 @@ func (s *HeartbeatService) applyDeviceVerdict(deviceID int64, anySuccess bool) {
 		count := s.failCounts[deviceID]
 		s.failCountsMu.Unlock()
 
-		const offlineThreshold = 5
-		if count < offlineThreshold {
+		// Offline threshold is configurable (heartbeat.offline_threshold,
+		// default 5). A device must fail this many consecutive probes before
+		// flipping to offline.
+		if count < s.cfg.OfflineThreshold {
 			return // not yet at threshold, keep current status
 		}
 		newStatus = "offline"
@@ -513,12 +528,18 @@ func (s *HeartbeatService) initStatusCache(ctx context.Context) {
 }
 
 // syncStatusLoop is the SOLE writer of devices.status to the main DB. It runs
-// every 30s, diffing the in-memory statusCache against lastSynced and writing
-// only the changes. In steady state (no status changes), this is zero writes.
+// at the configured tick cadence (heartbeat.tick_interval_seconds, default
+// 30s), diffing the in-memory statusCache against lastSynced and writing only
+// the changes. In steady state (no status changes), this is zero writes.
 // Probes never touch devices.status — they only update statusCache — so there's
-// no concurrent-write race on the main DB.
+// no concurrent-write race on the main DB. The sync cadence tracks the probe
+// ticker so status writes keep up with probe verdicts at any configured tick.
 func (s *HeartbeatService) syncStatusLoop(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
+	tickInterval := time.Duration(s.cfg.TickIntervalSeconds) * time.Second
+	if tickInterval <= 0 {
+		tickInterval = 30 * time.Second
+	}
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -592,7 +613,13 @@ func (s *HeartbeatService) syncStatus(ctx context.Context) {
 func (s *HeartbeatService) isDue(_ context.Context, cfg db.HeartbeatConfig) bool {
 	interval := time.Duration(cfg.IntervalSeconds) * time.Second
 	if interval <= 0 {
-		interval = 30 * time.Second
+		// Per-device interval unset → fall back to the configured tick cadence
+		// (heartbeat.tick_interval_seconds, default 30s) so the device is probed
+		// once per tick.
+		interval = time.Duration(s.cfg.TickIntervalSeconds) * time.Second
+		if interval <= 0 {
+			interval = 30 * time.Second
+		}
 	}
 
 	// Read the last probe time from the in-memory map — NOT from the heartbeat

--- a/internal/service/scannerv2/runner/change_detect_test.go
+++ b/internal/service/scannerv2/runner/change_detect_test.go
@@ -190,3 +190,47 @@ func TestDetectLost_ReappearanceResets(t *testing.T) {
 	conn.QueryRow(`SELECT miss_count FROM scan_snapshots WHERE ip='10.0.0.20'`).Scan(&miss)
 	require.Equal(t, int64(0), miss, "reappearance after 1 miss resets to 0")
 }
+
+// TestDetectLost_SetLostThreshold confirms scanner.lost_threshold (applied via
+// SetLostThreshold) is honored: with threshold=3 a device absent twice (which
+// WOULD be lost at the default threshold of 2) is still online, and only flips
+// to offline on the third consecutive absence. This is the regression guard for
+// the config key that replaced the hardcoded `const lostThreshold = 2`.
+func TestDetectLost_SetLostThreshold(t *testing.T) {
+	rn, _, conn := setupChangeDetectDB(t)
+	rn.SetLostThreshold(3)
+	require.Equal(t, int64(3), rn.LostThreshold(), "SetLostThreshold must apply")
+	ctx := context.Background()
+	netID := rn.networkID
+
+	rn.applyDeviceBridge(ctx, reportFor("10.0.0.30", "server", "", "aa:bb:cc:dd:ee:30"), netID, "")
+	// Scan 1: alive → snapshotted.
+	rn.DetectLost(ctx, netID, 1, []scannerv2.HostReport{
+		reportFor("10.0.0.30", "server", "", "aa:bb:cc:dd:ee:30"),
+	}, "")
+	// Scans 2 + 3: absent twice → miss_count=2 < threshold 3 → still online.
+	rn.DetectLost(ctx, netID, 1, nil, "")
+	rn.DetectLost(ctx, netID, 1, nil, "")
+	var status string
+	conn.QueryRow(`SELECT status FROM devices WHERE ip_address='10.0.0.30'`).Scan(&status)
+	require.Equal(t, "online", status, "absent twice at threshold=3 should NOT be lost")
+
+	// Scan 4: third absence → miss_count=3 >= threshold → LOST.
+	rn.DetectLost(ctx, netID, 1, nil, "")
+	conn.QueryRow(`SELECT status FROM devices WHERE ip_address='10.0.0.30'`).Scan(&status)
+	require.Equal(t, "offline", status, "absent three times at threshold=3 should be lost")
+}
+
+// TestSetLostThreshold_IgnoresNonPositive confirms SetLostThreshold rejects
+// non-positive values (keeps the constructor default of 2 — 0 means "unset →
+// use default", matching the config convention).
+func TestSetLostThreshold_IgnoresNonPositive(t *testing.T) {
+	rn, _, _ := setupChangeDetectDB(t)
+	require.Equal(t, int64(2), rn.LostThreshold(), "constructor default is 2")
+	rn.SetLostThreshold(0)
+	require.Equal(t, int64(2), rn.LostThreshold(), "0 is rejected (keeps default)")
+	rn.SetLostThreshold(-1)
+	require.Equal(t, int64(2), rn.LostThreshold(), "negative is rejected (keeps default)")
+	rn.SetLostThreshold(5)
+	require.Equal(t, int64(5), rn.LostThreshold(), "positive is applied")
+}

--- a/internal/service/scannerv2/runner/detect_lost.go
+++ b/internal/service/scannerv2/runner/detect_lost.go
@@ -20,12 +20,6 @@ import (
 	"mibee-steward/internal/service/scannerv2"
 )
 
-// lostThreshold is the number of consecutive scans a device must be absent
-// before being declared lost. Single missed scans (ICMP drop, brief host
-// downtime, network jitter) must not flap a device offline — see
-// architecture-future.md §8 note 3 (去抖动/grace period).
-const lostThreshold = 2
-
 // DetectLost runs the device_lost detection for one scan's outcome on one
 // network. It is the post-scan set-difference:
 //
@@ -35,6 +29,11 @@ const lostThreshold = 2
 //     set: increment its miss_count.
 //  3. Emit device_lost + mark status='offline' for snapshots whose miss_count
 //     has crossed the threshold AND whose device is still online.
+//
+// The threshold is the runner's lostThreshold (scanner.lost_threshold config
+// key, default 2). Single missed scans (ICMP drop, brief host downtime, network
+// jitter) must not flap a device offline — see architecture-future.md §8 note 3
+// (去抖动/grace period).
 //
 // agentID threads through to change_log provenance (empty on the local-scan
 // path). taskID is the scan that produced these reports (0/nil for agent
@@ -73,9 +72,10 @@ func (rn *Runner) DetectLost(ctx context.Context, networkID sql.NullInt64, taskI
 	}
 
 	// 3. Emit device_lost for snapshots past the threshold that are still online.
+	threshold := rn.LostThreshold()
 	lost, err := rn.queries.ListLostSnapshots(ctx, db.ListLostSnapshotsParams{
 		NetworkID: netID,
-		MissCount: lostThreshold,
+		MissCount: threshold,
 	})
 	if err != nil {
 		rn.logger.Warn("detect-lost: list lost snapshots failed", "network_id", netID, "error", err)
@@ -104,7 +104,7 @@ func (rn *Runner) DetectLost(ctx context.Context, networkID sql.NullInt64, taskI
 	}
 	if rn.logger != nil {
 		slog.Info("detect-lost: devices declared lost",
-			"network_id", netID, "count", len(lost), "threshold", lostThreshold)
+			"network_id", netID, "count", len(lost), "threshold", threshold)
 	}
 }
 

--- a/internal/service/scannerv2/runner/runner.go
+++ b/internal/service/scannerv2/runner/runner.go
@@ -70,6 +70,12 @@ type Runner struct {
 	// applyDeviceBridge (and device_lost from detectLost). nil on the agent
 	// (change detection is a center concern). See internal/changedetect.
 	changeRecorder changedetect.ChangeRecorder
+	// lostThreshold is the number of consecutive scans a device must be absent
+	// from the alive set before being declared "lost" by DetectLost. Default 2
+	// (single missed scans must not flap a device offline). Configurable via
+	// scanner.lost_threshold; SetLostThreshold applies the config value. See
+	// detect_lost.go. int64 to match scan_snapshots.miss_count's sqlc type.
+	lostThreshold int64
 }
 
 // ReportSink consumes a batch of alive HostReports at the end of a scan. The
@@ -100,7 +106,34 @@ func New(engine *engine.Engine, queries *db.Queries, dbConn *sql.DB, heartbeat H
 	if networkID > 0 {
 		nid = sql.NullInt64{Int64: networkID, Valid: true}
 	}
-	return &Runner{engine: engine, queries: queries, dbConn: dbConn, heartbeat: heartbeat, networkID: nid, logger: logger}
+	return &Runner{
+		engine:        engine,
+		queries:       queries,
+		dbConn:        dbConn,
+		heartbeat:     heartbeat,
+		networkID:     nid,
+		logger:        logger,
+		lostThreshold: 2, // default; override via SetLostThreshold from scanner.lost_threshold
+	}
+}
+
+// SetLostThreshold configures the consecutive-absence count before DetectLost
+// declares a device lost (scanner.lost_threshold config key, default 2). Values
+// <= 0 are ignored (the default of 2 is retained). Must be called before Run;
+// not safe to swap concurrently with a running scan.
+func (rn *Runner) SetLostThreshold(n int) {
+	if n > 0 {
+		rn.lostThreshold = int64(n)
+	}
+}
+
+// LostThreshold returns the configured consecutive-absence count for DetectLost.
+// Exposed for diagnostics + tests.
+func (rn *Runner) LostThreshold() int64 {
+	if rn.lostThreshold > 0 {
+		return rn.lostThreshold
+	}
+	return 2
 }
 
 // PersistManualDevice runs a single HostReport (synthesized for a manually-


### PR DESCRIPTION
## What

Fixes **H3+H4+H5** from the 2026-07-27 architecture audit. Three death-detection knobs + the probe cadence were hardcoded Go literals even though AGENTS.md claimed heartbeat was configurable — operators tuning liveness sensitivity had no override path short of editing Go + redeploying.

## New config keys

All default to current behavior → **zero-impact out of the box**. Koanf YAML + `MIBEE_*` env overrides.

| Key | Default | Was (hardcoded) | Controls |
|---|---|---|---|
| `heartbeat.tick_interval_seconds` | 30 | `time.NewTicker(30*time.Second)` @ heartbeat.go:117 | Probe loop cadence. Also now drives `syncStatusLoop`'s ticker + the `isDue` per-device-interval fallback (both were hardcoded 30s) so status writes + due-window keep up with the configured tick. |
| `heartbeat.offline_threshold` | 5 | `const offlineThreshold = 5` @ heartbeat.go:453 | Consecutive probe failures before a device flips offline. |
| `scanner.lost_threshold` | 2 | `const lostThreshold = 2` in detect_lost.go | Consecutive scan absences before `DetectLost` declares a device lost. |

`scanner.lost_threshold` is threaded into `Runner` via a new `SetLostThreshold` field+setter+getter (`int64` to match `scan_snapshots.miss_count`'s sqlc type), wired from `routes.go` (center) + `cmd/agent/main.go` (agent). Both `DetectLost` paths (local scan + agent→center ingestion) honor it.

## Tests

| Test | Asserts |
|---|---|
| `TestDetectLost_GracePeriod` (existing) | Default threshold 2 → absent-once online, absent-twice lost. **Passes unmodified** — behavior preserved. |
| `TestDetectLost_SetLostThreshold` (new) | `threshold=3` → absent twice still online, absent 3x → lost. **Proves the knob moves behavior.** |
| `TestSetLostThreshold_IgnoresNonPositive` (new) | 0/negative rejected (keeps default 2), matching the "0 = use default" config convention. |

## Verification (local)

- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l` ✅ (empty)
- `go test ./...` ✅ all packages pass
- `config.example.yaml` updated with all 3 keys + tradeoff docs + env-var names

🤖 Generated with [ZCode](https://zcode.dev)