### PR TITLE
feat(agent): wire passive discovery sources (Phase A router-agent)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -36,6 +36,7 @@ import (
 	"mibee-steward/internal/agent"
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/db"
+	scannerv2discovery "mibee-steward/internal/service/scannerv2/discovery"
 	scannerv2ebpf "mibee-steward/internal/service/scannerv2/ebpf"
 	scannerv2engine "mibee-steward/internal/service/scannerv2/engine"
 	scannerv2probe "mibee-steward/internal/service/scannerv2/probe"
@@ -160,6 +161,99 @@ func main() {
 		slog.Info("agent scan scheduler started")
 	}
 
+	// Passive discovery service — the SAME wiring the center uses
+	// (internal/api/routes/routes.go), so the agent gets the passive ARP-cache +
+	// multicast + router_arp sources for free. This is Phase A of the
+	// router-agent roadmap: a router-resident agent (or a center deployed on a
+	// router, form C) sees a far richer broadcast domain than a random LAN host,
+	// and the existing discovery/ sources capture that choke-point value without
+	// new code. The discovery config block (scanner.discovery.*) is shared with
+	// the center; an operator enables the same sources in agent.yaml.
+	//
+	// The sources write through the runner's device bridge → reportSink →
+	// upstream reporter, so passively-discovered hosts reach the center via the
+	// same path as actively-scanned ones. discCancel is invoked on shutdown.
+	var discCancel context.CancelFunc
+	if cfg.Scanner.Discovery.Enabled {
+		discSvc := scannerv2discovery.New(
+			scannerv2discovery.Config{
+				Interval:        time.Duration(cfg.Scanner.Discovery.Interval) * time.Second,
+				TriggerIdentify: cfg.Scanner.Discovery.TriggerIdentify,
+			},
+			scannerv2discovery.SinkAdapter{Runner: scanRunner},
+			scannerv2discovery.IdentifierAdapter(engine),
+			dbConn, 0, slog.Default(),
+		)
+		discCtx, cancel := context.WithCancel(ctxBg)
+		discCancel = cancel
+		discSvc.Start(discCtx)
+		interval := time.Duration(cfg.Scanner.Discovery.Interval) * time.Second
+		if interval <= 0 {
+			interval = 60 * time.Second
+		}
+		var activeSources []string
+		// router_arp: widest coverage — one SNMP Walk per configured router.
+		if cfg.Scanner.Discovery.RouterARP.Enabled {
+			routerCommunity := cfg.Scanner.SNMPCommunity
+			if cfg.Scanner.RouterARP.Community != "" {
+				routerCommunity = cfg.Scanner.RouterARP.Community
+			}
+			routerTimeout := time.Duration(cfg.Scanner.PerProbeTimeout) * time.Second
+			if routerTimeout <= 0 {
+				routerTimeout = 3 * time.Second
+			}
+			routerARPSrc := scannerv2discovery.NewRouterARPSource(
+				cfg.Scanner.RouterARP.Routers, routerCommunity, routerTimeout,
+				interval, discSvc, slog.Default(),
+			)
+			routerARPSrc.Start(discCtx)
+			activeSources = append(activeSources, "router_arp")
+		}
+		// arp_cache: free byproduct of normal operation (reads /proc/net/arp).
+		if cfg.Scanner.Discovery.ARPCache.Enabled {
+			arpCacheSrc := scannerv2discovery.NewARPCacheSource(interval, discSvc, slog.Default())
+			arpCacheSrc.Start(discCtx)
+			activeSources = append(activeSources, "arp_cache")
+		}
+		// multicast: passive mDNS/SSDP listener (zero outbound traffic).
+		if cfg.Scanner.Discovery.Multicast.Enabled {
+			mcastSrc := scannerv2discovery.NewMulticastSource(discSvc, slog.Default())
+			mcastSrc.Start(discCtx)
+			activeSources = append(activeSources, "multicast")
+		}
+		// arp_scan: WITH_ARPSCAN build only; NewARPScanSource returns nil
+		// otherwise (or without CAP_NET_RAW) — nil guard skips it silently.
+		if cfg.Scanner.Discovery.ARPScan.Enabled {
+			if arpScanSrc := scannerv2discovery.NewARPScanSource(
+				cfg.Network.CIDR, interval, cfg.Scanner.ARPScan.Interface,
+				discSvc, slog.Default(),
+			); arpScanSrc != nil {
+				arpScanSrc.Start(discCtx)
+				activeSources = append(activeSources, "arp_scan")
+			}
+		}
+		// lldp_frame / cdp_frame: WITH_LLDP / WITH_CDP builds only; the New*
+		// constructors return nil in the default build → skipped silently.
+		if lldpSrc := scannerv2discovery.NewLLDPFrameSource(
+			cfg.Scanner.Discovery.LLDPInterfaces, discSvc, nil, slog.Default(),
+		); lldpSrc != nil {
+			lldpSrc.Start(discCtx)
+			activeSources = append(activeSources, "lldp_frame")
+		}
+		if cdpSrc := scannerv2discovery.NewCDPFrameSource(
+			cfg.Scanner.Discovery.LLDPInterfaces, discSvc, nil, slog.Default(),
+		); cdpSrc != nil {
+			cdpSrc.Start(discCtx)
+			activeSources = append(activeSources, "cdp_frame")
+		}
+
+		discSvc.SetSources(activeSources)
+		slog.Info("agent passive discovery ready",
+			"interval", interval.String(),
+			"sources", activeSources,
+			"trigger_identify", cfg.Scanner.Discovery.TriggerIdentify)
+	}
+
 	// Command poller: fetches ad-hoc scan commands from the center (Phase 5c).
 	// The runScan callback wraps the runner so this package doesn't import runner
 	// directly (avoids an import cycle). Commands are best-effort — the agent's
@@ -194,6 +288,9 @@ func main() {
 	<-quit
 	slog.Info("shutting down mibee-agent...")
 	cancel()
+	if discCancel != nil {
+		discCancel() // stop passive-discovery sources before the runner goes away
+	}
 	cmdPoller.Stop()
 	if scanScheduler != nil {
 		scanScheduler.Stop()


### PR DESCRIPTION
## What

The agent previously ran **cron-driven active scans only** — the `discovery/` package's passive sources (ARP-cache diff, multicast mDNS/SSDP listener, router-arp SNMP walk, ARP-sweep, LLDP/CDP frame listeners) were wired exclusively in the center's `routes.go`. A router-resident agent (which sits at the network choke point and sees far richer broadcast traffic than a random LAN host) couldn't capture that choke-point value.

This adds the **same wiring block the center uses** (`routes.go:304-396`) to `cmd/agent/main.go`:
- Construct the discovery `Service` with the agent's own runner (`SinkAdapter`) + engine (`IdentifierAdapter`)
- Start each source the operator enables via the shared `scanner.discovery.*` config block (`router_arp` / `arp_cache` / `multicast` / `arp_scan` / `lldp_frame` / `cdp_frame`)
- The discovery config is **shared with the center** — an operator enables the same sources in `agent.yaml`
- Sources write through the runner's device bridge → `reportSink` → upstream reporter, so passively-discovered hosts reach the center via the same path as actively-scanned ones
- `discCancel` added to the shutdown path (stops sources before the runner goes away)

## Why (roadmap context)

Phase A of the router-agent roadmap (private doc §3). The 4 Tier-1 router-only signals (DHCP leases, conntrack, DNS query log, hostapd) land in Phase B as new `discovery/` sources — **center + agent share them**, so the planned **form C** (a center deployed ON a router) gets them too, not just the agent. Keeping the sources in the shared `discovery/` package (not `internal/agent/`) is the architectural decision that makes all three deployment forms benefit.

## Real-hardware verification (192.168.62.174 agent → 192.168.63.101 center)

| Check | Result |
|---|---|
| Agent binary builds (CGO-free, 18MB) | ✅ |
| `go test ./internal/agent/ ./internal/service/scannerv2/discovery/` | ✅ pass |
| Deployed to 62.174, `scanner.discovery.enabled` + 3 sources in agent.yaml | ✅ |
| Startup log: `agent passive discovery ready interval=1m0s sources=[router_arp arp_cache multicast] trigger_identify=true` | ✅ |
| Agent reports hosts upstream as before (`report accepted hosts=34`) | ✅ |
| `router_arp` on test router (.1) logs expected 'SNMP refused' with helpful hint (that router doesn't expose SNMP) | ✅ (graceful) |
| `arp_cache` + `multicast` run clean (no errors) | ✅ |
| Agent stable (PID 139008, RSS 100MB, service active) | ✅ |
| No regression to active scanning | ✅ |

🤖 Generated with [ZCode](https://zcode.dev)