### PR TITLE
feat(discovery): conntrack + dhcp_leases Tier-1 router sources (Phase B P0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ internal/service/scannerv2/ebpf/tcIngress_*.go
 internal/service/scannerv2/ebpf/tcIngress*.o
 cover.out
 *.prof
+agent

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -221,6 +221,20 @@ func main() {
 			mcastSrc.Start(discCtx)
 			activeSources = append(activeSources, "multicast")
 		}
+		// dhcp_leases: Tier-1 router signal — the DHCP authority's hostname↔MAC↔IP
+		// map. No-op on a host that isn't the LAN's DHCP server (file absent).
+		if cfg.Scanner.Discovery.DHCPLeases.Enabled {
+			dhcpSrc := scannerv2discovery.NewDHCPLeasesSource(interval, "", discSvc, slog.Default())
+			dhcpSrc.Start(discCtx)
+			activeSources = append(activeSources, "dhcp_leases")
+		}
+		// conntrack: Tier-1 router signal — the NAT choke point's "who is talking
+		// RIGHT NOW" view. Filters to the agent's own LAN CIDR.
+		if cfg.Scanner.Discovery.Conntrack.Enabled {
+			conntrackSrc := scannerv2discovery.NewConntrackSource(cfg.Network.CIDR, interval, discSvc, slog.Default())
+			conntrackSrc.Start(discCtx)
+			activeSources = append(activeSources, "conntrack")
+		}
 		// arp_scan: WITH_ARPSCAN build only; NewARPScanSource returns nil
 		// otherwise (or without CAP_NET_RAW) — nil guard skips it silently.
 		if cfg.Scanner.Discovery.ARPScan.Enabled {

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -181,6 +181,22 @@ scanner:
     # port is unavailable the source disables itself without crashing.
     multicast:
       enabled: true
+    # dhcp_leases: Tier-1 ROUTER signal. Reads the local DHCP server's lease
+    # table (dnsmasq /tmp/dhcp.leases on OpenWrt, /var/lib/misc/dnsmasq.leases
+    # on Debian) — the authoritative hostname↔MAC↔IP map, covering devices
+    # (sleeping IoT, firewalled hosts) that never answer SNMP/ICMP/rDNS. No-op
+    # on a host that isn't the LAN's DHCP server (file absent → source skips).
+    # Enable when the center/agent runs ON the gateway (router form).
+    dhcp_leases:
+      enabled: false
+    # conntrack: Tier-1 ROUTER signal. Reads /proc/net/nf_conntrack and emits
+    # the LAN-side endpoint of every ESTABLISHED/ASSURED flow — the NAT choke
+    # point's "who is talking RIGHT NOW" view. Liveness + discovery for hosts
+    # that don't answer active probes but maintain outbound flows. Filters to
+    # network.cidr so it doesn't emit a row per public IP. No-op when the
+    # nf_conntrack module isn't loaded. Enable on a router/gateway.
+    conntrack:
+      enabled: false
   # ── Agent lease (distributed model) ───────────────────────────────────────
   # Agent-managed devices (networks with agent_id set) are kept online by their
   # agent's reports — the center does NOT probe them locally (cross-subnet ICMP

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -350,6 +350,20 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			mcastSrc.Start(discCtx)
 			activeSources = append(activeSources, "multicast")
 		}
+		// dhcp_leases: Tier-1 router signal — the DHCP authority's hostname↔MAC↔IP
+		// map. No-op on a host that isn't the LAN's DHCP server (file absent).
+		if cfg.Scanner.Discovery.DHCPLeases.Enabled {
+			dhcpSrc := scannerv2discovery.NewDHCPLeasesSource(interval, "", discSvc, slog.Default())
+			dhcpSrc.Start(discCtx)
+			activeSources = append(activeSources, "dhcp_leases")
+		}
+		// conntrack: Tier-1 router signal — the NAT choke point's "who is talking
+		// RIGHT NOW" view. Filters to the center's own LAN CIDR.
+		if cfg.Scanner.Discovery.Conntrack.Enabled {
+			conntrackSrc := scannerv2discovery.NewConntrackSource(cfg.Network.CIDR, interval, discSvc, slog.Default())
+			conntrackSrc.Start(discCtx)
+			activeSources = append(activeSources, "conntrack")
+		}
 		// arp_scan: active ARP who-has sweep of the whole network CIDR. The only
 		// source that covers the entire broadcast domain with NO router access
 		// (every host must answer ARP — even firewalled ones). Needs the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -387,6 +387,22 @@ type DiscoveryConfig struct {
 	// No-op in default builds (needs WITH_ARPSCAN + CAP_NET_RAW); the toggle has
 	// effect only in a WITH_ARPSCAN build.
 	ARPScan DiscoverySourceToggle `koanf:"arp_scan"`
+	// DHCPLeases reads the local DHCP server's lease table (dnsmasq's
+	// /tmp/dhcp.leases on OpenWrt / /var/lib/misc/dnsmasq.leases on Debian). A
+	// Tier-1 router-resident signal: the gateway is the DHCP authority, so its
+	// lease table is the authoritative hostname↔MAC↔IP map — covering devices
+	// (sleeping IoT, firewalled hosts) that never answer SNMP/ICMP/rDNS. No-op
+	// on a host that isn't the LAN's DHCP server (file absent → source skips).
+	DHCPLeases DiscoverySourceToggle `koanf:"dhcp_leases"`
+	// Conntrack reads the kernel conntrack table (/proc/net/nf_conntrack) and
+	// emits the LAN-side endpoint of every ESTABLISHED/ASSURED flow. A Tier-1
+	// router-resident signal: the gateway is the NAT choke point, so its
+	// conntrack table is the authoritative "who is talking RIGHT NOW" view — a
+	// liveness + discovery source for hosts that don't answer active probes but
+	// maintain outbound flows. Filters to the local LAN CIDR (network.cidr) so
+	// it doesn't emit a row per public IP a device talks to. No-op when the
+	// nf_conntrack module isn't loaded or /proc/net/nf_conntrack is absent.
+	Conntrack DiscoverySourceToggle `koanf:"conntrack"`
 	// LLDPInterfaces is the list of NIC names for the raw-frame LLDPDU listener
 	// (ethertype 0x88cc). Empty = all UP non-loopback interfaces. Only active in
 	// WITH_LLDP builds (needs CAP_NET_RAW); no-op in the default build.

--- a/internal/service/scannerv2/discovery/conntrack.go
+++ b/internal/service/scannerv2/discovery/conntrack.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConntrackSource periodically reads the kernel conntrack table
+// (/proc/net/nf_conntrack) and emits a NewHostEvent for every LAN host that has
+// an active (ESTABLISHED / ASSURED) flow. It is a router-resident signal: the
+// gateway is the NAT/forwarding choke point, so its conntrack table is the
+// authoritative "who is talking RIGHT NOW" view — a host-based scanner on a
+// random LAN box sees none of this without being a traffic tap.
+//
+// Why it matters (Tier-1 router-only signal — see
+// docs/private/architecture-debt-and-openwrt-2026-07-27.md §3.2):
+//
+//   - Liveness: a device with an active flow is by definition up, even if it
+//     doesn't answer ICMP or SNMP. This catches sleeping phones/IoT that wake
+//     briefly to phone home, firewalled hosts that drop probes, etc.
+//   - Discovery of otherwise-invisible hosts: a NAT'd client behind the router
+//     that never responds to subnet sweeps but maintains an outbound flow
+//     appears here.
+//   - It complements (does not replace) the ARP-based sources: ARP says "this
+//     MAC was seen at L2 recently"; conntrack says "this IP is generating
+//     traffic RIGHT NOW".
+//
+// P0 scope: this source treats conntrack as a DISCOVERY + liveness signal — it
+// emits the LAN-side endpoint of each flow as a host sighting, deduped the same
+// way as the ARP sources. The richer per-flow topology ("device A is talking to
+// external service B on port 443") requires a new persistence surface (flow
+// records with src+dst+port+bytes) and is deferred — the host-event path here is
+// the high-value, low-risk first cut that all three deployment forms (center /
+// agent / router-center) get for free.
+//
+// The source filters to LAN-local endpoints (RFC1918 + link-local) so it doesn't
+// emit an event for every public internet host a device talks to (which would
+// flood the device table with one row per CDN IP).
+type ConntrackSource struct {
+	// cidr is the LAN CIDR this source considers "local" — only flows whose
+	// LAN-side endpoint falls inside it are emitted. Required: without it the
+	// source would emit every remote IP a device talks to.
+	cidr     string
+	localNet *net.IPNet
+	// filePath is the conntrack table path (default /proc/net/nf_conntrack;
+	// overridable via newConntrackSourceWithPath for tests).
+	filePath string
+	interval time.Duration
+	svc      *Service
+	logger   *slog.Logger
+
+	mu       sync.Mutex
+	previous map[string]bool // ip set, last sweep — for diff
+}
+
+// NewConntrackSource constructs the source. cidr is the local LAN (e.g.
+// "192.168.62.0/24") used to filter which flow endpoints count as "a device we
+// should record". interval is the poll cadence (typically 60s). Returns a
+// usable source even when the CIDR is unparseable (logs a warning, treats every
+// endpoint as remote → emits nothing), so a misconfigured CIDR degrades to a
+// no-op rather than crashing.
+func NewConntrackSource(cidr string, interval time.Duration, svc *Service, logger *slog.Logger) *ConntrackSource {
+	return newConntrackSourceWithPath(cidr, interval, "/proc/net/nf_conntrack", svc, logger)
+}
+
+// newConntrackSourceWithPath is the test seam: same as NewConntrackSource but
+// reads conntrack from an arbitrary file path (so tests can feed a fixture).
+func newConntrackSourceWithPath(cidr string, interval time.Duration, filePath string, svc *Service, logger *slog.Logger) *ConntrackSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var localNet *net.IPNet
+	if _, ipnet, err := net.ParseCIDR(cidr); err == nil {
+		localNet = ipnet
+	} else {
+		logger.Warn("discovery: conntrack source has invalid LAN CIDR; source will emit nothing", "cidr", cidr)
+	}
+	return &ConntrackSource{
+		cidr:     cidr,
+		localNet: localNet,
+		filePath: filePath,
+		interval: interval,
+		svc:      svc,
+		logger:   logger,
+		previous: map[string]bool{},
+	}
+}
+
+// Start launches the poll goroutine (immediate first sweep, then ticks).
+func (s *ConntrackSource) Start(ctx context.Context) {
+	go s.loop(ctx)
+}
+
+func (s *ConntrackSource) loop(ctx context.Context) {
+	s.sweep()
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep reads /proc/net/nf_conntrack, extracts the LAN-side endpoint of each
+// ESTABLISHED/ASSURED flow, diffs against the previous snapshot, and emits an
+// event per newly-active host. A missing/unreadable file (nf_conntrack module
+// not loaded, or /proc/sys/net/netfilter/nf_conntrack_entries not exposed) is
+// logged once-per-call at debug and tolerated — the source is a no-op there.
+func (s *ConntrackSource) sweep() {
+	if s.localNet == nil {
+		return // invalid CIDR at construction → emit nothing
+	}
+	hosts, err := s.readActiveLANHosts()
+	if err != nil {
+		s.logger.Debug("discovery: conntrack read failed (nf_conntrack unavailable?)", "error", err)
+		return
+	}
+
+	current := make(map[string]bool, len(hosts))
+	for ip := range hosts {
+		current[ip] = true
+	}
+
+	s.mu.Lock()
+	prev := s.previous
+	s.previous = current
+	s.mu.Unlock()
+
+	for ip := range hosts {
+		if prev[ip] {
+			continue
+		}
+		s.svc.Emit(NewHostEvent{
+			IP:     ip,
+			Source: "conntrack",
+			// No MAC: conntrack tracks L3+; the bridge's MAC-primary identity
+			// falls back to (ip, network_id) which is correct for a flow sighting.
+			// The MAC will be filled in later by an ARP/dhcp/scan sighting of the
+			// same IP and the bridge reconciles by IP+network.
+			Hints: map[string]string{
+				"discovery_note": "conntrack",
+				// active_flow flags the host as live-right-now for downstream
+				// consumers (a future heartbeat-boost, or just a status hint).
+				"active_flow": "true",
+			},
+		})
+	}
+	s.logger.Debug("discovery: conntrack sweep", "lan_hosts", len(hosts), "new", len(hosts)-len(prev))
+}
+
+// readActiveLANHosts parses /proc/net/nf_conntrack and returns the set of
+// LAN-local IPs that appear as the LAN-side endpoint of an established flow.
+//
+// The conntrack entry format (one flow per line) is space-separated tokens,
+// e.g.:
+//
+//	ipv4 2 tcp 6 431999 ESTABLISHED src=192.168.62.41 dst=142.250.187.78 sport=443 dport=54812 ... [ASSURED] mark=0 use=2
+//	ipv4 2 udp 17 29 src=192.168.62.1 dst=1.1.1.1 sport=53 dport=41220 ... [ASSURED] mark=0 use=2
+//
+// We look at BOTH src= and dport= and dst= and sport= because either endpoint
+// may be the LAN host (a flow LAN→internet has src=LAN; a reply internet→LAN
+// has dst=LAN). We take whichever of src/dst is inside the local CIDR.
+func (s *ConntrackSource) readActiveLANHosts() (map[string]bool, error) {
+	f, err := os.Open(s.filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	hosts := make(map[string]bool)
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // conntrack lines can be long (MUD/IPv6 entries)
+	for sc.Scan() {
+		line := sc.Text()
+		// Only count established/assured flows — a flow in SYN_SENT or TIME_WAIT
+		// is not evidence of an active host (could be a half-open or a closing
+		// connection). This keeps the liveness signal honest. Note conntrack
+		// emits ASSURED as the bracketed token "[ASSURED]" (UDP flows have no
+		// state field, only the [ASSURED] marker); ESTABLISHED is a bare state
+		// token for TCP. Match both spellings.
+		if !containsToken(line, "ESTABLISHED") &&
+			!containsToken(line, "[ASSURED]") {
+			continue
+		}
+		src := tokenValue(line, "src=")
+		dst := tokenValue(line, "dst=")
+		// Emit the endpoint that is LAN-local (at most one of the two for a
+		// LAN↔internet flow; for LAN↔LAN both are, emit both).
+		if src != "" && s.localNet.Contains(net.ParseIP(src)) {
+			hosts[src] = true
+		}
+		if dst != "" && s.localNet.Contains(net.ParseIP(dst)) {
+			hosts[dst] = true
+		}
+	}
+	return hosts, sc.Err()
+}
+
+// tokenValue extracts the value of a "key=val" token from a space-separated
+// line. Returns "" when the token is absent.
+func tokenValue(line, key string) string {
+	// Find " key=" (leading space avoids matching a substring inside another
+	// token) — but the first token has no leading space, so also try at index 0.
+	search := " " + key
+	idx := strings.Index(line, search)
+	if idx < 0 {
+		if strings.HasPrefix(line, key) {
+			idx = -1 // act as if found at position -1, value starts after len-1
+		} else {
+			return ""
+		}
+	}
+	start := idx + len(search)
+	rest := line[start:]
+	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
+		rest = rest[:sp]
+	}
+	return rest
+}
+
+// containsToken reports whether line contains the given whitespace-delimited
+// token (e.g. "ESTABLISHED"). Avoids matching a substring inside another token.
+func containsToken(line, token string) bool {
+	for _, f := range strings.Fields(line) {
+		if f == token {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/scannerv2/discovery/conntrack_test.go
+++ b/internal/service/scannerv2/discovery/conntrack_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeConntrackFile writes the given nf_conntrack-format content to a temp
+// file and returns its path.
+func writeConntrackFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nf_conntrack")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0644))
+	return p
+}
+
+// TestConntrack_ReadActiveLANHosts confirms the conntrack parser:
+//   - extracts the LAN-side endpoint (src OR dst) of ESTABLISHED/ASSURED flows
+//   - filters to the local CIDR (public IPs a device talks to are NOT emitted)
+//   - skips non-established flows (TIME_WAIT / SYN_SENT aren't liveness)
+//   - handles the LAN↔internet direction both ways (src=LAN and dst=LAN on reply)
+func TestConntrack_ReadActiveLANHosts(t *testing.T) {
+	// Two LAN hosts (.41 and .138) talking to the internet, one LAN↔LAN flow,
+	// and one non-established flow from a third host that must be ignored.
+	content := joinLines(
+		// .41 → 142.250.187.78 (TCP established) — src is LAN
+		"ipv4 2 tcp 6 431999 ESTABLISHED src=192.168.62.41 dst=142.250.187.78 sport=54812 dport=443 [ASSURED] mark=0 use=2",
+		// reply direction of the same flow — dst is LAN (must not double-count, it's the same IP)
+		"ipv4 2 tcp 6 431999 ESTABLISHED src=142.250.187.78 dst=192.168.62.41 sport=443 dport=54812 [ASSURED] mark=0 use=2",
+		// .138 → 1.1.1.1 (UDP assured DNS) — src is LAN
+		"ipv4 2 udp 17 29 src=192.168.62.138 dst=1.1.1.1 sport=41220 dport=53 [ASSURED] mark=0 use=2",
+		// LAN↔LAN: .41 ↔ .138 — both endpoints are LAN, both emitted (dedup'd in the map)
+		"ipv4 2 tcp 6 299 ESTABLISHED src=192.168.62.41 dst=192.168.62.138 sport=44000 dport=22 [ASSURED] mark=0 use=1",
+		// .200 → 8.8.8.8 but in TIME_WAIT (not established) — MUST be skipped
+		"ipv4 2 tcp 6 119 TIME_WAIT src=192.168.62.200 dst=8.8.8.8 sport=55000 dport=443 [UNREPLIED] mark=0 use=1",
+	)
+	path := writeConntrackFile(t, content)
+	src := newConntrackSourceWithPath("192.168.62.0/24", time.Minute, path, nil, nil)
+
+	hosts, err := src.readActiveLANHosts()
+	require.NoError(t, err)
+	// Only .41 and .138 (each seen on multiple flows, dedup'd to 2 entries).
+	require.Len(t, hosts, 2, "two distinct LAN hosts with established flows")
+	require.True(t, hosts["192.168.62.41"], "LAN src of established flow emitted")
+	require.True(t, hosts["192.168.62.138"], "LAN src of UDP-assured + LAN↔LAN flow emitted")
+	require.False(t, hosts["192.168.62.200"], "TIME_WAIT flow must NOT count as liveness")
+}
+
+// TestConntrack_InvalidCIDR_EmitsNothing confirms a misconfigured CIDR degrades
+// to a no-op (not a panic) — the source returns empty rather than emitting
+// every public IP.
+func TestConntrack_InvalidCIDR_EmitsNothing(t *testing.T) {
+	content := joinLines(
+		"ipv4 2 tcp 6 431999 ESTABLISHED src=192.168.62.41 dst=142.250.187.78 sport=54812 dport=443 [ASSURED] mark=0 use=2",
+	)
+	path := writeConntrackFile(t, content)
+	src := newConntrackSourceWithPath("not-a-cidr", time.Minute, path, nil, nil)
+	// sweep() short-circuits when localNet is nil; readActiveLANHosts would
+	// still work but sweep never calls it. Verify both: nil localNet + sweep
+	// produces no Emit (using the test Service + sink).
+	require.Nil(t, src.localNet, "invalid CIDR → nil localNet at construction")
+	svc, sink, _, _ := newTestService(t, false)
+	src.svc = svc
+	src.sweep()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, sink.count(), "invalid-CIDR source emits nothing")
+}
+
+// TestConntrack_MissingFile_Tolerated confirms the no-op-on-non-router behavior:
+// when /proc/net/nf_conntrack doesn't exist (host isn't a NAT gateway), sweep
+// logs at debug and emits nothing — no crash, no noisy errors.
+func TestConntrack_MissingFile_Tolerated(t *testing.T) {
+	src := newConntrackSourceWithPath("192.168.62.0/24", time.Minute,
+		filepath.Join(t.TempDir(), "does-not-exist"), nil, nil)
+	svc, sink, _, _ := newTestService(t, false)
+	src.svc = svc
+	src.sweep() // must not panic
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, sink.count(), "missing conntrack file → no events, no crash")
+}
+
+// TestConntrack_TokenParsing covers the tokenValue + containsToken helpers
+// directly (the line-level extraction the parser depends on). Documents the
+// [ASSURED] bracketed-token quirk the sweep check must account for.
+func TestConntrack_TokenParsing(t *testing.T) {
+	line := "ipv4 2 tcp 6 431999 ESTABLISHED src=192.168.62.41 dst=142.250.187.78 sport=54812 [ASSURED] mark=0 use=2"
+	require.Equal(t, "192.168.62.41", tokenValue(line, "src="))
+	require.Equal(t, "142.250.187.78", tokenValue(line, "dst="))
+	require.Equal(t, "54812", tokenValue(line, "sport="))
+	require.Equal(t, "", tokenValue(line, "missing="))
+	// ESTABLISHED is a bare state token — matched directly.
+	require.True(t, containsToken(line, "ESTABLISHED"))
+	// [ASSURED] is a bracketed token; a bare "ASSURED" is NOT present (the
+	// sweep check looks for "[ASSURED]" for UDP flows, which carry no state
+	// field, only the [ASSURED] marker).
+	require.True(t, containsToken(line, "[ASSURED]"))
+	require.False(t, containsToken(line, "ASSURED"))
+}

--- a/internal/service/scannerv2/discovery/dhcp_leases.go
+++ b/internal/service/scannerv2/discovery/dhcp_leases.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DHCPLeasesSource periodically reads the local DHCP server's lease table and
+// emits a NewHostEvent for every leased IP. It is a router-resident signal: the
+// DHCP server (dnsmasq on OpenWrt, dhcpd on generic Linux) runs ON the gateway,
+// so only a router/center deployed as the LAN's DHCP authority has this file.
+//
+// Why it matters (Tier-1 router-only signal — see
+// docs/private/architecture-debt-and-openwrt-2026-07-27.md §3.2):
+//
+//   - It is the AUTHORITATIVE hostname↔MAC↔IP map. Every device that ever got a
+//     lease is listed, including ones that don't respond to SNMP sysName, reverse
+//     DNS, or ICMP (sleeping IoT, firewalled hosts, transient guests).
+//   - The hostname arrives as a first-class field (the client sends it in the
+//     DHCP REQUEST), so device naming no longer depends on a PTR record existing
+//     in the local DNS — a frequent gap for devices the router's dnsmasq hands
+//     out names to but never synthesizes PTRs for.
+//
+// Format parsed (dnsmasq's lease file, the OpenWrt/Debian/Devuan default):
+//
+//	<expiry_unix> <mac> <ipv4> <hostname> <client_id>
+//	1700000000 aa:bb:cc:dd:ee:ff 192.168.1.50 phone-n13 *
+//
+// The hostname may be "*" when the client didn't send one. The mac is lowercased
+// by dnsmasq. dhcpd's lease file (/var/lib/dhcp/dhcpd.leases) has a different
+// block format and is NOT parsed here — dnsmasq is the OpenWrt/consumer-router
+// default; dhcpd support can be added later behind a format probe.
+type DHCPLeasesSource struct {
+	// leaseFiles are the paths probed in order; the first that exists + reads is
+	// used. Defaults to the conventional dnsmasq locations across distros
+	// (OpenWrt /tmp/dhcp.leases, Debian /var/lib/misc/dnsmasq.leases). Override
+	// via NewDHCPLeasesSource for tests.
+	leaseFiles []string
+	interval   time.Duration
+	svc        *Service
+	logger     *slog.Logger
+
+	mu       sync.Mutex
+	previous map[string]bool // "ip\x00mac" set, last sweep — for diff
+}
+
+// NewDHCPLeasesSource constructs the source. interval is the poll cadence
+// (typically 60s — leases change slowly). leaseFile is optional; when empty the
+// conventional dnsmasq paths are probed.
+func NewDHCPLeasesSource(interval time.Duration, leaseFile string, svc *Service, logger *slog.Logger) *DHCPLeasesSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	files := []string{
+		"/tmp/dhcp.leases",             // OpenWrt / GL.iNet / Asuswrt-merlin (dnsmasq)
+		"/var/lib/misc/dnsmasq.leases", // Debian / Ubuntu / Arch (dnsmasq default)
+		"/var/db/dnsmasq.leases",       // BSD / macOS (dnsmasq)
+	}
+	if leaseFile != "" {
+		files = []string{leaseFile}
+	}
+	return &DHCPLeasesSource{
+		leaseFiles: files,
+		interval:   interval,
+		svc:        svc,
+		logger:     logger,
+		previous:   map[string]bool{},
+	}
+}
+
+// Start launches the poll goroutine (immediate first sweep, then ticks).
+func (s *DHCPLeasesSource) Start(ctx context.Context) {
+	go s.loop(ctx)
+}
+
+func (s *DHCPLeasesSource) loop(ctx context.Context) {
+	s.sweep()
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep reads the lease file, diffs against the previous snapshot, and emits an
+// event for each lease not seen last sweep. A missing/unreadable file (host is
+// not the DHCP server) is logged once-per-call at debug level and tolerated —
+// the source is a no-op there, same as ARPCacheSource on a non-Linux host.
+func (s *DHCPLeasesSource) sweep() {
+	leases, path, err := s.readLeases()
+	if err != nil {
+		s.logger.Debug("discovery: dhcp_leases read failed (host not a DHCP server?)", "error", err)
+		return
+	}
+	if len(leases) == 0 {
+		return
+	}
+
+	current := make(map[string]bool, len(leases))
+	for _, l := range leases {
+		current[l.ip+"\x00"+l.mac] = true
+	}
+
+	s.mu.Lock()
+	prev := s.previous
+	s.previous = current
+	s.mu.Unlock()
+
+	// Emit only newly-seen leases (first sweep: everything is new). Re-emitting
+	// unchanged leases every tick would re-trigger the identify pipeline; the
+	// coordinator dedups against the device DB anyway, but the diff keeps the
+	// event stream quiet in steady state.
+	for _, l := range leases {
+		if prev[l.ip+"\x00"+l.mac] {
+			continue
+		}
+		hints := map[string]string{"discovery_note": "dhcp"}
+		if l.hostname != "" && l.hostname != "*" {
+			// node_hostname is the field the device bridge reads for the device's
+			// name (device_bridge.go resolveHostname). foldHints only sets it when
+			// the identify scan didn't already produce one, so DHCP is a fallback
+			// for hosts that don't answer reverse DNS / SNMP sysName.
+			hints["node_hostname"] = l.hostname
+		}
+		s.svc.Emit(NewHostEvent{
+			IP:     l.ip,
+			MAC:    l.mac,
+			Source: "dhcp_leases",
+			Hints:  hints,
+		})
+	}
+	s.logger.Debug("discovery: dhcp_leases sweep", "path", path, "leases", len(leases), "new", len(leases)-len(prev))
+}
+
+// dhcpLease is one parsed row of the dnsmasq lease file.
+type dhcpLease struct {
+	expiry   int64
+	mac      string
+	ip       string
+	hostname string
+	clientID string
+}
+
+// readLeases opens the first existing lease file in s.leaseFiles and parses it.
+// Returns the chosen path so the caller can attribute log lines.
+func (s *DHCPLeasesSource) readLeases() (leases []dhcpLease, path string, err error) {
+	for _, p := range s.leaseFiles {
+		f, openErr := os.Open(p)
+		if openErr != nil {
+			continue // try next path; common case: file doesn't exist on non-DHCP hosts
+		}
+		path = p
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			// dnsmasq format: <expiry> <mac> <ip> <hostname> <clientid>
+			// duid format has extra columns; tolerate by taking the first 5.
+			fields := strings.Fields(line)
+			if len(fields) < 4 {
+				continue
+			}
+			var exp int64
+			for _, ch := range fields[0] {
+				if ch < '0' || ch > '9' {
+					exp = 0
+					break
+				}
+				exp = exp*10 + int64(ch-'0')
+			}
+			l := dhcpLease{
+				expiry:   exp,
+				mac:      strings.ToLower(fields[1]),
+				ip:       fields[2],
+				hostname: strings.Trim(fields[3], `"`),
+			}
+			if len(fields) >= 5 {
+				l.clientID = fields[4]
+			}
+			// Skip expired leases (expiry in the past). dnsmasq leaves stale rows
+			// until they're reused; an expired lease isn't a current device.
+			if l.expiry != 0 && time.Now().Unix() > l.expiry {
+				continue
+			}
+			if l.ip != "" {
+				leases = append(leases, l)
+			}
+		}
+		f.Close()
+		if sc.Err() != nil {
+			return leases, path, sc.Err()
+		}
+		return leases, path, nil
+	}
+	// No path existed — not an error worth retrying loudly. Caller logs at debug.
+	return nil, "", os.ErrNotExist
+}

--- a/internal/service/scannerv2/discovery/dhcp_leases_test.go
+++ b/internal/service/scannerv2/discovery/dhcp_leases_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeLeaseFile writes the given dnsmasq-format content to a temp file and
+// returns its path.
+func writeLeaseFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "dhcp.leases")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0644))
+	return p
+}
+
+// TestDHCPLeases_ReadLeases confirms the dnsmasq lease format is parsed
+// correctly: 5-field rows, hostname de-quoted, MAC lowercased, and the
+// hostname carried through. Also confirms expired leases are skipped and
+// malformed/short rows are tolerated.
+func TestDHCPLeases_ReadLeases(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).Unix()
+	past := time.Now().Add(-1 * time.Hour).Unix()
+	content := joinLines(
+		// valid, future expiry, with hostname
+		itoa(future)+" AA:BB:CC:DD:EE:FF 192.168.1.50 phone-n13 *",
+		// valid, hostname in quotes (some dnsmasq builds)
+		itoa(future)+" 11:22:33:44:55:66 192.168.1.51 \"my-laptop\" 01:02:03",
+		// expired — must be skipped
+		itoa(past)+" 99:88:77:66:55:44 192.168.1.99 oldhost *",
+		// hostname "*" — valid, just no name (client didn't send one)
+		itoa(future)+" aa:bb:cc:00:00:01 192.168.1.52 * *",
+		// malformed: only 2 fields — must be skipped, not crash
+		"garbage row",
+		// blank line + comment
+		"",
+		"# comment line",
+	)
+	path := writeLeaseFile(t, content)
+	src := NewDHCPLeasesSource(time.Minute, path, nil, nil)
+
+	leases, usedPath, err := src.readLeases()
+	require.NoError(t, err)
+	require.Equal(t, path, usedPath, "should use the explicit path")
+	require.Len(t, leases, 3, "3 valid future leases (expired + malformed skipped)")
+
+	byIP := map[string]dhcpLease{}
+	for _, l := range leases {
+		byIP[l.ip] = l
+	}
+	require.Equal(t, "phone-n13", byIP["192.168.1.50"].hostname)
+	require.Equal(t, "aa:bb:cc:dd:ee:ff", byIP["192.168.1.50"].mac, "MAC lowercased")
+	require.Equal(t, "my-laptop", byIP["192.168.1.51"].hostname, "hostname de-quoted")
+	require.Equal(t, "192.168.1.52", byIP["192.168.1.52"].ip, "ip parsed")
+	require.Equal(t, "*", byIP["192.168.1.52"].hostname, "star hostname preserved")
+	require.NotContains(t, byIP, "192.168.1.99", "expired lease skipped")
+}
+
+// TestDHCPLeases_ReadLeases_ProbesDefaultPaths confirms that when leaseFile is
+// empty, the constructor probes the conventional paths and returns
+// os.ErrNotExist when none exist (the no-op-on-non-DHCP-host case).
+func TestDHCPLeases_ReadLeases_ProbesDefaultPaths(t *testing.T) {
+	// Point all conventional paths at a TempDir they don't exist in by
+	// constructing with an empty string (which forces probing the real default
+	// paths). On the test host none of them should exist, so readLeases returns
+	// ErrNotExist — the documented no-op behavior on a non-DHCP host.
+	src := NewDHCPLeasesSource(time.Minute, "", nil, nil)
+	leases, _, err := src.readLeases()
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Nil(t, leases)
+}
+
+// TestDHCPLeases_Sweep_EmitsOnlyNew confirms the sweep diff: the first sweep
+// emits every lease, the second identical sweep emits nothing (steady state is
+// quiet). Uses the test Service helper + a capturing sink.
+func TestDHCPLeases_Sweep_EmitsOnlyNew(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).Unix()
+	path := writeLeaseFile(t, joinLines(
+		itoa(future)+" aa:bb:cc:dd:ee:01 192.168.1.10 host-a *",
+		itoa(future)+" aa:bb:cc:dd:ee:02 192.168.1.11 host-b *",
+	))
+	svc, sink, _, _ := newTestService(t, false)
+	sink.isNew = true // so Apply records every event (handle reaches sink)
+	src := NewDHCPLeasesSource(time.Minute, path, svc, nil)
+
+	src.sweep()
+	time.Sleep(150 * time.Millisecond) // drain Emit → handle → sink
+	require.Equal(t, 2, sink.count(), "first sweep emits both leases")
+	// hostnames folded into the synthesized report's Fields via the dhcp hint.
+	ips := map[string]bool{}
+	for _, r := range sink.snapshot() {
+		ips[r.IP] = true
+	}
+	require.True(t, ips["192.168.1.10"])
+	require.True(t, ips["192.168.1.11"])
+
+	// Second sweep — same file, nothing new.
+	nBefore := sink.count()
+	src.sweep()
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, nBefore, sink.count(), "second identical sweep emits nothing")
+}
+
+// joinLines joins lines with newlines (helper to keep the table-driven content
+// readable without trailing-newline ambiguity).
+func joinLines(lines ...string) string {
+	out := ""
+	for _, l := range lines {
+		out += l + "\n"
+	}
+	return out
+}
+
+// itoa is a tiny int→string to avoid importing strconv just for the test
+// lease-expiry timestamps.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## What

Adds the **two highest-value router-only discovery signals** from the router-agent analysis (private doc §3.2). Both land in the **shared `discovery/` package** so all three deployment forms (center / agent / **router-center form C**) get them — not agent-specific, per the 'center must also deploy to a router' requirement.

### `dhcp_leases` (`discovery/dhcp_leases.go`)
Reads the local DHCP server's lease table (dnsmasq `/tmp/dhcp.leases` on OpenWrt, `/var/lib/misc/dnsmasq.leases` on Debian — all three conventional paths probed). The gateway is the DHCP authority, so its lease table is the **authoritative hostname↔MAC↔IP map** — covering devices (sleeping IoT, firewalled hosts) that never answer SNMP/ICMP/rDNS. Hostname arrives as a first-class field, folded via the existing `Hints['node_hostname']` → `foldHints` path (only fills when the identify scan didn't produce one → fallback, not override). Skips expired leases, malformed rows, `*` hostnames.

### `conntrack` (`discovery/conntrack.go`)
Reads `/proc/net/nf_conntrack` and emits the LAN-side endpoint of every `ESTABLISHED`/`[ASSURED]` flow — the NAT choke point's **"who is talking RIGHT NOW"** view. Liveness + discovery for hosts that don't answer active probes but maintain outbound flows. Filters to the configured LAN CIDR (so it doesn't emit a row per public IP a device talks to). Handles both directions + the conntrack bracketed-token quirk (`[ASSURED]` for UDP flows that have no state field, vs bare `ESTABLISHED` for TCP).

### Graceful no-op on non-router hosts
Both read files only a router/gateway has. On a non-DHCP host (no lease file) or without `nf_conntrack` loaded, each sweep logs once at DEBUG and returns — never errors, never crashes. Same pattern as `ARPCacheSource` on a non-Linux host.

## Wiring

- New `ScannerConfig.Discovery.DHCPLeases` + `.Conntrack` toggles (**default false** — opt-in, only useful on a router)
- Wired in both `routes.go` (center) and `cmd/agent/main.go` (agent), reading `network.cidr` for conntrack's LAN filter
- `config.example.yaml` documents both with the 'enable on a router' guidance

## P0 scope note

conntrack here is treated as a **discovery + liveness signal** (emit the LAN endpoint of active flows). The richer per-flow topology (src+dst+port+bytes records, "device A talks to service B") needs a new persistence surface and is **deferred** — this host-event path is the high-value, low-risk first cut all three deployment forms get for free.

## Tests (7 new, all pass under `-race`)

| Test | Covers |
|---|---|
| `TestDHCPLeases_ReadLeases` | dnsmasq format parse, expiry skip, malformed-row tolerance, MAC lowercase, hostname de-quote |
| `TestDHCPLeases_ReadLeases_ProbesDefaultPaths` | no-op when no lease file (non-DHCP host) |
| `TestDHCPLeases_Sweep_EmitsOnlyNew` | sweep diff (first sweep emits all, second identical sweep emits nothing) |
| `TestConntrack_ReadActiveLANHosts` | LAN-endpoint extraction, CIDR filter, TIME_WAIT skip, both directions |
| `TestConntrack_InvalidCIDR_EmitsNothing` | misconfigured CIDR degrades to no-op (no panic) |
| `TestConntrack_MissingFile_Tolerated` | no-op when `/proc/net/nf_conntrack` absent |
| `TestConntrack_TokenParsing` | helper contract (documents the `[ASSURED]` bracketed-token quirk) |

## Real-hardware verification (192.168.62.174 agent)

With all 5 sources enabled, startup logs:
```
agent passive discovery ready interval=1m0s sources=[router_arp arp_cache multicast dhcp_leases conntrack] trigger_identify=true
```
Agent stable (RSS 165MB, 1m+ uptime), no errors. On the test VM (**not** a router: no dnsmasq lease file, no readable `/proc/net/nf_conntrack`) both new sources no-op cleanly — graceful degradation confirmed, exactly the designed behavior.

## Out of scope (separate PRs)

- The other 2 Tier-1 signals: `hostapd` (WiFi STA associations) + `dns_log` (passive DNS fingerprint) — PR 7
- Form C: center binary OpenWrt-ready — PR 8

🤖 Generated with [ZCode](https://zcode.dev)