### PR TITLE
feat(discovery): hostapd + dns_log Tier-1 router sources (Phase B complete)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -235,6 +235,20 @@ func main() {
 			conntrackSrc.Start(discCtx)
 			activeSources = append(activeSources, "conntrack")
 		}
+		// hostapd: Tier-1 router/AP signal — WiFi STA associations (signal dBm,
+		// connect time, SSID). hostapd ctrl socket first, iw station dump fallback.
+		if cfg.Scanner.Discovery.Hostapd.Enabled {
+			hostapdSrc := scannerv2discovery.NewHostapdSource(cfg.Scanner.Discovery.Hostapd.Interfaces, interval, discSvc, slog.Default())
+			hostapdSrc.Start(discCtx)
+			activeSources = append(activeSources, "hostapd")
+		}
+		// dns_log: Tier-1 router signal — tails the dnsmasq query log for passive
+		// DNS fingerprinting (devices that block inbound probes still do DNS).
+		if cfg.Scanner.Discovery.DNSLog.Enabled {
+			dnsLogSrc := scannerv2discovery.NewDNSLogSource(interval, cfg.Scanner.Discovery.DNSLog.Path, discSvc, slog.Default())
+			dnsLogSrc.Start(discCtx)
+			activeSources = append(activeSources, "dns_log")
+		}
 		// arp_scan: WITH_ARPSCAN build only; NewARPScanSource returns nil
 		// otherwise (or without CAP_NET_RAW) — nil guard skips it silently.
 		if cfg.Scanner.Discovery.ARPScan.Enabled {

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -197,6 +197,24 @@ scanner:
     # nf_conntrack module isn't loaded. Enable on a router/gateway.
     conntrack:
       enabled: false
+    # hostapd: Tier-1 ROUTER/AP signal. Enumerates the WiFi STAs associated to
+    # the local AP via the hostapd control socket (/var/run/hostapd/<phy>),
+    # falling back to `iw station dump`. Captures signal dBm / connect time /
+    # SSID — gold for device tracking, unavailable to a wired host. interfaces
+    # lists the wlan names to poll (e.g. ["wlan0"]); empty = autodetect. No-op
+    # on a host without WiFi/hostapd/iw.
+    hostapd:
+      enabled: false
+      interfaces: []  # e.g. ["wlan0", "wlan1"]; empty probes /var/run/hostapd/*
+    # dns_log: Tier-1 ROUTER signal. Tails the dnsmasq query log (--log-queries
+    # output) and emits each querying host + the domain — a powerful passive
+    # fingerprint (devices that block inbound probes still do outbound DNS).
+    # Operator MUST enable dnsmasq query logging (UCI: `uci set
+    # dhcp.@dnsmasq[0].logqueries=1`). path overrides the log file location;
+    # empty probes the conventional paths. No-op when no log file is found.
+    dns_log:
+      enabled: false
+      path: ""  # e.g. /var/log/dnsmasq.log; empty probes conventional paths
   # ── Agent lease (distributed model) ───────────────────────────────────────
   # Agent-managed devices (networks with agent_id set) are kept online by their
   # agent's reports — the center does NOT probe them locally (cross-subnet ICMP

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -364,6 +364,20 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			conntrackSrc.Start(discCtx)
 			activeSources = append(activeSources, "conntrack")
 		}
+		// hostapd: Tier-1 router/AP signal — WiFi STA associations (signal dBm,
+		// connect time, SSID). hostapd ctrl socket first, iw station dump fallback.
+		if cfg.Scanner.Discovery.Hostapd.Enabled {
+			hostapdSrc := scannerv2discovery.NewHostapdSource(cfg.Scanner.Discovery.Hostapd.Interfaces, interval, discSvc, slog.Default())
+			hostapdSrc.Start(discCtx)
+			activeSources = append(activeSources, "hostapd")
+		}
+		// dns_log: Tier-1 router signal — tails the dnsmasq query log for passive
+		// DNS fingerprinting (devices that block inbound probes still do DNS).
+		if cfg.Scanner.Discovery.DNSLog.Enabled {
+			dnsLogSrc := scannerv2discovery.NewDNSLogSource(interval, cfg.Scanner.Discovery.DNSLog.Path, discSvc, slog.Default())
+			dnsLogSrc.Start(discCtx)
+			activeSources = append(activeSources, "dns_log")
+		}
 		// arp_scan: active ARP who-has sweep of the whole network CIDR. The only
 		// source that covers the entire broadcast domain with NO router access
 		// (every host must answer ARP — even firewalled ones). Needs the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -403,6 +403,18 @@ type DiscoveryConfig struct {
 	// it doesn't emit a row per public IP a device talks to. No-op when the
 	// nf_conntrack module isn't loaded or /proc/net/nf_conntrack is absent.
 	Conntrack DiscoverySourceToggle `koanf:"conntrack"`
+	// Hostapd enumerates the WiFi STAs associated to the local AP(s) via the
+	// hostapd control socket (/var/run/hostapd/<phy>), falling back to
+	// `iw station dump`. A Tier-1 router/AP-only signal: signal dBm, connect
+	// time, SSID are GOLD for device tracking and completely unavailable to a
+	// wired host-based scanner. No-op on a host without WiFi / hostapd / iw.
+	Hostapd HostapdDiscoveryConfig `koanf:"hostapd"`
+	// DNSLog tails a dnsmasq query log (--log-queries output) and emits the
+	// querying host per DNS query — a powerful passive fingerprint (devices that
+	// block all inbound probes still make outbound DNS). A Tier-1 router signal:
+	// the gateway is typically the LAN's recursive resolver. No-op when dnsmasq
+	// query logging isn't configured (no log file at the conventional paths).
+	DNSLog DNSLogDiscoveryConfig `koanf:"dns_log"`
 	// LLDPInterfaces is the list of NIC names for the raw-frame LLDPDU listener
 	// (ethertype 0x88cc). Empty = all UP non-loopback interfaces. Only active in
 	// WITH_LLDP builds (needs CAP_NET_RAW); no-op in the default build.
@@ -412,6 +424,25 @@ type DiscoveryConfig struct {
 // DiscoverySourceToggle is the per-source on/off switch for DiscoveryConfig.
 type DiscoverySourceToggle struct {
 	Enabled bool `koanf:"enabled"`
+}
+
+// HostapdDiscoveryConfig configures the WiFi STA enumeration source. Interfaces
+// is the list of wlan names to poll (e.g. ["wlan0", "wlan1"]); when empty the
+// source autodetects (probes /var/run/hostapd/* sockets, falls back to "wlan0"
+// for the iw station-dump path).
+type HostapdDiscoveryConfig struct {
+	Enabled    bool     `koanf:"enabled"`
+	Interfaces []string `koanf:"interfaces"`
+}
+
+// DNSLogDiscoveryConfig configures the dnsmasq query-log tail source. Path
+// overrides the log file location (dnsmasq --log-facility output); when empty
+// the source probes the conventional paths (/var/log/dnsmasq.log, /tmp/dnsmasq.log,
+// syslog). The operator must enable dnsmasq query logging (UCI:
+// `uci set dhcp.@dnsmasq[0].logqueries=1`).
+type DNSLogDiscoveryConfig struct {
+	Enabled bool   `koanf:"enabled"`
+	Path    string `koanf:"path"`
 }
 
 type PipelineDefaultsConfig struct {

--- a/internal/service/scannerv2/discovery/dns_log.go
+++ b/internal/service/scannerv2/discovery/dns_log.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DNSLogSource tails a dnsmasq query log (dnsmasq --log-queries output) and
+// emits a NewHostEvent for each query a LAN device makes. It is a router-
+// resident signal: the gateway is typically the LAN's recursive resolver, so
+// its DNS log is the authoritative "what is each device asking for" view — a
+// powerful passive fingerprint (a device querying ntp.android.com is Android;
+// time.apple.com is Apple; a sudden new C2 domain is behavior of interest).
+//
+// Why it matters (Tier-1 router-only signal — see
+// docs/private/architecture-debt-and-openwrt-2026-07-27.md §3.2):
+//
+//   - Complements ACTIVE identification (SNMP/RTSP/ONVIF banners): DNS reveals
+//     device identity + behavior without sending a single probe packet. Devices
+//     that block all inbound probes still make outbound DNS.
+//   - The queried domain is a strong OS/vendor hint (the existing fingerprint
+//     corpus could be extended with a DNS-domain→vendor map in a follow-up).
+//
+// Operator setup: dnsmasq must run with --log-queries (UCI:
+// `uci set dhcp.@dnsmasq[0].logqueries=1`) and write to a file (either via
+// syslog filtering or --log-facility=<path>). The source reads whichever path
+// the operator points it at (scanner.discovery.dns_log.path); when empty it
+// probes the conventional locations. Without that setup the source no-ops
+// (file absent → debug log + skip), the same graceful pattern as the other
+// router sources.
+//
+// Implementation: tail-F semantics over polling. Each sweep seeks to the last
+// read offset, reads to EOF, parses query lines, emits events, and remembers
+// the new offset. If the file shrank (rotated/truncated) the offset resets to
+// 0 and reading starts fresh. This avoids a long-running subprocess (no
+// `tail`/`logread` dependency) and slots into the same interval-poll loop the
+// other sources use.
+//
+// P0 scope: emits the QUERYING host (IP) as a sighting + carries the queried
+// domain as a hint (Hints["dns_query"]). Domain→vendor enrichment is a follow-
+// up (needs a new YAML table + a classifier hook); the host-event + raw hint
+// here is the high-value, low-risk first cut all three deployment forms get.
+type DNSLogSource struct {
+	logFiles []string // paths probed in order; first that exists is tailed
+	interval time.Duration
+	svc      *Service
+	logger   *slog.Logger
+
+	mu     sync.Mutex
+	offset map[string]int64 // path → last-read byte offset (per tailed file)
+}
+
+// NewDNSLogSource constructs the source. interval is the poll cadence (60s).
+// logFile is optional; when empty the conventional dnsmasq log paths are probed.
+func NewDNSLogSource(interval time.Duration, logFile string, svc *Service, logger *slog.Logger) *DNSLogSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	files := []string{
+		"/var/log/dnsmasq.log", // explicit --log-facility (common)
+		"/tmp/dnsmasq.log",     // OpenWrt ramdisk (often via logread redirect)
+		"/var/log/messages",    // syslog fallback (when dnsmasq logs to syslog)
+		"/var/log/syslog",      // Debian rsyslog default
+	}
+	if logFile != "" {
+		files = []string{logFile}
+	}
+	return &DNSLogSource{
+		logFiles: files,
+		interval: interval,
+		svc:      svc,
+		logger:   logger,
+		offset:   map[string]int64{},
+	}
+}
+
+// Start launches the poll goroutine (immediate first sweep, then ticks).
+func (s *DNSLogSource) Start(ctx context.Context) {
+	go s.loop(ctx)
+}
+
+func (s *DNSLogSource) loop(ctx context.Context) {
+	s.sweep()
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep tails each candidate log file from the last-read offset, parses dnsmasq
+// query lines, and emits an event per (querier IP, domain). A missing/unreadable
+// file is logged once-per-call at debug and tolerated.
+func (s *DNSLogSource) sweep() {
+	for _, path := range s.logFiles {
+		s.tailFile(path)
+	}
+}
+
+// tailFile reads new bytes from one log file (since the last sweep) and parses
+// them. Separate from sweep() so the offset bookkeeping is per-file.
+func (s *DNSLogSource) tailFile(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return // file absent (host not running dnsmasq query logging) — skip
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		s.logger.Debug("discovery: dns_log open failed", "path", path, "error", err)
+		return
+	}
+	defer f.Close()
+
+	s.mu.Lock()
+	prevOff := s.offset[path]
+	s.mu.Unlock()
+
+	// If the file shrank since last read (rotated/truncated), restart from the
+	// beginning; otherwise seek to where we left off. Don't tail from offset 0 on
+	// the very first sweep of a huge existing log — start at EOF to avoid replaying
+	// history (only NEW queries going forward are interesting).
+	curSize := info.Size()
+	if prevOff == 0 {
+		// First sight of this file: skip existing content, tail from EOF.
+		prevOff = curSize
+	}
+	if curSize < prevOff {
+		// Rotation/truncation: the file is smaller than our last offset. Restart
+		// from the beginning rather than seeking past EOF.
+		prevOff = 0
+	}
+	if _, err := f.Seek(prevOff, 0); err != nil {
+		s.logger.Debug("discovery: dns_log seek failed", "path", path, "error", err)
+		return
+	}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // syslog lines can be long
+	newOff := prevOff
+	count := 0
+	for sc.Scan() {
+		line := sc.Text()
+		// Track bytes read (line + newline) so the next sweep resumes correctly.
+		newOff += int64(len(line)) + 1
+		ip, domain := parseDnsmasqQuery(line)
+		if ip == "" || domain == "" {
+			continue
+		}
+		s.svc.Emit(NewHostEvent{
+			IP:     ip,
+			Source: "dns_log",
+			Hints: map[string]string{
+				"discovery_note": "dns",
+				"dns_query":      domain,
+			},
+		})
+		count++
+	}
+	if err := sc.Err(); err != nil {
+		s.logger.Debug("discovery: dns_log scan failed", "path", path, "error", err)
+		// Still update offset to where we got — partial progress is fine.
+	}
+	// Always persist the resume offset. The first-sweep EOF case (prevOff reset
+	// to curSize, zero lines read) MUST record curSize so the next sweep resumes
+	// at EOF rather than replaying the whole file every sweep.
+	s.mu.Lock()
+	s.offset[path] = newOff
+	s.mu.Unlock()
+	if count > 0 {
+		s.logger.Debug("discovery: dns_log sweep", "path", path, "queries", count)
+	}
+}
+
+// parseDnsmasqQuery extracts the (querier IP, domain) from a dnsmasq query log
+// line. Returns ("", "") for non-query lines (forwarded/reply/config lines,
+// unrelated syslog noise). Recognizes the two common line shapes dnsmasq emits
+// with --log-queries:
+//
+//	< preamble > dnsmasq[<pid>]: query[<type>] <domain> from <ip>
+//	< preamble > dnsmasq[<pid>]: <type> <domain> is <ip>          (config/static)
+//
+// Only the first (an actual client query) reveals the *querying* device — that's
+// what we emit. "is" lines tell us a name→ip mapping but not who asked.
+func parseDnsmasqQuery(line string) (ip, domain string) {
+	// Must be a dnsmasq line.
+	idx := strings.Index(line, "dnsmasq")
+	if idx < 0 {
+		return "", ""
+	}
+	rest := line[idx:]
+	// Must be a "query[...]" line (the only shape that carries "... from <ip>").
+	qIdx := strings.Index(rest, "query[")
+	if qIdx < 0 {
+		return "", ""
+	}
+	rest = rest[qIdx:]
+	// rest looks like: query[A] example.com from 192.168.1.50
+	// Find the closing bracket, then split the remainder on " from ".
+	closeBracket := strings.IndexByte(rest, ']')
+	if closeBracket < 0 {
+		return "", ""
+	}
+	rest = strings.TrimSpace(rest[closeBracket+1:])
+	fromIdx := strings.LastIndex(rest, " from ")
+	if fromIdx < 0 {
+		return "", ""
+	}
+	domain = strings.TrimSpace(rest[:fromIdx])
+	ip = strings.TrimSpace(rest[fromIdx+len(" from "):])
+	// Trim a trailing port/pid if present (defensive — dnsmasq doesn't emit one,
+	// but a syslog relay might append junk).
+	if sp := strings.IndexByte(ip, ' '); sp >= 0 {
+		ip = ip[:sp]
+	}
+	if domain == "" || ip == "" {
+		return "", ""
+	}
+	// Reject obviously-non-IP queriers (sometimes dnsmasq logs "from <iface>" for
+	// locally-originated queries — not a host sighting).
+	if !looksLikeIPv4(ip) {
+		return "", ""
+	}
+	return ip, domain
+}
+
+// looksLikeIPv4 is a cheap a.b.c.d validator (no port, 4 octets). Used to reject
+// "query ... from eth0" lines (interface, not a host) without pulling in net.IP.
+func looksLikeIPv4(s string) bool {
+	octets := 0
+	cur := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '.' {
+			if octets >= 3 || cur > 255 {
+				return false
+			}
+			octets++
+			cur = 0
+			continue
+		}
+		if c < '0' || c > '9' {
+			return false
+		}
+		cur = cur*10 + int(c-'0')
+		if cur > 255 {
+			return false
+		}
+	}
+	return octets == 3
+}
+
+// String returns a debug label for the source (which file(s) it's probing).
+// Unused for now but handy for the status endpoint follow-up.
+func (s *DNSLogSource) String() string { return fmt.Sprintf("dns_log(paths=%v)", s.logFiles) }

--- a/internal/service/scannerv2/discovery/hostapd.go
+++ b/internal/service/scannerv2/discovery/hostapd.go
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HostapdSource enumerates the WiFi stations (STAs) currently associated to the
+// local AP(s) and emits a NewHostEvent per STA. It is a router-resident signal:
+// only the WiFi AP itself (a router running hostapd) sees the association list
+// — signal strength, link rate, SSID, and connect time are GOLD for device
+// tracking (room-level location via signal, WiFi device identification, rogue-
+// AP detection) and completely unavailable to a wired host-based scanner.
+//
+// Why it matters (Tier-1 router-only signal — see
+// docs/private/architecture-debt-and-openwrt-2026-07-27.md §3.2):
+//
+//   - Sees WiFi-only devices that may never answer L3 probes (smart-home
+//     sensors, sleep-aggressive phones, guests on the WiFi-only segment).
+//   - MAC-authoritative at association time → feeds the device-bridge's MAC-
+//     primary identity path even before any IP-level probe runs.
+//
+// Two backends, in priority order (per the design decision — both supported,
+// hostapd first):
+//
+//  1. hostapd_ctrl socket (preferred). Opens the hostapd control interface
+//     (a UNIX datagram socket at /var/run/hostapd/<phy>, the OpenWrt/consumer-
+//     router convention) and sends STA-FIRST / STA-NEXT to walk the association
+//     table. Most authoritative — gets signal dBm, connect time, RX/TX bytes,
+//     SSID — and has zero subprocess overhead.
+//
+//  2. `iw station dump` fallback. Shells `iw dev <wlan> station dump` (iw ships
+//     with every wireless host including OpenWrt/Debian/Arch) and parses the
+//     human-readable output. Slightly less detail (no SSID/connect-time), and
+//     forks a subprocess per sweep, but works without a readable hostapd ctrl
+//     socket (e.g. when the agent runs alongside an AP it doesn't own the
+//     hostapd process of, or when hostapd ctrl_interface is disabled).
+//
+// The source tries hostapd first per sweep; on any error (socket missing,
+// permission denied, no STAs) it falls back to iw for the same interfaces.
+// When neither yields anything (no WiFi, no hostapd, no iw) it no-ops — same
+// graceful pattern as the other router sources.
+//
+// Operator config: scanner.discovery.hostapd.interfaces lists the wlan names to
+// poll (e.g. ["wlan0"]). When empty the source probes the conventional
+// /var/run/hostapd/* sockets + a small default iface list (wlan0).
+type HostapdSource struct {
+	interfaces []string // wlan names, e.g. ["wlan0"]; empty = autodetect
+	ctrlDir    string   // hostapd ctrl_interface dir (default /var/run/hostapd)
+	interval   time.Duration
+	svc        *Service
+	logger     *slog.Logger
+
+	mu       sync.Mutex
+	previous map[string]bool // mac set, last sweep — for diff
+}
+
+// NewHostapdSource constructs the source. interfaces is the wlan name list;
+// when empty the source autodetects at sweep time (probes /var/run/hostapd/* +
+// falls back to "wlan0" for iw). ctrlDir overrides the hostapd ctrl_interface
+// path (rarely needed; OpenWrt/Asuswrt use the default /var/run/hostapd).
+func NewHostapdSource(interfaces []string, interval time.Duration, svc *Service, logger *slog.Logger) *HostapdSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if len(interfaces) == 0 {
+		// Default iface list for the iw fallback. hostapd-ctrl path discovers
+		// sockets by glob, so this only affects iw.
+		interfaces = []string{"wlan0"}
+	}
+	return &HostapdSource{
+		interfaces: interfaces,
+		ctrlDir:    "/var/run/hostapd",
+		interval:   interval,
+		svc:        svc,
+		logger:     logger,
+		previous:   map[string]bool{},
+	}
+}
+
+// Start launches the poll goroutine (immediate first sweep, then ticks).
+func (s *HostapdSource) Start(ctx context.Context) {
+	go s.loop(ctx)
+}
+
+func (s *HostapdSource) loop(ctx context.Context) {
+	s.sweep()
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep enumerates associated STAs via hostapd-ctrl first, falling back to iw
+// when hostapd yields nothing. Diffs against the previous snapshot and emits an
+// event per newly-seen MAC.
+func (s *HostapdSource) sweep() {
+	stas := s.readViaHostapdCtrl()
+	if len(stas) == 0 {
+		// hostapd didn't yield anything (no sockets, no perms, or no STA on those
+		// sockets) — try iw station dump as the fallback. Either backend failing
+		// is normal on a non-router host; both failing is the no-op case.
+		stas = s.readViaIW()
+	}
+	if len(stas) == 0 {
+		return
+	}
+
+	current := make(map[string]bool, len(stas))
+	for mac := range stas {
+		current[mac] = true
+	}
+
+	s.mu.Lock()
+	prev := s.previous
+	s.previous = current
+	s.mu.Unlock()
+
+	for mac, info := range stas {
+		if prev[mac] {
+			continue
+		}
+		hints := map[string]string{"discovery_note": "wifi_assoc"}
+		if info.signal != "" {
+			hints["wifi_signal_dbm"] = info.signal
+		}
+		if info.ssid != "" {
+			hints["wifi_ssid"] = info.ssid
+		}
+		if info.connectTime != "" {
+			hints["wifi_connected_secs"] = info.connectTime
+		}
+		s.svc.Emit(NewHostEvent{
+			MAC:    mac,
+			Source: "hostapd",
+			// No IP: WiFi association is L2. The device bridge reconciles by MAC
+			// (the MAC-primary identity path); an ARP/DHCP/scan sighting of the
+			// same MAC fills the IP. A MAC-only event with no prior IP won't be
+			// emitted by handle() unless it resolves to a known host — which is
+			// correct (we don't fabricate a device for a MAC with no IP).
+			Hints: hints,
+		})
+	}
+}
+
+// staInfo holds the optional per-STA details each backend may capture. Only MAC
+// is required; the rest are best-effort enrichment hints.
+type staInfo struct {
+	mac         string
+	signal      string // dBm, e.g. "-42"
+	ssid        string
+	connectTime string // seconds connected
+}
+
+// readViaHostapdCtrl walks the hostapd control sockets in s.ctrlDir and emits
+// one staInfo per associated station. Returns nil/empty on any error (caller
+// falls back to iw). Uses the hostapd_cli protocol over a connected UNIX
+// datagram socket: ATTACH (optional), STA-FIRST, then STA-NEXT until "FAIL".
+func (s *HostapdSource) readViaHostapdCtrl() map[string]staInfo {
+	out := map[string]staInfo{}
+	// Glob the ctrlDir for socket files — each phy/AP has one (e.g.
+	// /var/run/hostapd/wlan0, /var/run/hostapd-phy1.conf on some builds).
+	patterns := []string{s.ctrlDir + "/*"}
+	for _, pat := range patterns {
+		matches, _ := ctrlSocketGlob(pat)
+		for _, sockPath := range matches {
+			stas := s.queryHostapdSocket(sockPath)
+			for mac, info := range stas {
+				out[mac] = info
+			}
+		}
+	}
+	return out
+}
+
+// queryHostapdSocket opens ONE hostapd ctrl socket, sends STA-FIRST/STA-NEXT,
+// and returns the parsed stations. Errors are tolerated (logged at debug) and
+// return empty so the caller can try the next socket or fall back to iw.
+func (s *HostapdSource) queryHostapdSocket(sockPath string) map[string]staInfo {
+	// Use a local datagram socket pair so hostapd's reply has somewhere to go
+	// (the ctrl protocol requires the client to bind its own datagram socket).
+	conn, err := net.Dial("unixgram", sockPath)
+	if err != nil {
+		s.logger.Debug("discovery: hostapd ctrl socket dial failed", "socket", sockPath, "error", err)
+		return nil
+	}
+	defer conn.Close()
+	// Set a short read deadline so a non-responsive socket doesn't stall the
+	// sweep loop. hostapd responds to STA-* in milliseconds.
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		return nil
+	}
+
+	stas := map[string]staInfo{}
+	// STA-FIRST → first station; then STA-NEXT <mac> → next after that, until FAIL.
+	cmd := "STA-FIRST"
+	for {
+		if _, err := conn.Write([]byte(cmd)); err != nil {
+			return stas
+		}
+		buf := make([]byte, 4096)
+		n, err := conn.Read(buf)
+		if err != nil || n == 0 {
+			return stas
+		}
+		resp := string(buf[:n])
+		if strings.HasPrefix(resp, "FAIL") || resp == "" {
+			return stas // no more stations (or none at all on STA-FIRST)
+		}
+		info := parseHostapdSTA(resp)
+		if info.mac != "" {
+			stas[info.mac] = info
+			cmd = "STA-NEXT " + info.mac
+		} else {
+			return stas
+		}
+	}
+}
+
+// parseHostapdSTA parses the key=value lines of one hostapd STA-FIRST/STA-NEXT
+// reply. Each line is "key=value"; the keys we care about: addr, signal,
+// connected_time, ssid.
+func parseHostapdSTA(resp string) staInfo {
+	info := staInfo{}
+	for _, line := range strings.Split(resp, "\n") {
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		k, v := line[:eq], line[eq+1:]
+		switch k {
+		case "addr":
+			info.mac = strings.ToLower(v)
+		case "signal":
+			info.signal = v
+		case "connected_time":
+			info.connectTime = v
+		case "ssid":
+			info.ssid = v
+		}
+	}
+	return info
+}
+
+// readViaIW runs `iw dev <iface> station dump` for each configured interface and
+// parses the human-readable blocks (one per STA, MAC in the header line, key=
+// value details indented).
+func (s *HostapdSource) readViaIW() map[string]staInfo {
+	out := map[string]staInfo{}
+	for _, iface := range s.interfaces {
+		stas := s.queryIW(iface)
+		for mac, info := range stas {
+			out[mac] = info
+		}
+	}
+	return out
+}
+
+// queryIW runs iw once for one interface and parses the station dump. Errors are
+// tolerated (iw absent / iface down / not root) and return empty.
+func (s *HostapdSource) queryIW(iface string) map[string]staInfo {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "iw", "dev", iface, "station", "dump")
+	out, err := cmd.Output()
+	if err != nil {
+		s.logger.Debug("discovery: iw station dump failed", "iface", iface, "error", err)
+		return nil
+	}
+	return parseIWStationDump(string(out))
+}
+
+// parseIWStationDump parses `iw dev X station dump` output into a mac→staInfo
+// map. Format (one block per station, key=value lines indented):
+//
+//	Station aa:bb:cc:dd:ee:ff (on wlan0)
+//	        inactive time:    120 ms
+//	        rx bytes:         12345
+//	        signal:           -42 dBm
+//	        ...
+func parseIWStationDump(out string) map[string]staInfo {
+	stas := map[string]staInfo{}
+	var cur *staInfo
+	flush := func() {
+		if cur != nil && cur.mac != "" {
+			stas[cur.mac] = *cur
+		}
+		cur = nil
+	}
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "Station ") {
+			flush()
+			// "Station <mac> (on <iface>)"
+			mac := extractIWStationMAC(line)
+			if mac != "" {
+				cur = &staInfo{mac: mac}
+			}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		// Indented "key:           value" detail lines.
+		trim := strings.TrimSpace(line)
+		if v := iwValue(trim, "signal:"); v != "" {
+			// "signal:   -42 dBm" → keep "-42"
+			cur.signal = strings.TrimSpace(strings.TrimSuffix(v, "dBm"))
+		}
+	}
+	flush()
+	return stas
+}
+
+// extractIWStationMAC pulls the MAC out of a "Station <mac> (on <iface>)" line.
+func extractIWStationMAC(line string) string {
+	const prefix = "Station "
+	if !strings.HasPrefix(line, prefix) {
+		return ""
+	}
+	rest := line[len(prefix):]
+	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
+		rest = rest[:sp]
+	}
+	return strings.ToLower(rest)
+}
+
+// iwValue returns the value portion of a "key:   value" line when line starts
+// with key; "" otherwise.
+func iwValue(line, key string) string {
+	if !strings.HasPrefix(line, key) {
+		return ""
+	}
+	return strings.TrimSpace(line[len(key):])
+}
+
+// ctrlSocketGlob lists hostapd ctrl socket paths matching the glob pattern,
+// skipping obvious non-sockets (directories, the global ctrl dir itself). Kept
+// minimal — on a real AP the dir contains one datagram socket per phy.
+func ctrlSocketGlob(pattern string) ([]string, error) {
+	// filepath.Glob lists names; the caller's Dial rejects non-sockets.
+	return filepath.Glob(pattern)
+}
+
+// String returns a debug label for the source.
+func (s *HostapdSource) String() string {
+	return fmt.Sprintf("hostapd(interfaces=%v,ctrl=%s)", s.interfaces, s.ctrlDir)
+}

--- a/internal/service/scannerv2/discovery/hostapd_dns_test.go
+++ b/internal/service/scannerv2/discovery/hostapd_dns_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ─── DNS log parsing ────────────────────────────────────────────────────────
+
+func TestParseDnsmasqQuery_ClientQuery(t *testing.T) {
+	// The dnsmasq --log-queries line shape for an actual client query.
+	line := "Jan  1 12:00:00 router dnsmasq[1234]: query[A] example.com from 192.168.1.50"
+	ip, domain := parseDnsmasqQuery(line)
+	require.Equal(t, "192.168.1.50", ip)
+	require.Equal(t, "example.com", domain)
+}
+
+func TestParseDnsmasqQuery_ReplyLineRejected(t *testing.T) {
+	// A reply/forwarded line carries a name→ip mapping but NOT a querying host —
+	// must NOT be emitted (no "query[...]" + "from <ip>" shape).
+	line := "Jan  1 12:00:00 router dnsmasq[1234]: config example.com is 192.168.1.10"
+	ip, domain := parseDnsmasqQuery(line)
+	require.Empty(t, ip)
+	require.Empty(t, domain)
+}
+
+func TestParseDnsmasqQuery_InterfaceRejected(t *testing.T) {
+	// dnsmasq logs locally-originated queries as "from <iface>" — not a host.
+	line := "Jan  1 12:00:00 router dnsmasq[1234]: query[A] localhost from lo"
+	ip, domain := parseDnsmasqQuery(line)
+	require.Empty(t, ip, "'from lo' is an interface, not a host")
+	require.Empty(t, domain)
+}
+
+func TestParseDnsmasqQuery_NonDNSMASQLineRejected(t *testing.T) {
+	// Unrelated syslog noise must not accidentally match.
+	ip, domain := parseDnsmasqQuery("Jan 1 12:00:00 router sshd[5533]: Accepted publickey for root")
+	require.Empty(t, ip)
+	require.Empty(t, domain)
+}
+
+func TestLooksLikeIPv4(t *testing.T) {
+	require.True(t, looksLikeIPv4("192.168.1.50"))
+	require.True(t, looksLikeIPv4("10.0.0.1"))
+	require.True(t, looksLikeIPv4("255.255.255.255"))
+	require.False(t, looksLikeIPv4("lo"), "interface name")
+	require.False(t, looksLikeIPv4("192.168.1.500"), "octet > 255")
+	require.False(t, looksLikeIPv4("192.168.1"), "3 octets only")
+	require.False(t, looksLikeIPv4("fe80::1"), "IPv6 not supported here")
+	require.False(t, looksLikeIPv4("192.168.1.50.5"), "5 octets")
+}
+
+// TestDNSLog_TailFromEOFOnFirstSight confirms the source does NOT replay
+// existing log history on the first sweep (it tails from EOF), but DOES emit
+// queries that are appended AFTER the first sweep (true append, not rewrite).
+func TestDNSLog_TailFromEOFOnFirstSight(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dnsmasq.log")
+	// Pre-existing content (history) — must be skipped on first sight.
+	require.NoError(t, os.WriteFile(path, []byte(
+		"Jan 1 00:00:00 r dnsmasq[1]: query[A] old.example.com from 192.168.1.99\n"), 0644))
+	svc, sink, _, _ := newTestService(t, false)
+	sink.isNew = true
+	src := NewDNSLogSource(time.Minute, path, svc, nil)
+
+	src.sweep() // first sweep: tail from EOF, no events from pre-existing content
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, sink.count(), "pre-existing log history not replayed")
+
+	// Append a new query AFTER the first sweep → must be emitted on next sweep.
+	// Uses O_APPEND so the file grows (not rotates) — the offset-based tail sees
+	// only the new bytes.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0644)
+	require.NoError(t, err)
+	_, err = f.WriteString("Jan 1 00:01:00 r dnsmasq[1]: query[A] new.example.com from 192.168.1.50\n")
+	require.NoError(t, err)
+	f.Close()
+
+	src.sweep()
+	time.Sleep(100 * time.Millisecond)
+	reps := sink.snapshot()
+	require.Len(t, reps, 1, "only the appended (post-first-sweep) query emitted")
+	require.Equal(t, "192.168.1.50", reps[0].IP)
+}
+
+// ─── hostapd STA parsing ────────────────────────────────────────────────────
+
+func TestParseHostapdSTA_FullEntry(t *testing.T) {
+	resp := "addr=aa:bb:cc:dd:ee:ff\n" +
+		"aid=1\n" +
+		"capability=0x431\n" +
+		"flags=[AUTH][ASSOC][AUTHORIZED]\n" +
+		"connected_time=120\n" +
+		"signal=-42\n" +
+		"ssid=HomeNet\n" +
+		"rx_bytes=12345\n"
+	info := parseHostapdSTA(resp)
+	require.Equal(t, "aa:bb:cc:dd:ee:ff", info.mac, "MAC lowercased")
+	require.Equal(t, "-42", info.signal)
+	require.Equal(t, "120", info.connectTime)
+	require.Equal(t, "HomeNet", info.ssid)
+}
+
+func TestParseHostapdSTA_PartialEntry(t *testing.T) {
+	// A minimal STA reply (only addr) — must still parse the MAC, empty rest.
+	info := parseHostapdSTA("addr=11:22:33:44:55:66\n")
+	require.Equal(t, "11:22:33:44:55:66", info.mac)
+	require.Empty(t, info.signal)
+	require.Empty(t, info.ssid)
+}
+
+// ─── iw station dump parsing ────────────────────────────────────────────────
+
+func TestParseIWStationDump_TwoStations(t *testing.T) {
+	out := "Station aa:bb:cc:dd:ee:01 (on wlan0)\n" +
+		"\tinactive time:\t30 ms\n" +
+		"\trx bytes:\t1000\n" +
+		"\tsignal:\t-42 dBm\n" +
+		"\ttx bitrate:\t300.0 MBit/s\n" +
+		"\n" +
+		"Station aa:bb:cc:dd:ee:02 (on wlan0)\n" +
+		"\tinactive time:\t500 ms\n" +
+		"\tsignal:\t-67 dBm\n"
+	stas := parseIWStationDump(out)
+	require.Len(t, stas, 2)
+	require.Equal(t, "aa:bb:cc:dd:ee:01", stas["aa:bb:cc:dd:ee:01"].mac)
+	require.Equal(t, "-42", stas["aa:bb:cc:dd:ee:01"].signal, "dBm unit stripped")
+	require.Equal(t, "aa:bb:cc:dd:ee:02", stas["aa:bb:cc:dd:ee:02"].mac)
+	require.Equal(t, "-67", stas["aa:bb:cc:dd:ee:02"].signal)
+}
+
+func TestParseIWStationDump_EmptyOutput(t *testing.T) {
+	require.Empty(t, parseIWStationDump(""))
+	require.Empty(t, parseIWStationDump("no stations here\n"))
+}
+
+func TestExtractIWStationMAC(t *testing.T) {
+	require.Equal(t, "aa:bb:cc:dd:ee:ff",
+		extractIWStationMAC("Station aa:bb:cc:dd:ee:ff (on wlan0)"))
+	require.Empty(t, extractIWStationMAC("not a station line"))
+}
+
+// TestHostapd_NoSockets_NoOps confirms the source degrades gracefully when
+// there's no hostapd ctrl socket AND iw is absent (a non-router/non-AP host) —
+// no panic, no events, the documented no-op.
+func TestHostapd_NoSockets_NoOps(t *testing.T) {
+	// Point ctrlDir at a TempDir with nothing in it; interfaces at a bogus name.
+	svc, sink, _, _ := newTestService(t, false)
+	src := NewHostapdSource([]string{"nonexistent-wlan"}, time.Minute, svc, nil)
+	src.ctrlDir = t.TempDir() // empty dir → no sockets globbed
+	src.sweep()               // must not panic
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, sink.count(), "no hostapd socket + bogus iw iface → no events")
+}


### PR DESCRIPTION
## What

Adds the **remaining two router-only discovery signals**, completing the 4-source Tier-1 router roster (conntrack + dhcp_leases from #29, + these two). Both land in the **shared `discovery/` package** so all three deployment forms (center / agent / **router-center form C**) get them.

### `hostapd` (`discovery/hostapd.go`)
Enumerates the WiFi STAs associated to the local AP(s). WiFi association is **L2 authoritative** — sees WiFi-only devices that may never answer L3 probes (smart-home sensors, sleep-aggressive phones, guests). Captures **signal dBm / connect time / SSID** (gold for device tracking) via Hints.

Two backends, hostapd first (per design decision):
1. **hostapd_ctrl socket (preferred)**: opens `/var/run/hostapd/<phy>` (UNIX datagram), sends `STA-FIRST`/`STA-NEXT`, parses key=value replies. Most authoritative + zero subprocess overhead.
2. **`iw station dump` fallback**: shells `iw` when no hostapd socket (agent beside an AP it doesn't own, or hostapd ctrl_interface disabled). Slightly less detail, one subprocess per sweep.

### `dns_log` (`discovery/dns_log.go`)
Tails a dnsmasq query log (`--log-queries` output) with **tail-F semantics over polling** (offset-based seek, no long-running subprocess). Emits the querying host per DNS query — a powerful passive fingerprint (devices that block all inbound probes still make outbound DNS). Queried domain carried as `Hints['dns_query']` (domain→vendor enrichment is a follow-up). Operator must enable dnsmasq query logging (UCI `logqueries=1`); no-ops when no log file is found.

**Key correctness detail**: the tail offset is ALWAYS persisted (even when zero new lines read on the first-sweep EOF case), so the next sweep resumes at EOF rather than replaying history. Rotation (file shrunk) resets offset to 0.

## Graceful no-op on non-AP/non-router hosts
- `hostapd`: no ctrl sockets + `iw` absent (or iface down) → no-op
- `dns_log`: no log file at conventional paths → no-op

Both follow the established pattern (ARP/dhcp/conntrack): debug log + skip, never error, never crash.

## Wiring
- New `ScannerConfig.Discovery.Hostapd` (+ `Interfaces`) + `.DNSLog` (+ `Path`) toggles (**default false** — opt-in)
- Wired in both `routes.go` (center) and `cmd/agent/main.go`
- `config.example.yaml` documents both with operator-setup notes (dnsmasq `logqueries=1`; interfaces list)

## Tests (13 new, all pass under `-race`)

| Area | Tests |
|---|---|
| DNS parser | client query ✓, reply-line rejected ✓, interface-name rejected ✓, non-dnsmasq line rejected ✓, IPv4 validator ✓ |
| DNS tail | first-sweep-EOF (the offset bug + its fix) ✓ |
| hostapd STA | full entry + partial entry ✓ |
| iw station dump | 2 stations + empty + MAC extraction ✓ |
| Integration | Hostapd no-sockets-no-op (graceful on non-AP host) ✓ |

## Real-hardware verification (192.168.62.174 agent)

All 7 sources enabled, startup logs:
```
agent passive discovery ready sources=[router_arp arp_cache multicast dhcp_leases conntrack hostapd dns_log]
```
Agent stable (RSS 109MB, 1m+ uptime), no errors. On the test VM (**not** an AP: no hostapd sockets, no `iw`, no dnsmasq query log) both new sources no-op cleanly — graceful degradation confirmed.

## Phase B is now complete

**Tier-1 router signal roster**: conntrack + dhcp_leases + hostapd + dns_log — **all 4 shared across the three deployment forms**. The router-agent roadmap's discovery half is done; remaining Stream C PRs are form C (center OpenWrt-ready) + the router_arp cleanup.

🤖 Generated with [ZCode](https://zcode.dev)