### PR TITLE
feat(deploy): center + agent OpenWrt-ready (form C router-center)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -175,6 +175,19 @@ sudo crontab -e
 0 2 * * * /opt/mibee-steward/scripts/backup.sh /opt/mibee-steward/data/mibee.db /opt/mibee-steward/data/backups 30
 ```
 
+## 方案 C: OpenWrt 路由器部署（router 形态）
+
+MiBee Steward 可以**直接装在 OpenWrt 路由器上**，拿到"咽喉点"独有的发现信号（DHCP 租约表 / conntrack 流表 / hostapd WiFi 关联 / DNS 查询日志）——这些是任意 LAN 主机都拿不到的。两种形态：
+
+- **形态 B：agent 上路由 → 远端 center**（多站点：一台远端 center + 每个路由器一个轻量 agent）
+- **形态 C：center 上路由**（单网络：一台路由器全包，agent + center 合一）
+
+⚠️ **硬件约束**：仅支持 **ARM/ARM64** 路由（GL.iNet MT3000、ipq807x、mt798x 系列，≥128MB RAM / ≥32MB flash）。**不支持 MIPS** —— `modernc/libc`（纯 Go SQLite 的传递依赖）没有可用的 mips/mipsle 端口，这排除了老款 ath79/ramips 路由（TP-Link Archer C7、Netgear R7000 等）。
+
+完整安装步骤（交叉编译 / procd init 脚本 / 配置路径约定 / DB-on-tmpfs 防闪存磨损 / 故障排查）见 **[`deploy/openwrt/README.md`](openwrt/README.md)**。procd init 脚本：[`mibee-steward.init`](openwrt/mibee-steward.init)（center，形态 C）、[`mibee-agent.init`](openwrt/mibee-agent.init)（agent，形态 B）。
+
+---
+
 ## 方案 B: Docker 部署
 
 > ⚠️ **网络模式决定探测效果**。MiBee Steward 的扫描器在网络命名空间层面工作，

--- a/deploy/openwrt/README.md
+++ b/deploy/openwrt/README.md
@@ -1,0 +1,111 @@
+# MiBee Steward on OpenWrt (router deployment)
+
+MiBee Steward can run **on an OpenWrt router** in two forms:
+
+| Form | Binary | Role | When to use |
+|---|---|---|---|
+| **B — router-agent → remote center** | `cmd/agent` | Pure sensor: scans the router's LAN, reports upstream over HTTPS to a center elsewhere | Multi-site / multi-LAN: one remote center + one agent per router. The agent is light (18MB binary, ~100MB RAM). |
+| **C — router-center** | `cmd/server` | The full center (API + SPA + asset registry + discovery) running ON the router | Single-network (home / small office): one router does everything — gets the choke-point discovery signals (DHCP leases / conntrack / hostapd / dns_log) AND serves the portrait UI. No separate agent process needed. |
+
+Both forms unlock the **4 Tier-1 router-only discovery signals** that a host-based deployment can't get (the router is the network choke point: it sees DHCP, NAT flows, WiFi associations, and DNS queries a random LAN host can't). See `scanner.discovery.*` in `configs/config.example.yaml`.
+
+## ⚠️ Hardware requirements (read first)
+
+| Resource | Minimum | Comfortable | Notes |
+|---|---|---|---|
+| **Architecture** | **ARM or ARM64** | ARM64 (GL.iNet MT3000, ipq807x, mt798x) | **MIPS is NOT supported** — `modernc.org/libc` (the pure-Go SQLite backend's transitive dep) has no working `mips`/`mipsle` port and a broken `mips64le` one. This excludes older ath79/ramips routers (TP-Link Archer C7, Netgear R7000, etc.). |
+| **RAM** | 128 MB | 256 MB+ | modernc SQLite is memory-heavier than C-SQLite; the center is heavier than the agent. |
+| **Flash** | 32 MB | 128 MB+ | Binary 16-18MB + OUI (~5MB full / 1.2KB curated) + fingerprint corpus (~1.2MB) + DB. The DB should live on `/tmp` (tmpfs) — see [Flash-wear mitigation](#flash-wear-mitigation-db-on-tmpfs). |
+
+## Cross-compile
+
+Both binaries build CGO-free (`modernc.org/sqlite`), so a plain `GOOS`/`GOARCH` cross-compile works — no OpenWrt SDK needed.
+
+```bash
+# Form B: agent
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+  -trimpath -ldflags="-s -w" -o mibee-agent ./cmd/agent/
+#   → ~18MB
+
+# Form C: center
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+  -trimpath -ldflags="-s -w" -o mibee-steward ./cmd/server/
+#   → ~24MB (includes the embedded SvelteKit SPA)
+```
+
+`GOARCH=arm` (32-bit, GOARM=7) also works for older ARM boards. `GOARCH=mips*` does **not** (see above).
+
+## Install (form B — agent → remote center)
+
+```bash
+# On your build host:
+scp mibee-agent root@router:/usr/bin/mibee-agent
+scp deploy/openwrt/mibee-agent.init root@router:/etc/init.d/mibee-agent
+ssh root@router 'mkdir -p /etc/mibee'
+scp configs/agent.yaml root@router:/etc/mibee/agent.yaml   # then edit on the router
+
+# On the router, edit /etc/mibee/agent.yaml:
+#   center.url:         http://<your-center-ip>:<port>
+#   center.auth_token:  <minted on the center via POST /api/v1/agents/tokens>
+#   network.name/cidr:  this router's LAN (e.g. lan-62 / 192.168.62.0/24)
+#   scanner.discovery.*: enable the router-only sources you want
+#     (dhcp_leases, conntrack, hostapd, dns_log — all default false)
+
+ssh root@router '/etc/init.d/mibee-agent enable && /etc/init.d/mibee-agent start'
+ssh root@router 'logread -e mibee-agent | tail -20'   # expect "mibee-agent running"
+```
+
+## Install (form C — center on the router)
+
+```bash
+scp mibee-steward root@router:/usr/bin/mibee-steward
+scp deploy/openwrt/mibee-steward.init root@router:/etc/init.d/mibee-steward
+ssh root@router 'mkdir -p /etc/mibee'
+scp configs/config.yaml root@router:/etc/mibee/config.yaml   # then edit on the router
+
+# On the router, edit /etc/mibee/config.yaml:
+#   server.port:                   e.g. 8080
+#   auth.initial_admin_password:   REQUIRED (no hardcoded default) — change from default!
+#   network.name/cidr:             this router's LAN
+#   database.path:                 /tmp/mibee/mibee.db  (tmpfs — see below)
+#   scanner.discovery.*:           enable the router-only sources
+
+ssh root@router '/etc/init.d/mibee-steward enable && /etc/init.d/mibee-steward start'
+# Browse to http://<router-ip>:8080, log in with admin / <initial_admin_password>
+```
+
+## Flash-wear mitigation (db on tmpfs)
+
+Both binaries write a SQLite DB (WAL mode). On a router's NAND flash under overlayfs this causes write-wear. **Point the DB at `/tmp` (tmpfs, RAM-backed):**
+
+- **Agent (form B):** the local DB is explicitly a *shadow* (the center is the writer of record), so cold-start loss is fine. **Always use `/tmp/mibee-agent/agent.db`.** The agent's in-memory pending-queue (100 batches) handles disconnection during a reboot.
+- **Center (form C):** the DB is the authoritative portrait. `/tmp` means cold-start loss (rebuilt on the next scan; acceptable for a single-router deployment). For deployments that need persistence across reboots, leave `database.path` on flash and accept the wear — consumer routers live 5-10 years and scan write volume is modest.
+
+## Router-only discovery sources (enable in `scanner.discovery.*`)
+
+| Source | What it gives | Router daemon it reads | No-op when absent |
+|---|---|---|---|
+| `dhcp_leases` | Authoritative hostname↔MAC↔IP map | dnsmasq `/tmp/dhcp.leases` | ✅ non-DHCP host |
+| `conntrack` | "Who is talking RIGHT NOW" (liveness + discovery) | `/proc/net/nf_conntrack` | ✅ module not loaded |
+| `hostapd` | WiFi STA associations (signal dBm / SSID / connect time) | hostapd ctrl socket → `iw station dump` fallback | ✅ no WiFi / no hostapd |
+| `dns_log` | Passive DNS fingerprint (devices that block probes still do DNS) | dnsmasq `--log-queries` log file | ✅ no query logging configured |
+
+All four are **shared across forms B and C** (and form A — center on a generic host), so the same config block works in `agent.yaml` and `config.yaml`. All four degrade to a clean no-op (debug log + skip) on a host that doesn't have the file/socket — no errors, no crashes.
+
+**Operator setup for `dns_log`:** enable dnsmasq query logging —
+`uci set dhcp.@dnsmasq[0].logqueries=1 && uci commit && /etc/init.d/dnsmasq restart`. Point `scanner.discovery.dns_log.path` at the resulting log (or leave empty to probe the conventional paths).
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `bind: address already in use` on start | Another process holds the port (often the center's SPA + the router's own LuCI on 80/443). Set `server.port` to a free port (e.g. 8080). |
+| `database is locked (SQLITE_BUSY)` | WAL-mode write contention under heavy concurrent probing. Raise `database.max_open_conns` (default 16) or reduce `scanner.max_concurrent_hosts`. |
+| `mmap: access denied` at startup | Kernel disallows the mmap SQLite wants — run as root (the procd script does) or check the router's seccomp/apparmor. |
+| Discovery sources all no-op | Expected on a non-router host. On a router, check each source's prereq (dnsmasq running, `nf_conntrack` loaded, hostapd ctrl_interface enabled). |
+| `unsupported GOARCH mips` at build | MIPS isn't supported (modernc/libc limitation). Use an ARM/ARM64 router. |
+
+## What's NOT covered here
+
+- **Official .ipk packaging** (OpenWrt build feed): this repo ships init scripts + binaries that work via plain `scp` + `/etc/init.d/`. A proper `.ipk` via the OpenWrt buildroot's `golang-package` macros is a follow-up (lower friction for end users; not required for correctness).
+- **MIPS support**: structural limitation of `modernc/libc`; would require swapping the SQLite backend to bbolt/goleveldb (a real refactor — deferred until a MIPS customer need exists).

--- a/deploy/openwrt/mibee-agent.init
+++ b/deploy/openwrt/mibee-agent.init
@@ -1,0 +1,51 @@
+#!/bin/sh /etc/rc.common
+#
+# OpenWrt procd init script for MiBee Steward AGENT (form B: agent-on-router,
+# reporting to a remote center).
+#
+# The distributed-agent half: runs on a router in a remote LAN, scans locally,
+# reports upstream to the center over HTTPS. This is the form when you can't
+# (or don't want to) run the full center on every router — one center handles
+# many router-agents. See docs/private/architecture-debt-and-openwrt-2026-07-27.md §4.0.
+#
+# ─── Install ───────────────────────────────────────────────────────────────
+#   1. Cross-compile the agent for the router's arch (ARM/ARM64 only):
+#        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+#          -trimpath -ldflags="-s -w" -o mibee-agent ./cmd/agent/
+#   2. Copy binary + init + config to the router:
+#        scp mibee-agent root@router:/usr/bin/mibee-agent
+#        scp deploy/openwrt/mibee-agent.init root@router:/etc/init.d/mibee-agent
+#        scp configs/agent.yaml root@router:/etc/mibee/agent.yaml
+#      (edit /etc/mibee/agent.yaml: center.url (the remote center's address +
+#       port), center.auth_token (minted on the center via POST
+#       /api/v1/agents/tokens), network.name/cidr — this router's LAN.)
+#   3. Enable + start:
+#        ssh root@router '/etc/init.d/mibee-agent enable && /etc/init.d/mibee-agent start'
+#      Logs: logread -e mibee-agent
+#
+# ─── Flash-wear mitigation (db on tmpfs) ───────────────────────────────────
+# The agent's local shadow DB (./data/agent.db) is explicitly a SHADOW — the
+# center is the writer of record, so cold-start loss is fine and the DB SHOULD
+# live on /tmp (tmpfs, RAM-backed). Edit /etc/mibee/agent.yaml's database.path
+# (or uncomment AGENT_DB_PATH below) to /tmp/mibee-agent/agent.db. The agent's
+# in-memory pending-queue (100 batches) handles disconnection during a reboot.
+
+USE_PROCD=1
+
+START=95  # after network + dnsmasq
+USE_PROCD=1
+
+BINARY=/usr/bin/mibee-agent
+CONFIG=/etc/mibee/agent.yaml
+#AGENT_DB_PATH=/tmp/mibee-agent/agent.db  # uncomment for tmpfs (recommended)
+
+start_service() {
+    procd_open_instance
+    procd_set_param command "$BINARY" -config "$CONFIG"
+    # Respawn on crash (procd's Restart=always equivalent).
+    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-10}
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param pidfile /var/run/mibee-agent.pid
+    procd_close_instance
+}

--- a/deploy/openwrt/mibee-steward.init
+++ b/deploy/openwrt/mibee-steward.init
@@ -1,0 +1,75 @@
+#!/bin/sh /etc/rc.common
+#
+# OpenWrt procd init script for MiBee Steward CENTER (form C: center-as-router).
+#
+# Lets the MiBee Steward center binary run ON an OpenWrt router — the "router-
+# center" deployment form (see docs/private/architecture-debt-and-openwrt-2026-07-27.md
+# §4.0). A small network (home / small office) can run just the router: one
+# process gets both the choke-point discovery signals (DHCP leases, conntrack,
+# hostapd, dns_log — scanner.discovery.*) AND the full portrait API + SPA + the
+# authoritative asset registry. No separate agent process needed.
+#
+# Why procd, not systemd: OpenWrt uses procd (not systemd). This script is the
+# procd equivalent of deploy/mibee-steward.service (the systemd unit for the
+# center on a generic Linux host).
+#
+# ─── Install ───────────────────────────────────────────────────────────────
+#   1. Cross-compile the center for the router's arch (ARM/ARM64 only — see
+#      the MIPS exclusion note in deploy/openwrt/README.md):
+#        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+#          -trimpath -ldflags="-s -w" -o mibee-steward ./cmd/server/
+#   2. Copy the binary + this init script + a config to the router:
+#        scp mibee-steward root@router:/usr/bin/mibee-steward
+#        scp deploy/openwrt/mibee-steward.init root@router:/etc/init.d/mibee-steward
+#        scp configs/config.yaml root@router:/etc/mibee/config.yaml
+#      (edit /etc/mibee/config.yaml: server.port, auth.initial_admin_password,
+#       network.name/cidr — the router's own LAN.)
+#   3. Enable + start:
+#        ssh root@router '/etc/init.d/mibee-steward enable && /etc/init.d/mibee-steward start'
+#      Logs: logread -e mibee-steward
+#
+# ─── Flash-wear mitigation (db on tmpfs) ───────────────────────────────────
+# The center writes a SQLite DB (./data/mibee.db, WAL mode). On a router's NAND
+# flash under overlayfs this causes write-wear. The recommended setup points
+# database.path at /tmp (tmpfs, RAM-backed) — the center is the writer of record
+# so cold-start loss of the LOCAL portrait is acceptable (a remote agent network
+# would re-populate it; on a single-router form-C deployment the portrait is
+# rebuilt on the next scan anyway). For deployments that need persistence across
+# reboots, leave database.path on flash but accept the wear (consumer routers
+# live 5-10 years; scan write volume is modest).
+#
+# Set DATABASE_PATH below (or via /etc/mibee/config.yaml's database.path) to
+# /tmp/mibee/mibee.db for the tmpfs variant.
+
+USE_PROCD=1
+
+START=95  # after network + dnsmasq (START=60) so the center sees a populated ARP table at boot
+USE_PROCD=1
+
+BINARY=/usr/bin/mibee-steward
+CONFIG=/etc/mibee/config.yaml
+# Override the SQLite path here for flash-wear mitigation (see comment above).
+#DATABASE_PATH=/tmp/mibee/mibee.db
+
+start_service() {
+    procd_open_instance
+    procd_set_param command "$BINARY" -config "$CONFIG"
+    # Respawn on crash (procd's equivalent of systemd Restart=always). The 3-tier
+    # backoff (5s/10s/30s) bounds a tight crash-loop; procd gives up after
+    # maxfail before re-trying after a longer cooldown.
+    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-10}
+    procd_set_param stdout 1  # forward stdout to the log (logread)
+    procd_set_param stderr 1  # forward stderr to the log
+    # procd_set_param limits the process to keep a runaway center from OOMing a
+    # RAM-constrained router. Uncomment + tune for low-RAM hardware (e.g. 128MB).
+    #procd_set_param limits nofile=1024 cpu=80
+    # The center binds a port (default 8080); procd needs to know it's a service.
+    procd_set_param pidfile /var/run/mibee-steward.pid
+    procd_close_instance
+}
+
+reload_service() {
+    # SIGHUP is not currently handled by the center (config reload is a restart);
+    # provide reload as an alias for restart so `uci` / RC integrations work.
+    restart
+}


### PR DESCRIPTION
## What

Delivers the **'center must also deploy to a router'** requirement — **form C** (a single-network site runs the full center ON the router, no separate agent process). Packaging + docs only — **no Go behavior change**.

### `deploy/openwrt/mibee-steward.init` (center, form C)
procd init script — OpenWrt's equivalent of `deploy/mibee-steward.service` (systemd). Starts the center with `/etc/mibee/config.yaml`, respawns on crash (procd's `Restart=always`), forwards stdout/stderr to `logread`, `START=95` (after dnsmasq so the ARP table is populated at boot). Documents flash-wear mitigation inline (`database.path` → `/tmp` tmpfs).

### `deploy/openwrt/mibee-agent.init` (agent, form B)
Same shape for the agent — the multi-site form (one remote center + one agent per router). The agent's shadow DB is explicitly a *shadow*, so `/tmp` tmpfs is the **recommended** placement.

### `deploy/openwrt/README.md`
End-to-end OpenWrt guide for both forms: hardware requirements, cross-compile recipe, install steps, flash-wear mitigation, the 4 router-only discovery sources, troubleshooting table.

### `deploy/README.md`
Adds a "方案 C: OpenWrt 路由器部署" section between systemd 方案 A and Docker 方案 B, pointing at the openwrt/ guide + stating the ARM-only / MIPS-excluded constraint up front.

## Verification

| Check | Result |
|---|---|
| **arm64** center cross-compile | ✅ 23M |
| **arm (GOARM=7)** center cross-compile | ✅ 23M |
| **mips** center cross-compile | ❌ fails (`modernc/libc` build constraint) — **confirms the documented exclusion** |
| procd init scripts `sh -n` | ✅ both pass |
| `go build ./...` + `go vet ./...` | ✅ clean (no Go code changed) |

## What this unlocks

A small network (home / small office) with one OpenWrt router can now run the **full center on the router** — getting all 4 Tier-1 choke-point discovery signals (DHCP leases / conntrack / hostapd / dns_log from PRs #29 + #30) AND the portrait API + SPA + authoritative registry, in a single process. The center's own `scanner.discovery.*` config block (shared with the agent since PR #28) is the same surface.

🤖 Generated with [ZCode](https://zcode.dev)