### PR TITLE
fix(web): ConfirmDialog 在 async onConfirm 完成前不再关闭（spinner + 防中途关闭）(#45)

### DIFF
--- a/web/src/lib/components/ConfirmDialog.svelte
+++ b/web/src/lib/components/ConfirmDialog.svelte
@@ -34,26 +34,49 @@
 		confirmVariant?: 'primary' | 'danger';
 		/** When true, the confirm button shows a spinner and is disabled. */
 		loading?: boolean;
-		onConfirm: () => void;
+		/** May be async — the dialog stays open (with a spinner) until it resolves,
+		 *  closes on success, stays open on rejection so the user can retry. */
+		onConfirm: () => unknown;
 		onCancel?: () => void;
 	} = $props();
 
 	const resolvedConfirmLabel = $derived(confirmLabel ?? m['common.Confirm']());
 	const resolvedCancelLabel = $derived(cancelLabel ?? m['common.Cancel']());
 
-	function handleConfirm() {
-		if (loading) return;
-		onConfirm();
-		open = false;
+	// Internal in-flight flag driven while `onConfirm` is awaiting. OR-ed with
+	// the caller-supplied `loading` prop so both light up the spinner / disable
+	// the buttons / block Modal close paths.
+	let busy = $state(false);
+	const pending = $derived(busy || loading);
+
+	async function handleConfirm() {
+		if (pending) return;
+		busy = true;
+		try {
+			await onConfirm();
+			// On success, close. If the caller's onConfirm rejects AND the
+			// caller does NOT swallow it internally, the catch below keeps
+			// the dialog open so the user can retry. (Most callers do their
+			// own try/catch + toast, in which case the promise resolves and
+			// we close here — they can re-open the dialog to retry.)
+			open = false;
+		} catch {
+			// Caller let the error bubble (did not try/catch inside onConfirm).
+			// Keep the dialog open + busy=false so the user can fix input and
+			// retry. The caller is expected to surface its own error toast.
+		} finally {
+			busy = false;
+		}
 	}
 
 	function handleCancel() {
+		if (pending) return;
 		onCancel?.();
 		open = false;
 	}
 </script>
 
-	<Modal bind:open {title} maxWidth="24rem" onClose={handleCancel}>
+	<Modal bind:open {title} maxWidth="24rem" onClose={handleCancel} closable={!pending}>
 		<div
 			class="confirm-content"
 			role="alertdialog"
@@ -67,7 +90,7 @@
 				<button
 					class="cd-btn cd-cancel"
 					onclick={handleCancel}
-					disabled={loading}
+					disabled={pending}
 				>
 					{resolvedCancelLabel}
 				</button>
@@ -75,10 +98,10 @@
 					class="cd-btn cd-confirm"
 					class:cd-confirm-danger={confirmVariant === 'danger'}
 					onclick={handleConfirm}
-					disabled={loading}
-					aria-busy={loading ? 'true' : undefined}
+					disabled={pending}
+					aria-busy={pending ? 'true' : undefined}
 				>
-					{#if loading}
+					{#if pending}
 						<LoaderCircle class="w-4 h-4 animate-spin" aria-hidden="true" />
 					{/if}
 					<span>{resolvedConfirmLabel}</span>

--- a/web/src/lib/components/Modal.svelte
+++ b/web/src/lib/components/Modal.svelte
@@ -18,6 +18,7 @@
 		title,
 		maxWidth = '32rem',
 		onClose,
+		closable = true,
 		confirmDiscard,
 		discardTitle,
 		discardMessage,
@@ -27,6 +28,9 @@
 		title: string;
 		maxWidth?: string;
 		onClose?: () => void;
+		/** When false, Escape / backdrop / X are ignored (e.g. while an async
+		 *  confirm is in flight — see ConfirmDialog). Defaults to true. */
+		closable?: boolean;
 		/**
 		 * Return `true` to block the close and instead show the "unsaved
 		 * changes" discard confirmation. The previous name `onBeforeClose`
@@ -90,6 +94,9 @@
 	}
 
 	function close() {
+		// Locked by the caller (e.g. ConfirmDialog during an in-flight async
+		// confirm): ignore Escape / backdrop / X so the request is not orphaned.
+		if (!closable) return;
 		// If the discard-confirm overlay is already up, a backdrop click just
 		// dismisses the overlay (back to the open modal) instead of re-running
 		// confirmDiscard and re-showing it — that flickery loop was the old bug.

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -380,7 +380,6 @@ interface Stats {
 			addToast('error', getErrorMessage(err));
 		} finally {
 			batchLoading = false;
-			batchDeleteOpen = false;
 		}
 	}
 

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -91,6 +91,7 @@
 	let editingConfig = $state<typeof heartbeatConfigs[0] | null>(null);
 	let editConfigLoading = $state(false);
 	let deletingConfigId = $state<number | null>(null);
+	let heartbeatDeleteOpen = $state(false);
 	let deleteConfigLoading = $state(false);
 	// --- Label state ---
 	let labelSaving = $state(false);
@@ -334,6 +335,7 @@
 				await api.delete(`/heartbeat-configs/${cfg.id}`);
 				addToast('success', m['heartbeat.Config Deleted']());
 				deletingConfigId = null;
+				heartbeatDeleteOpen = false;
 				await fetchHeartbeatConfigs();
 			} catch (err: unknown) {
 				addToast('error', getErrorMessage(err));
@@ -1393,7 +1395,7 @@
 								</button>
 								<button
 									type="button"
-									onclick={() => { deletingConfigId = cfg.id; }}
+									onclick={() => { deletingConfigId = cfg.id; heartbeatDeleteOpen = true; }}
 									class="p-1 rounded text-muted hover:text-error hover:bg-error/10 transition-colors"
 									aria-label={m['heartbeat.Delete Config']()}
 									title={m['heartbeat.Delete Config']()}
@@ -1695,7 +1697,7 @@
 
 <!-- Heartbeat config delete confirmation -->
 <ConfirmDialog
-	open={deletingConfigId !== null}
+	bind:open={heartbeatDeleteOpen}
 	title={m['heartbeat.Delete Config']()}
 	message={m['heartbeat.Delete Confirm']()}
 	confirmLabel={m['common.Delete']()}
@@ -1703,7 +1705,7 @@
 	onConfirm={() => {
 		if (deletingConfigId !== null) {
 			const cfg = heartbeatConfigs.find((c) => c.id === deletingConfigId);
-			if (cfg) deleteConfig(cfg);
+			if (cfg) return deleteConfig(cfg);
 		}
 	}}
 	onCancel={() => { deletingConfigId = null; }}

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -217,7 +217,6 @@
 	}
 
 	async function performAdd() {
-		confirmAddOpen = false;
 		adding = true;
 		try {
 			const devices = getAliveHosts()

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -218,7 +218,6 @@
 				label: m["common.Undo"](),
 				timeout: 10000
 			});
-			deleteOpen = false;
 			deleteTarget = null;
 			fetchDocuments();
 		} catch (err: unknown) {


### PR DESCRIPTION
## Summary

ConfirmDialog 原本在点击确认的**瞬间**关闭，即使 onConfirm 是 async 网络请求。请求失败时弹窗已消失，用户只看到一个 transient toast，必须重新触发整个流程才能重试。现有的 `loading` prop 无法修——调用方无法在异步工作期间驱动它，因为 dialog 已经关了。

## Changes

**核心契约**（`ConfirmDialog.svelte`）：
- `handleConfirm` 改 async：`busy=true` → `await onConfirm()` → 成功才关，rejection 保持打开
- 按钮/spinner 用 `pending = busy || loading`（caller 传的 loading 仍兼容）
- `onConfirm` 类型放宽 `() => void` → `() => unknown`（await 类型安全）

**防中途关闭**（`Modal.svelte`）：
- 新增可选 `closable` prop（默认 true）。false 时 Escape/backdrop/X 被忽略
- ConfirmDialog 传 `closable={!pending}`——请求飞行中无法关闭，避免孤儿请求

**调用点清理**（4 处，新契约下变冗余）：
| 文件 | 改动 |
|---|---|
| `devices/+page.svelte` | confirmBatchDelete finally 里删 `batchDeleteOpen=false` |
| `documents/+page.svelte` | confirmDelete 删 `deleteOpen=false` |
| `devices/scanner/+page.svelte` | performAdd 删第一行的 `confirmAddOpen=false` workaround |
| `devices/detail/[id]/+page.svelte` | heartbeat 删除 dialog 从 one-way `open={expr}` 改 `bind:open`（与其他 11 个调用点统一） |

**不改动的 8 个调用点**（agents/users/devices-single/device-detail-system/scan-tasks/networks/dashboard/notifications）——纯增益，无需改动。

## 关于失败路径 UX

调用方的 `onConfirm` 普遍自带 try/catch + toast（如 `confirmDelete`）。这会吞掉 rejection，promise 正常 resolve，dialog 在 toast 后关闭。这仍是**巨大改进**（原行为：瞬间关闭无 spinner）。若要"失败保持打开可重试"，调用方需不在 onConfirm 里 catch（让错误冒泡）——契约已支持，留给后续按需采纳。

## Verification

- ✅ `npm test`: 142/142 pass
- ✅ `svelte-check`: 38 errors（与 main 持平，无回归）
- ✅ `npm run build`: clean
- ✅ **浏览器实测**（192.168.63.101）：
  - 设备删除：请求飞行中 **spinner 显示 + dialog 保持打开**，成功后关闭
  - 设备删除（API abort）：请求已发出，dialog 正常关闭，无崩溃
  - **请求飞行中按 Escape**：dialog **保持打开**（closable=false 生效）
  - 空闲 dialog 按 Escape：正常关闭（closable 默认 true）
  - heartbeat config 删除（bind:open 路径）：dialog 打开 → spinner → 关闭，DB 行删除（3→2 configs）

## Test plan

- [ ] `npm test` + `npm run build` 通过
- [ ] 浏览器实测任一删除流程：spinner 显示、成功关闭
- [ ] 删除进行中按 Escape：拒绝关闭

Closes #45