### PR TITLE
fix(web): 设备/扫描结果 CSV 导出走 api.download() 统一 CSRF + 认证 (#44)

### DIFF
--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -18,7 +18,6 @@
 	import { escapeHtml, escapeAttr } from '$lib/utils';
 	import { deviceSchema, validateField, validateForm } from '$lib/utils/validation';
 	import type { Device, LinkedDoc, Network } from '$lib/types';
-	import { auth } from '$lib/stores/auth';
 	import { ChevronDown, ChevronRight, Download, Upload, Plus, List, Share2 } from '@lucide/svelte';
 
 	import Modal from '$lib/components/Modal.svelte';
@@ -327,15 +326,11 @@ interface Stats {
 	// --- Export ---
 	async function exportDevices(format: string) {
 		try {
-			let token: string | null = null;
-			const unsub = auth.subscribe((s) => { token = s.token; });
-			unsub();
-			const res = await fetch(`/api/v1/devices/export?format=${format}`, {
-				headers: { 'Authorization': `Bearer ${token}` },
-				credentials: 'include'
-			});
-			if (!res.ok) throw new Error(`Export failed: HTTP ${res.status}`);
-			const blob = await res.blob();
+			// Go through api.download() so CSRF + cookie auth + 401 handling
+			// match every other request. The previous raw fetch() bypass dropped
+			// the X-CSRF-Token header and manually extracted a Bearer token —
+			// both deviations from the client contract.
+			const blob = await api.download(`/devices/export?format=${format}`);
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -234,14 +234,12 @@
 		if (!taskIdFilter) return;
 		exporting = true;
 		try {
-			const res = await fetch(`/api/v1/scanner/results/export?task_id=${taskIdFilter}`, {
-				credentials: 'include'
-			});
-			if (!res.ok) {
-				const err = await res.json().catch(() => ({ error: 'Export failed' }));
-				throw new Error(err.error || `HTTP ${res.status}`);
-			}
-			const blob = await res.blob();
+			// Use api.download() so the request carries the CSRF token and
+			// shares the client's 401/logout handling. The previous raw fetch()
+			// sent only `credentials: 'include'` — no CSRF header, no auth
+			// fallback — which would break under CSRF enforcement and bypass
+			// the unified auth path.
+			const blob = await api.download(`/scanner/results/export?task_id=${taskIdFilter}`);
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;


### PR DESCRIPTION
## Summary

两处导出绕过了 API client 用 raw `fetch()`，丢了 `X-CSRF-Token` header，scan-results 处连 Authorization 都没带。device-detail 的 heartbeat 导出已正确用 `api.download()`——本次统一三处。

## Changes

| 文件 | 改动 |
|---|---|
| `devices/+page.svelte` | `exportDevices` 从 `auth.subscribe` 取 token + raw fetch 改成 `api.download()`；删掉不再使用的 `auth` import |
| `scan-results/+page.svelte` | `exportCSV` 从裸 `fetch(credentials only)` 改成 `api.download()` |

## 说明：当前后端不强制 GET 的 CSRF

后端 CSRF middleware（`internal/api/middleware/csrf.go:30-34`）对 GET/HEAD/OPTIONS 直接放行，所以两处导出**当前不会 403**。但修复仍有价值：
- **防御纵深**：export 若改成 POST（带复杂 filter body 时常见），或 CSRF scope 扩大，raw fetch 会立刻坏
- **401 处理**：raw fetch 在 session 过期时静默失败；client 会 logout + 跳登录
- **一致性**：三处导出现在都走 `api.download()`

## Verification

- ✅ `npm test`: 142/142 pass
- ✅ `svelte-check`: 38 errors（与 main 持平）
- ✅ `npm run build`: clean
- ✅ **浏览器实测**（192.168.63.101）：
  - devices CSV 导出：200 OK，15245 字节 `text/csv` blob 下载成功
  - scan-results CSV 导出：200 OK，44563 字节 `text/csv` blob 下载成功

## Test plan

- [ ] `npm test` + `npm run build` 通过
- [ ] 浏览器实测两处导出能下载文件
- [ ] （可选）session 过期后导出 → 跳登录（client 的 401 路径）

Closes #44