### PR TITLE
fix(web): 统一状态枚举本地化（共享 badge map，6 处）(#41)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -359,7 +359,9 @@
 		"Description": "Description",
 		"Tags": "Tags",
 		"Chart Unavailable": "Chart unavailable",
-		"Clear Search": "Clear search"
+		"Clear Search": "Clear search",
+		"On": "on",
+		"Off": "off"
 	},
 	"scanner": {
 		"Scanner": "Network Scanner",
@@ -514,7 +516,9 @@
 		"Cancelled": "Cancelled",
 		"Failed": "Failed",
 		"Run": "Run",
-		"New": "New"
+		"New": "New",
+		"Completed": "Completed",
+		"Status Triggered": "Triggered"
 	},
 	"labels": {
 		"Per Device Labels": "Per-Device Labels",
@@ -787,7 +791,11 @@
 		"Trigger Identify": "Identify",
 		"Pipeline": "Discovery Pipeline",
 		"Recent": "Recent Discoveries",
-		"No Recent": "No recent discoveries. New hosts detected by the passive sources will appear here."
+		"No Recent": "No recent discoveries. New hosts detected by the passive sources will appear here.",
+		"Recorded": "Recorded",
+		"Skipped Known": "Known (skipped)",
+		"Skipped Recent": "Suppressed (recent)",
+		"Identify Failed": "Identify failed"
 	},
 	"topology": {
 		"Title": "Network Topology",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -359,7 +359,9 @@
 		"Description": "描述",
 		"Tags": "标签",
 		"Chart Unavailable": "图表不可用",
-		"Clear Search": "清除搜索"
+		"Clear Search": "清除搜索",
+		"On": "开",
+		"Off": "关"
 	},
 	"scanner": {
 		"Scanner": "网络扫描器",
@@ -514,7 +516,9 @@
 		"Cancelled": "已取消",
 		"Failed": "失败",
 		"Run": "运行",
-		"New": "新增"
+		"New": "新增",
+		"Completed": "已完成",
+		"Status Triggered": "已触发"
 	},
 	"labels": {
 		"Per Device Labels": "设备级标签",
@@ -787,7 +791,11 @@
 		"Trigger Identify": "识别",
 		"Pipeline": "发现流水线",
 		"Recent": "最近发现",
-		"No Recent": "暂无最近发现。被动来源检测到的新主机将显示在此。"
+		"No Recent": "暂无最近发现。被动来源检测到的新主机将显示在此。",
+		"Recorded": "已记录",
+		"Skipped Known": "已知（跳过）",
+		"Skipped Recent": "已抑制（近期）",
+		"Identify Failed": "识别失败"
 	},
 	"topology": {
 		"Title": "网络拓扑",

--- a/web/src/lib/utils/badges.ts
+++ b/web/src/lib/utils/badges.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+ *
+ * This file is part of MiBee Steward, distributed under the GNU Affero General
+ * Public License v3.0 or later. A commercial license is available for use cases
+ * the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+ */
+
+import { m } from '$lib/i18n-paraglide';
+
+/**
+ * Shared status→badge maps. Each returns a localized `{ label, cls }` pair so
+ * backend enum values never reach the user as raw English. The `cls` follows
+ * the tailwind badge convention used across the app
+ * (`bg-<tone>/10 text-<tone>`). Unknown values fall back to a neutral badge
+ * and the raw string so new backend states remain visible rather than blank.
+ *
+ * Pattern cribbed from src/routes/agents/+page.svelte (commandStatusBadge).
+ */
+
+export interface Badge {
+	label: string;
+	cls: string;
+}
+
+/**
+ * Scan run lifecycle (5 states, per internal/service/scannerv2/runner + taskservice):
+ * running / completed / failed / cancelled / triggered.
+ */
+export function scanRunStatusBadge(status: string): Badge {
+	switch (status) {
+		case 'running':
+			return { label: m['scanner.Running'](), cls: 'bg-warning/10 text-warning' };
+		case 'completed':
+			return { label: m['scanner.Completed'](), cls: 'bg-success/10 text-success' };
+		case 'failed':
+			return { label: m['scanner.Failed'](), cls: 'bg-error/10 text-error' };
+		case 'cancelled':
+			return { label: m['scanner.Cancelled'](), cls: 'bg-surface text-text-muted border border-border' };
+		case 'triggered':
+			return { label: m['scanner.Status Triggered'](), cls: 'bg-accent/10 text-accent' };
+		default:
+			return { label: status, cls: 'bg-surface text-text-muted border border-border' };
+	}
+}
+
+/**
+ * Discovery event outcome (4 states, per internal/service/scannerv2/discovery):
+ * recorded / skipped_known / skipped_recent / identify_failed.
+ */
+export function discoveryOutcomeBadge(outcome: string): Badge {
+	switch (outcome) {
+		case 'recorded':
+			return { label: m['discovery.Recorded'](), cls: 'bg-success/10 text-success' };
+		case 'skipped_known':
+			return { label: m['discovery.Skipped Known'](), cls: 'bg-surface text-text-muted border border-border' };
+		case 'skipped_recent':
+			return { label: m['discovery.Skipped Recent'](), cls: 'bg-warning/10 text-warning' };
+		case 'identify_failed':
+			return { label: m['discovery.Identify Failed'](), cls: 'bg-error/10 text-error' };
+		default:
+			return { label: outcome, cls: 'bg-surface text-text-muted border border-border' };
+	}
+}
+
+/**
+ * Notification channel type (2 states, per internal/domain/notification):
+ * webhook / email.
+ */
+export function channelTypeBadge(type: string): Badge {
+	switch (type) {
+		case 'webhook':
+			return { label: m['notifications.Webhook'](), cls: 'bg-accent/10 text-accent' };
+		case 'email':
+			return { label: m['notifications.Email'](), cls: 'bg-primary/10 text-primary' };
+		default:
+			return { label: type, cls: 'bg-surface text-text-muted border border-border' };
+	}
+}
+
+/**
+ * Localized on/off for boolean flags rendered as a status word.
+ * Treats undefined/null as "off" (flags default off in the backend config).
+ */
+export function onOffBadge(value: boolean | undefined | null): Badge {
+	return value
+		? { label: m['common.On'](), cls: 'bg-success/10 text-success' }
+		: { label: m['common.Off'](), cls: 'bg-surface text-text-muted border border-border' };
+}

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -23,6 +23,7 @@
 	import { goto } from '$app/navigation';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { scanRunStatusBadge } from '$lib/utils/badges';
 	import { auth } from '$lib/stores/auth';
 	import type { EChartsOption } from '$lib/charts/echarts';
 
@@ -911,11 +912,12 @@
 								</thead>
 								<tbody>
 									{#each overview.scanning.recent_runs as run}
+										{@const s = scanRunStatusBadge(run.status)}
 										<tr class="border-b border-border/50 last:border-0">
 											<td class="py-2 pr-3 font-mono text-xs">#{run.id}</td>
 											<td class="py-2 pr-3">
-												<span class="inline-flex items-center gap-1 {run.status === 'completed' ? 'text-success' : run.status === 'failed' ? 'text-error' : 'text-accent'}">
-													{run.status === 'completed' ? '✓' : run.status === 'failed' ? '✗' : '◌'} {run.status}
+												<span class="inline-flex items-center gap-1 {s.cls}">
+													{s.label}
 												</span>
 											</td>
 											<td class="py-2 pr-3 tabular-nums">{run.alive_hosts}/{run.total_hosts}</td>

--- a/web/src/routes/devices/discovery/+page.svelte
+++ b/web/src/routes/devices/discovery/+page.svelte
@@ -16,6 +16,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount, onDestroy } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { discoveryOutcomeBadge, onOffBadge } from '$lib/utils/badges';
 	import PageSkeleton from '$lib/components/PageSkeleton.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { Radar as RadarIcon } from '@lucide/svelte';
@@ -48,16 +49,6 @@
 	function formatTime(iso?: string): string {
 		if (!iso) return '-';
 		try { return new Date(iso).toLocaleString(); } catch { return iso; }
-	}
-
-	function outcomeBadge(outcome: string): string {
-		switch (outcome) {
-			case 'recorded': return 'bg-success/10 text-success';
-			case 'skipped_known': return 'bg-surface text-text-muted border border-border';
-			case 'skipped_recent': return 'bg-accent/10 text-accent';
-			case 'identify_failed': return 'bg-error/10 text-error';
-			default: return 'bg-surface text-text-muted border border-border';
-		}
 	}
 
 	let stats = $derived(status?.stats ?? {});
@@ -135,7 +126,7 @@
 			{#if status.config}
 				<div class="flex flex-wrap items-center gap-4 mt-2 text-xs text-text-muted">
 					<span>{m['discovery.Interval']()}: <span class="font-mono text-text">{(status.config.Interval ?? 0) / 1e9}s</span></span>
-					<span>{m['discovery.Trigger Identify']()}: <span class="font-mono text-text">{status.config.TriggerIdentify ? 'on' : 'off'}</span></span>
+					<span>{m['discovery.Trigger Identify']()}: <span class="font-mono text-text">{onOffBadge(status.config.TriggerIdentify).label}</span></span>
 				</div>
 			{/if}
 		</div>
@@ -170,12 +161,13 @@
 						</thead>
 						<tbody>
 							{#each [...status.recent_discoveries].reverse() as ev}
+								{@const ob = discoveryOutcomeBadge(ev.outcome)}
 								<tr class="border-b border-border/50 last:border-b-0">
 									<td class="px-4 py-2 font-mono text-xs text-text">{ev.ip}</td>
 									<td class="px-4 py-2 font-mono text-xs text-text-muted">{ev.mac ?? '-'}</td>
 									<td class="px-4 py-2 font-mono text-xs text-text-muted">{ev.source}</td>
 									<td class="px-4 py-2">
-										<span class="text-xs px-2 py-0.5 rounded-full font-mono {outcomeBadge(ev.outcome)}">{ev.outcome}</span>
+									<span class="text-xs px-2 py-0.5 rounded-full font-mono {ob.cls}">{ob.label}</span>
 									</td>
 									<td class="px-4 py-2 text-xs text-text-muted">{formatTime(ev.at)}</td>
 								</tr>

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -14,6 +14,7 @@
 	import { onMount } from 'svelte';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { scanRunStatusBadge } from '$lib/utils/badges';
 	import { goto } from '$app/navigation';
 
 	import Pagination from '$lib/components/Pagination.svelte';
@@ -308,19 +309,6 @@
 		if (bytes < 1024) return `${bytes} B`;
 		if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
 		return `${(bytes / 1048576).toFixed(1)} MB`;
-	}
-
-	function runStatusClass(status: string): string {
-		switch (status) {
-			case 'completed':
-				return 'text-success bg-success/10';
-			case 'running':
-				return 'text-warning bg-warning/10';
-			case 'failed':
-				return 'text-error bg-error/10';
-			default:
-				return 'text-text-muted bg-border';
-		}
 	}
 </script>
 
@@ -711,14 +699,15 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each runs as run}
-							<tr class="border-b border-border last:border-b-0 hover:bg-border/30 transition-colors">
-								<td class="px-4 py-3 text-sm font-mono text-text-muted">#{run.id}</td>
-								<td class="px-4 py-3">
-									<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize {runStatusClass(run.status)}">
-										{run.status}
-									</span>
-								</td>
+							{#each runs as run}
+								{@const s = scanRunStatusBadge(run.status)}
+								<tr class="border-b border-border last:border-b-0 hover:bg-border/30 transition-colors">
+									<td class="px-4 py-3 text-sm font-mono text-text-muted">#{run.id}</td>
+									<td class="px-4 py-3">
+										<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {s.cls}">
+											{s.label}
+										</span>
+									</td>
 								<td class="px-4 py-3 text-sm text-text">{formatDuration(run.duration_ms)}</td>
 								<td class="px-4 py-3 text-sm text-text">
 									<span class="text-success">{run.alive_hosts}</span>

--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -505,7 +505,7 @@
 											</div>
 										{:else if run?.status === 'completed'}
 											<span class="inline-flex items-center gap-1 text-success">
-												✓ {run.alive_hosts}/{run.total_hosts} alive ({run.duration_ms}ms)
+												✓ {m['scanner.Scan Done']({ alive: run.alive_hosts, total: run.total_hosts, new: run.new_hosts, duration: run.duration_ms })}
 											</span>
 										{:else if run?.status === 'cancelled'}
 											<span class="inline-flex items-center gap-1 text-text-muted">

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -14,6 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { channelTypeBadge } from '$lib/utils/badges';
 	import { addToast } from '$lib/stores/toast';
 
 	import Modal from '$lib/components/Modal.svelte';
@@ -278,8 +279,8 @@
 			sortable: true,
 			render: (row: Record<string, unknown>) => {
 				const t = String(row.type);
-				const color = t === 'webhook' ? 'var(--color-accent)' : 'var(--color-primary)';
-				return `<span class="text-xs px-2 py-0.5 rounded font-mono" style="background: ${color}10; color: ${color}">${t}</span>`;
+				const b = channelTypeBadge(t);
+				return `<span class="text-xs px-2 py-0.5 rounded font-mono ${b.cls}">${b.label}</span>`;
 			}
 		},
 		{


### PR DESCRIPTION
## Summary

6 处页面把后端 enum 值原始渲染（`completed`/`running`/`recorded`/`webhook`/`on`），没走 i18n。agents 页已有正确模式（`commandStatusBadge`）。本 PR 把模式抽成共享 util 并应用到所有点。

## Changes

**新文件 `src/lib/utils/badges.ts`** — 4 个本地化 `{label, cls}` map：
- `scanRunStatusBadge`（running/completed/failed/cancelled/triggered）
- `discoveryOutcomeBadge`（recorded/skipped_known/skipped_recent/identify_failed）
- `channelTypeBadge`（webhook/email）
- `onOffBadge`（boolean → 本地化 on/off，容许 undefined）

每个对未知值 fallback 到原始字符串 + 中性样式（新 backend 状态保持可见而非空白）。

**调用点转换**：
| 文件 | 原始渲染 | 改为 |
|---|---|---|
| dashboard | `{run.status === 'completed' ? '✓' : ...} {run.status}` | `scanRunStatusBadge` |
| scan-results | `runStatusClass()` + 原始 `{run.status}` | `scanRunStatusBadge`（删冗余 helper） |
| scan-tasks | `alive (Nms)` 硬编码 | 现成 `scanner.Scan Done` 参数化 key |
| discovery | `'on'/'off'` + `outcomeBadge()` CSS-only + 原始 `{ev.outcome}` | `onOffBadge` + `discoveryOutcomeBadge` |
| notifications | 原始 `${t}` channel type | `channelTypeBadge` |

## i18n

8 个新 key（en + zh 对齐）：
- `scanner.Completed` / `scanner.Status Triggered`
- `discovery.Recorded` / `Skipped Known` / `Skipped Recent` / `Identify Failed`
- `common.On` / `common.Off`

复用现有 `scanner.Running`/`Cancelled`/`Failed`、`notifications.Webhook`/`Email`。**未**复用 `scanner.Triggered`（那是 toast，语义不对）。

## Verification

- ✅ `npm test`: 142/142 pass
- ✅ `svelte-check`: 38 errors（与 main 持平）
- ✅ `npm run build`: clean（修了 build 抓到的 2 个 `{@const}` in `<td>` 位置错误——移到 `{#each}` 首子级）
- ✅ **浏览器实测**（192.168.63.101，zh 环境）：
  - dashboard 扫描活动：**"已完成" / "运行中" / "失败"**（原 completed/running/failed）
  - discovery：TriggerIdentify 显示 **"开"**（原 'on'）；outcome badge 显示 **"已抑制（近期）"**（原 skipped_recent）

## Test plan

- [ ] `npm test` + `npm run build` 通过
- [ ] 浏览器实测：dashboard/scan-results/discovery/notifications 各 enum 显示中文

Closes #41