### PR TITLE
fix(web,api): per-user unread tracking for notification bell (#48)

### DIFF
--- a/db/queries/notifications.sql
+++ b/db/queries/notifications.sql
@@ -53,3 +53,34 @@ DELETE FROM notification_log
 WHERE rowid IN (
     SELECT rowid FROM notification_log WHERE notification_log.sent_at < ? LIMIT ?
 );
+
+-- name: ListNotificationLogsForUser :many
+-- Recent notification logs with a per-user is_read flag (drives the bell's
+-- unread styling).notification_log is system-wide; read state is per-user.
+SELECT l.id, l.rule_id, l.channel_id, l.status, l.payload, l.error_message, l.sent_at,
+       EXISTS(
+           SELECT 1 FROM notification_read_states s
+           WHERE s.user_id = ? AND s.notification_log_id = l.id
+       ) AS is_read
+FROM notification_log l
+ORDER BY l.sent_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: CountUnreadNotificationLogsForUser :one
+-- Unread count for a user (logs with no matching read_state row).
+SELECT COUNT(*) FROM notification_log l
+WHERE NOT EXISTS(
+    SELECT 1 FROM notification_read_states s
+    WHERE s.user_id = ? AND s.notification_log_id = l.id
+);
+
+-- name: MarkAllNotificationLogsRead :execrows
+-- Idempotently mark all currently-unread notification logs as read for a
+-- user (INSERT OR IGNORE skips any pair already present). Returns the number
+-- of rows inserted (i.e. newly-read logs).
+INSERT OR IGNORE INTO notification_read_states (user_id, notification_log_id)
+SELECT ?, l.id FROM notification_log l
+WHERE NOT EXISTS(
+    SELECT 1 FROM notification_read_states s
+    WHERE s.user_id = ? AND s.notification_log_id = l.id
+);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -237,6 +237,17 @@ CREATE TABLE IF NOT EXISTS notification_log (
     sent_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Per-user notification read state. notification_log is system-wide (no
+-- recipient concept — it's a delivery log), so a separate join table tracks
+-- which (user_id, notification_log_id) pairs each user has read. This lets
+-- the header bell show a per-user unread count and clear on dropdown open.
+CREATE TABLE IF NOT EXISTS notification_read_states (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    notification_log_id INTEGER NOT NULL REFERENCES notification_log(id) ON DELETE CASCADE,
+    read_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, notification_log_id)
+);
+
 -- User TOTP (2FA)
 CREATE TABLE IF NOT EXISTS user_totp (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -146,8 +146,12 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 		r.Post("/{id}/test", notificationHandler.TestChannel)
 	})
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		// Notification logs + mark-as-read are RequireAuth (the header bell
+		// renders for every authenticated user, each with per-user read state).
+		// Channel CRUD above stays admin-only.
+		r.Use(middleware.RequireAuth)
 		r.Get("/api/v1/notification/logs", notificationHandler.ListNotificationLogs)
+		r.Post("/api/v1/notification/logs/read", notificationHandler.MarkAllNotificationLogsRead)
 	})
 
 	// Prometheus metrics
@@ -175,7 +179,15 @@ func insertTestAdmin(t *testing.T, db *sql.DB) {
 // loginAsAdmin logs in with the seeded admin and returns the JWT token.
 func loginAsAdmin(t *testing.T, server *httptest.Server) string {
 	t.Helper()
-	body := `{"username":"admin","password":"admin123"}`
+	return loginAs(t, server, "admin", "admin123")
+}
+
+// loginAs logs in with an arbitrary username/password and returns the JWT
+// token. Use insertTestAdmin + loginAsAdmin for the admin, or insert a user
+// row directly then call this for non-admin test users.
+func loginAs(t *testing.T, server *httptest.Server, username, password string) string {
+	t.Helper()
+	body := `{"username":"` + username + `","password":"` + password + `"}`
 	resp, err := http.Post(server.URL+"/api/v1/auth/login", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -212,13 +212,25 @@ func (h *NotificationHandler) TestChannel(w http.ResponseWriter, r *http.Request
 // --- Notification Log Endpoints ---
 
 // ListNotificationLogs handles GET /api/v1/notification/logs
+//
+// Returns the most recent logs for the requesting user with a per-user
+// is_read flag, and a "total" field that is the user's UNREAD count (not the
+// total row count) — this is what the header bell needs for the badge. The
+// legacy system-wide view is available via the service layer but not exposed
+// over HTTP (no current consumer needs it).
 func (h *NotificationHandler) ListNotificationLogs(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
 	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
 
-	logs, total, err := h.svc.ListNotificationLogs(r.Context(), limit, offset)
+	userID, _, ok := middleware.GetUserFromContext(r)
+	if !ok {
+		Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	logs, unread, err := h.svc.ListNotificationLogsForUser(r.Context(), userID, limit, offset)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to list notification logs")
 		return
@@ -226,8 +238,29 @@ func (h *NotificationHandler) ListNotificationLogs(w http.ResponseWriter, r *htt
 
 	Success(w, domain.NotificationLogListResponse{
 		Logs:  logs,
-		Total: int(total),
+		Total: int(unread),
 	})
+}
+
+// MarkAllNotificationLogsRead handles POST /api/v1/notification/logs/read
+//
+// Marks every currently-unread notification log as read for the requesting
+// user (idempotent). The header bell calls this when its dropdown is opened,
+// clearing the unread badge.
+func (h *NotificationHandler) MarkAllNotificationLogsRead(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := middleware.GetUserFromContext(r)
+	if !ok {
+		Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	n, err := h.svc.MarkAllNotificationLogsRead(r.Context(), userID)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to mark notification logs as read")
+		return
+	}
+
+	Success(w, domain.MarkAllReadResponse{Marked: n})
 }
 
 // --- Helpers ---

--- a/internal/api/handler/notification_test.go
+++ b/internal/api/handler/notification_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 
 	"mibee-steward/internal/domain"
 )
@@ -137,6 +138,10 @@ func TestNotificationChannel_NotFound(t *testing.T) {
 // --- Alert Rule Tests removed: MiBee Steward does not build alerting. ---
 
 // --- Notification Log Tests ---
+//
+// Note: the "total" field in GET /notification/logs responses is the
+// requesting user's UNREAD count (not the total row count) — the header bell
+// consumes it for the badge. The tests below assert unread semantics.
 
 func TestNotificationLogs_List(t *testing.T) {
 	server, db := setupTestServer(t)
@@ -169,7 +174,7 @@ func TestNotificationLogs_Pagination(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Default pagination
+	// Default pagination — 5 unread for admin (total == unread count)
 	resp := authGet(t, server.URL+"/api/v1/notification/logs", token)
 	require.Equal(t, 200, resp.StatusCode)
 	var result map[string]interface{}
@@ -178,8 +183,12 @@ func TestNotificationLogs_Pagination(t *testing.T) {
 	logList, ok := result["logs"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, logList, 5)
+	// Each log carries a per-user is_read flag (all unread here).
+	firstLog, ok := logList[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, false, firstLog["is_read"])
 
-	// Limit 2
+	// Limit 2 — unread count is still 5 (pagination doesn't change the badge)
 	resp = authGet(t, server.URL+"/api/v1/notification/logs?limit=2&offset=0", token)
 	require.Equal(t, 200, resp.StatusCode)
 	var paginated map[string]interface{}
@@ -197,6 +206,142 @@ func TestNotificationLogs_Pagination(t *testing.T) {
 	offsetList, ok := offsetResult["logs"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, offsetList, 2)
+}
+
+// TestNotificationLogs_MarkAllRead verifies the bell's core flow: unread count
+// reflects new logs, drops to 0 after mark-all-read, and stays 0 on refresh.
+func TestNotificationLogs_MarkAllRead(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+	token := loginAsAdmin(t, server)
+
+	// Insert 3 notification logs
+	for i := 0; i < 3; i++ {
+		_, err := db.Exec(
+			"INSERT INTO notification_log (status, payload, error_message) VALUES (?, ?, ?)",
+			"sent", `{"subject":"test"}`, "",
+		)
+		require.NoError(t, err)
+	}
+
+	// GET /logs → unread count = 3, all logs is_read=false
+	resp := authGet(t, server.URL+"/api/v1/notification/logs", token)
+	require.Equal(t, 200, resp.StatusCode)
+	var before map[string]interface{}
+	decodeJSON(t, resp, &before)
+	require.Equal(t, float64(3), before["total"])
+
+	// POST /logs/read → mark all read
+	resp = authPost(t, server.URL+"/api/v1/notification/logs/read", token, "")
+	require.Equal(t, 200, resp.StatusCode)
+	var markResult map[string]interface{}
+	decodeJSON(t, resp, &markResult)
+	require.Equal(t, float64(3), markResult["marked"])
+
+	// GET /logs again → unread count = 0, all logs is_read=true
+	resp = authGet(t, server.URL+"/api/v1/notification/logs", token)
+	require.Equal(t, 200, resp.StatusCode)
+	var after map[string]interface{}
+	decodeJSON(t, resp, &after)
+	require.Equal(t, float64(0), after["total"])
+	logList, ok := after["logs"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, logList, 3) // list still shows all logs, just marked read
+	firstLog, ok := logList[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, firstLog["is_read"])
+
+	// POST /logs/read again → idempotent, 0 newly-marked
+	resp = authPost(t, server.URL+"/api/v1/notification/logs/read", token, "")
+	require.Equal(t, 200, resp.StatusCode)
+	var markResult2 map[string]interface{}
+	decodeJSON(t, resp, &markResult2)
+	require.Equal(t, float64(0), markResult2["marked"])
+}
+
+// TestNotificationLogs_PerUserIsolation verifies each user has an independent
+// read water mark — user A marking read does NOT clear user B's badge.
+func TestNotificationLogs_PerUserIsolation(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+	adminToken := loginAsAdmin(t, server)
+
+	// Create a second (non-admin) user
+	hash, err := bcrypt.GenerateFromPassword([]byte("user123"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	_, err = db.Exec(
+		"INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+		"alice", "alice@test.com", string(hash), "user",
+	)
+	require.NoError(t, err)
+	aliceToken := loginAs(t, server, "alice", "user123")
+
+	// Insert 2 notification logs
+	for i := 0; i < 2; i++ {
+		_, err := db.Exec(
+			"INSERT INTO notification_log (status, payload, error_message) VALUES (?, ?, ?)",
+			"sent", `{"subject":"test"}`, "",
+		)
+		require.NoError(t, err)
+	}
+
+	// Both users start with 2 unread
+	for _, tok := range []string{adminToken, aliceToken} {
+		resp := authGet(t, server.URL+"/api/v1/notification/logs", tok)
+		require.Equal(t, 200, resp.StatusCode)
+		var r map[string]interface{}
+		decodeJSON(t, resp, &r)
+		require.Equal(t, float64(2), r["total"], "both users should see 2 unread initially")
+	}
+
+	// Admin marks all read
+	resp := authPost(t, server.URL+"/api/v1/notification/logs/read", adminToken, "")
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Admin now has 0 unread, Alice STILL has 2 (independent water marks)
+	resp = authGet(t, server.URL+"/api/v1/notification/logs", adminToken)
+	require.Equal(t, 200, resp.StatusCode)
+	var adminAfter map[string]interface{}
+	decodeJSON(t, resp, &adminAfter)
+	require.Equal(t, float64(0), adminAfter["total"], "admin should have 0 unread after marking")
+
+	resp = authGet(t, server.URL+"/api/v1/notification/logs", aliceToken)
+	require.Equal(t, 200, resp.StatusCode)
+	var aliceAfter map[string]interface{}
+	decodeJSON(t, resp, &aliceAfter)
+	require.Equal(t, float64(2), aliceAfter["total"], "alice should still have 2 unread (independent water mark)")
+}
+
+// TestNotificationLogs_RequireAuthNotAdmin verifies the route was widened from
+// RequireAdmin to RequireAuth: a regular (non-admin) user can now read logs
+// and mark them read, because the bell renders for every authenticated user.
+func TestNotificationLogs_RequireAuthNotAdmin(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+
+	// Create a non-admin user
+	hash, err := bcrypt.GenerateFromPassword([]byte("user123"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	_, err = db.Exec(
+		"INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+		"bob", "bob@test.com", string(hash), "user",
+	)
+	require.NoError(t, err)
+	bobToken := loginAs(t, server, "bob", "user123")
+
+	// Non-admin can GET /logs (would have been 403 under the old RequireAdmin)
+	resp := authGet(t, server.URL+"/api/v1/notification/logs", bobToken)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Non-admin can POST /logs/read
+	resp = authPost(t, server.URL+"/api/v1/notification/logs/read", bobToken, "")
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Unauthenticated is still rejected
+	resp, err = server.Client().Get(server.URL + "/api/v1/notification/logs")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, 401, resp.StatusCode)
 }
 
 // --- Test Channel Endpoint ---

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -729,10 +729,13 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Post("/{id}/test", notificationHandler.TestChannel)
 	})
 
-	// Notification log routes (admin only)
+	// Notification log routes — every authenticated user sees the header bell
+	// and has their own per-user read state, so logs + mark-as-read are
+	// RequireAuth (NOT RequireAdmin). Channel CRUD above stays admin-only.
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireAuth)
 		r.Get("/api/v1/notification/logs", notificationHandler.ListNotificationLogs)
+		r.Post("/api/v1/notification/logs/read", notificationHandler.MarkAllNotificationLogsRead)
 	})
 
 	// Prometheus metrics + HTTP service discovery are PUBLIC: Prometheus

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -247,6 +247,12 @@ type NotificationLog struct {
 	SentAt       time.Time `json:"sent_at"`
 }
 
+type NotificationReadState struct {
+	UserID            int64     `json:"user_id"`
+	NotificationLogID int64     `json:"notification_log_id"`
+	ReadAt            time.Time `json:"read_at"`
+}
+
 type ScanResult struct {
 	ID                   int64     `json:"id"`
 	TaskID               int64     `json:"task_id"`

--- a/internal/db/notifications.sql.go
+++ b/internal/db/notifications.sql.go
@@ -21,6 +21,22 @@ func (q *Queries) CountNotificationLogs(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const countUnreadNotificationLogsForUser = `-- name: CountUnreadNotificationLogsForUser :one
+SELECT COUNT(*) FROM notification_log l
+WHERE NOT EXISTS(
+    SELECT 1 FROM notification_read_states s
+    WHERE s.user_id = ? AND s.notification_log_id = l.id
+)
+`
+
+// Unread count for a user (logs with no matching read_state row).
+func (q *Queries) CountUnreadNotificationLogsForUser(ctx context.Context, userID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countUnreadNotificationLogsForUser, userID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createChannel = `-- name: CreateChannel :one
 
 INSERT INTO notification_channels (name, type, config, enabled)
@@ -309,6 +325,93 @@ func (q *Queries) ListNotificationLogsByRule(ctx context.Context, ruleID *int64)
 		return nil, err
 	}
 	return items, nil
+}
+
+const listNotificationLogsForUser = `-- name: ListNotificationLogsForUser :many
+SELECT l.id, l.rule_id, l.channel_id, l.status, l.payload, l.error_message, l.sent_at,
+       EXISTS(
+           SELECT 1 FROM notification_read_states s
+           WHERE s.user_id = ? AND s.notification_log_id = l.id
+       ) AS is_read
+FROM notification_log l
+ORDER BY l.sent_at DESC
+LIMIT ? OFFSET ?
+`
+
+type ListNotificationLogsForUserParams struct {
+	UserID int64 `json:"user_id"`
+	Limit  int64 `json:"limit"`
+	Offset int64 `json:"offset"`
+}
+
+type ListNotificationLogsForUserRow struct {
+	ID           int64     `json:"id"`
+	RuleID       *int64    `json:"rule_id"`
+	ChannelID    *int64    `json:"channel_id"`
+	Status       string    `json:"status"`
+	Payload      string    `json:"payload"`
+	ErrorMessage string    `json:"error_message"`
+	SentAt       time.Time `json:"sent_at"`
+	IsRead       bool      `json:"is_read"`
+}
+
+// Recent notification logs with a per-user is_read flag (drives the bell's
+// unread styling).notification_log is system-wide; read state is per-user.
+func (q *Queries) ListNotificationLogsForUser(ctx context.Context, arg ListNotificationLogsForUserParams) ([]ListNotificationLogsForUserRow, error) {
+	rows, err := q.db.QueryContext(ctx, listNotificationLogsForUser, arg.UserID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListNotificationLogsForUserRow{}
+	for rows.Next() {
+		var i ListNotificationLogsForUserRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.RuleID,
+			&i.ChannelID,
+			&i.Status,
+			&i.Payload,
+			&i.ErrorMessage,
+			&i.SentAt,
+			&i.IsRead,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const markAllNotificationLogsRead = `-- name: MarkAllNotificationLogsRead :execrows
+INSERT OR IGNORE INTO notification_read_states (user_id, notification_log_id)
+SELECT ?, l.id FROM notification_log l
+WHERE NOT EXISTS(
+    SELECT 1 FROM notification_read_states s
+    WHERE s.user_id = ? AND s.notification_log_id = l.id
+)
+`
+
+type MarkAllNotificationLogsReadParams struct {
+	UserID   int64 `json:"user_id"`
+	UserID_2 int64 `json:"user_id_2"`
+}
+
+// Idempotently mark all currently-unread notification logs as read for a
+// user (INSERT OR IGNORE skips any pair already present). Returns the number
+// of rows inserted (i.e. newly-read logs).
+func (q *Queries) MarkAllNotificationLogsRead(ctx context.Context, arg MarkAllNotificationLogsReadParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markAllNotificationLogsRead, arg.UserID, arg.UserID_2)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateChannel = `-- name: UpdateChannel :one

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -58,6 +58,9 @@ type NotificationLogResponse struct {
 	Payload      string    `json:"payload"`
 	ErrorMessage string    `json:"error_message"`
 	SentAt       time.Time `json:"sent_at"`
+	// IsRead is per-user (the bell renders for every authenticated user, each
+	// with an independent unread water mark). Drives unread styling + count.
+	IsRead bool `json:"is_read"`
 }
 
 type ChannelListResponse struct {
@@ -66,6 +69,15 @@ type ChannelListResponse struct {
 }
 
 type NotificationLogListResponse struct {
-	Logs  []NotificationLogResponse `json:"logs"`
-	Total int                       `json:"total"`
+	Logs []NotificationLogResponse `json:"logs"`
+	// Total is the requesting user's UNREAD count (not the total log row count).
+	// The field name is kept for backwards-compat with the existing frontend
+	// NotificationBell consumer; the bell only ever needed the unread count.
+	Total int `json:"total"`
+}
+
+// MarkAllReadResponse is returned by POST /notification/logs/read.
+type MarkAllReadResponse struct {
+	// Marked is the number of logs newly marked as read for the user.
+	Marked int64 `json:"marked"`
 }

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -155,6 +155,9 @@ func (s *NotificationService) DeleteChannel(ctx context.Context, id int64) error
 // --- Notification Logs ---
 
 // ListNotificationLogs returns notification logs with pagination.
+// NOTE: this is the legacy system-wide view (no per-user read state). The
+// header bell uses ListNotificationLogsForUser instead; this is kept for any
+// future admin/audit consumer that wants the raw delivery log.
 func (s *NotificationService) ListNotificationLogs(ctx context.Context, limit, offset int64) ([]domain.NotificationLogResponse, int64, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
@@ -178,9 +181,65 @@ func (s *NotificationService) ListNotificationLogs(ctx context.Context, limit, o
 
 	result := make([]domain.NotificationLogResponse, len(logs))
 	for i, log := range logs {
-		result[i] = toNotificationLogResponse(log)
+		// Legacy view has no per-user read state; treat all as read.
+		result[i] = toNotificationLogResponse(log, true)
 	}
 	return result, total, nil
+}
+
+// ListNotificationLogsForUser returns the most recent notification logs for a
+// user, each annotated with that user's is_read flag, plus the user's unread
+// count. This is what the header bell consumes: the list for the dropdown and
+// the unread count for the badge.
+func (s *NotificationService) ListNotificationLogsForUser(ctx context.Context, userID, limit, offset int64) ([]domain.NotificationLogResponse, int64, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	unread, err := s.q.CountUnreadNotificationLogsForUser(ctx, userID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count unread notification logs: %w", err)
+	}
+
+	rows, err := s.q.ListNotificationLogsForUser(ctx, db.ListNotificationLogsForUserParams{
+		UserID: userID,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list notification logs for user: %w", err)
+	}
+
+	result := make([]domain.NotificationLogResponse, len(rows))
+	for i, row := range rows {
+		result[i] = domain.NotificationLogResponse{
+			ID:           row.ID,
+			RuleID:       row.RuleID,
+			ChannelID:    row.ChannelID,
+			Status:       row.Status,
+			Payload:      row.Payload,
+			ErrorMessage: row.ErrorMessage,
+			SentAt:       row.SentAt,
+			IsRead:       row.IsRead,
+		}
+	}
+	return result, unread, nil
+}
+
+// MarkAllNotificationLogsRead marks every currently-unread notification log as
+// read for the user (idempotent). Returns the number of logs newly marked.
+func (s *NotificationService) MarkAllNotificationLogsRead(ctx context.Context, userID int64) (int64, error) {
+	n, err := s.q.MarkAllNotificationLogsRead(ctx, db.MarkAllNotificationLogsReadParams{
+		UserID:   userID,
+		UserID_2: userID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to mark notification logs as read: %w", err)
+	}
+	return n, nil
 }
 
 // --- Response transformers ---
@@ -197,7 +256,7 @@ func toChannelResponse(ch db.NotificationChannel) domain.ChannelResponse {
 	}
 }
 
-func toNotificationLogResponse(log db.NotificationLog) domain.NotificationLogResponse {
+func toNotificationLogResponse(log db.NotificationLog, isRead bool) domain.NotificationLogResponse {
 	return domain.NotificationLogResponse{
 		ID:           log.ID,
 		RuleID:       log.RuleID,
@@ -206,5 +265,6 @@ func toNotificationLogResponse(log db.NotificationLog) domain.NotificationLogRes
 		Payload:      log.Payload,
 		ErrorMessage: log.ErrorMessage,
 		SentAt:       log.SentAt,
+		IsRead:       isRead,
 	}
 }

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -66,6 +66,7 @@ func TestSetupTestDBFromSchema(t *testing.T) {
 		"networks",
 		"notification_channels",
 		"notification_log",
+		"notification_read_states",
 		"scan_results",
 		"scan_snapshots",
 		"scan_task_runs",
@@ -85,12 +86,12 @@ func TestSetupTestDBFromSchema_Reusable(t *testing.T) {
 	db1, err := testutil.SetupTestDBFromSchema()
 	require.NoError(t, err)
 	defer db1.Close()
-	require.Len(t, listTables(t, db1), 27)
+	require.Len(t, listTables(t, db1), 28)
 
 	db2, err := testutil.SetupTestDBFromSchema()
 	require.NoError(t, err)
 	defer db2.Close()
-	require.Len(t, listTables(t, db2), 27)
+	require.Len(t, listTables(t, db2), 28)
 }
 
 func TestSetupTestDB_WithPragmas(t *testing.T) {

--- a/web/src/lib/components/NotificationBell.svelte
+++ b/web/src/lib/components/NotificationBell.svelte
@@ -17,34 +17,39 @@
 
 	interface NotificationLog {
 		id: number;
-		rule_name: string;
-		channel_name: string;
-		channel_type: string;
 		status: string;
 		payload: string;
 		error_message: string;
 		sent_at: string;
+		is_read: boolean;
 	}
 
 	interface NotificationLogsResponse {
 		logs: NotificationLog[];
+		// "total" is the requesting user's UNREAD count (server semantics), used
+		// directly as the bell badge value.
 		total: number;
+	}
+
+	interface MarkAllReadResponse {
+		marked: number;
 	}
 
 	let notifications = $state<NotificationLog[]>([]);
 	let unreadCount = $state(0);
 	let showDropdown = $state(false);
 	let loading = $state(false);
+	let marking = $state(false);
 	let containerRef: HTMLDivElement | undefined = $state();
 
 	async function fetchNotifications() {
 		try {
 			loading = true;
 			const res = await api.get<NotificationLogsResponse>(
-				'/notification/logs?status=sent&limit=10'
+				'/notification/logs?limit=10'
 			);
 			notifications = res.logs ?? [];
-			unreadCount = Math.min(res.total ?? 0, 99);
+			unreadCount = res.total ?? 0;
 		} catch {
 			// Silently fail — non-critical UI
 		} finally {
@@ -52,8 +57,46 @@
 		}
 	}
 
-	function toggleDropdown() {
+	async function markAllRead() {
+		if (marking || unreadCount === 0) return;
+		marking = true;
+		try {
+			await api.post<MarkAllReadResponse>('/notification/logs/read', {});
+			// Clear the badge + flip each visible item's is_read flag in place
+			// (index mutation, not array reassignment — reassigning the $state
+			// array while the dropdown's {#each} is mounted tears Svelte 5's
+			// effect graph and snaps the panel shut under hydration).
+			unreadCount = 0;
+			for (let i = 0; i < notifications.length; i++) {
+				notifications[i].is_read = true;
+			}
+		} catch {
+			// Silently fail — the badge will re-sync on the next poll.
+		} finally {
+			marking = false;
+		}
+	}
+
+	async function toggleDropdown() {
 		showDropdown = !showDropdown;
+		// Opening the dropdown marks everything read (clears the badge). This
+		// matches the common bell pattern (open == acknowledge all).
+		if (showDropdown) {
+			await markAllRead();
+		}
+	}
+
+	// Extract a human-readable subject from the notification payload JSON.
+	// The dispatcher stores { subject, body, recipient } — fall back to the
+	// delivery status if no subject is present.
+	function subject(payload: string, status: string): string {
+		try {
+			const parsed = JSON.parse(payload) as { subject?: string };
+			if (parsed.subject) return parsed.subject;
+		} catch {
+			// payload isn't JSON — fall through
+		}
+		return status === 'sent' ? m['notifications.Sent']() : m['notifications.Failed']();
 	}
 
 	function handleClickOutside(e: MouseEvent) {
@@ -91,7 +134,8 @@
 		<button
 			onclick={toggleDropdown}
 			class="btn-icon relative"
-			aria-label={m["notifications.Notification"]()}
+			aria-label={m["notifications.Notification"]()
+				+ (unreadCount > 0 ? ` (${unreadCount} ${m['notifications.Unread']()})` : '')}
 		>
 			<Bell class="w-5 h-5" />
 
@@ -136,36 +180,44 @@
 					{:else}
 						{#each notifications as notif}
 							<div
-								class="px-4 py-3 border-b border-border last:border-b-0
-									hover:bg-surface-2 transition-colors cursor-default"
+								class="flex gap-2 px-4 py-3 border-b border-border last:border-b-0
+									hover:bg-surface-2 transition-colors cursor-default
+									{notif.is_read ? 'opacity-60' : ''}"
 							>
-								<div class="flex items-start justify-between gap-2">
-									<p class="text-sm text-text font-medium truncate">
-										{notif.rule_name}
-									</p>
-									<span
-										class="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium
+								<!-- Unread dot (left rail) — only renders for unread items -->
+								<span
+									class="shrink-0 mt-1.5 w-2 h-2 rounded-full
+										{notif.is_read ? 'bg-transparent' : 'bg-primary'}"
+									aria-label={notif.is_read ? undefined : m['notifications.Unread']()}
+								></span>
+								<div class="min-w-0 flex-1">
+									<div class="flex items-start justify-between gap-2">
+										<p class="text-sm text-text truncate {notif.is_read ? 'font-normal' : 'font-medium'}">
+											{subject(notif.payload, notif.status)}
+										</p>
+										<span
+											class="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium
+												{notif.status === 'sent'
+												? 'bg-success/15 text-success'
+												: notif.status === 'failed'
+													? 'bg-error/15 text-error'
+													: 'bg-surface-2 text-muted'}"
+										>
 											{notif.status === 'sent'
-											? 'bg-success/15 text-success'
-											: notif.status === 'failed'
-												? 'bg-error/15 text-error'
-												: 'bg-surface-2 text-muted'}"
-									>
-										{notif.status === 'sent'
-											? m["notifications.Sent"]()
-											: notif.status === 'failed'
-												? m["notifications.Failed"]()
-												: notif.status}
-									</span>
-								</div>
-								<div class="flex items-center gap-2 mt-1">
-									<span class="text-xs text-muted truncate">
-										{notif.channel_name}
-									</span>
-									<span class="text-border-strong">·</span>
-									<span class="text-xs text-muted">
-										{formatTime(notif.sent_at)}
-									</span>
+												? m["notifications.Sent"]()
+												: notif.status === 'failed'
+													? m["notifications.Failed"]()
+													: notif.status}
+										</span>
+									</div>
+									{#if notif.error_message}
+										<p class="text-xs text-error mt-1 truncate">{notif.error_message}</p>
+									{/if}
+									<div class="flex items-center gap-2 mt-1">
+										<span class="text-xs text-muted">
+											{formatTime(notif.sent_at)}
+										</span>
+									</div>
 								</div>
 							</div>
 						{/each}


### PR DESCRIPTION
## Summary

The header notification bell badge **never cleared** — its `unreadCount` was the cumulative `COUNT(*)` of `notification_log` rows (a system-wide delivery log), and no mark-as-read path existed. Every admin saw a permanent badge that could only grow. This PR adds per-user unread tracking so the badge reflects what each user has actually seen and clears on dropdown open.

Confirmed design decisions (from issue discussion):
1. **Per-user read state table** (`notification_read_states`) — each user has an independent unread water mark
2. **Open dropdown = mark all read** (common bell pattern)
3. **Widen `/notification/logs` from `RequireAdmin` → `RequireAuth`** — the bell renders for every authenticated user, so per-user read state is meaningful for all of them (channel CRUD stays admin-only)

## Backend

- **New table** `notification_read_states(user_id, notification_log_id, read_at)` with composite PK + cascade FKs. `notification_log` is system-wide (no recipient concept), so read state lives in a separate join table.
- **3 new sqlc queries**: `ListNotificationLogsForUser` (EXISTS join → `is_read` flag), `CountUnreadNotificationLogsForUser`, `MarkAllNotificationLogsRead` (idempotent `INSERT OR IGNORE`).
- **GET `/notification/logs`** now returns per-user logs + `is_read`, and the response `total` field is the user's **unread count** (not total rows) — the bell consumes it directly as the badge value. Field name kept for backwards-compat with the existing frontend consumer.
- **New POST `/notification/logs/read`** marks all current logs read for the requesting user (idempotent, returns `{ marked: N }`).
- **Route widened** `RequireAdmin` → `RequireAuth` for `/notification/logs` (+ the new read endpoint). Channel CRUD routes stay `RequireAdmin`.

## Frontend

`web/src/lib/components/NotificationBell.svelte`:
- `fetchNotifications`: badge now driven by the unread count (dropped the dead `?status=sent` param and the `Math.min(..., 99)` cap).
- `toggleDropdown`: opening the dropdown fires `POST /logs/read` and clears the badge optimistically; each visible item's `is_read` flips in place via **index mutation** (NOT array reassignment — reassigning the `$state` array while the dropdown's `{#each}` is mounted tears Svelte 5's effect graph and snaps the panel shut under hydration; this was a real regression caught in browser testing).
- Dropdown items now show the **payload subject** (parsed from JSON) instead of the `undefined` `rule_name`/`channel_name` fields the backend never returned (secondary bug fixed in passing).
- Unread items get a primary-color left-rail dot + bold text; read items dim to 60% opacity. Failed deliveries surface their `error_message`. `aria-label` reflects the unread count.

## Tests

- **+3 backend tests**: `TestNotificationLogs_MarkAllRead` (3 unread → POST → 0 unread, idempotent re-POST returns 0), `TestNotificationLogs_PerUserIsolation` (admin marks read, viewer keeps their unread count — independent water marks), `TestNotificationLogs_RequireAuthNotAdmin` (non-admin can read + mark, unauthenticated still 401).
- Existing `List`/`Pagination` tests updated for the new `total == unread` semantics.
- `testutil` schema-tables test updated for the new table (+1 → 28 tables).
- Added a `loginAs(t, server, user, pass)` test helper (previously only `loginAsAdmin` existed, non-admin login was inline).

## Verification

- `sqlc compile` clean
- `go test ./...` — all pass (including 3 new notification tests)
- `gofmt -l` + `goimports -l` — both empty
- `npm test` → 142/142 pass
- `npx svelte-check` → 38 errors (baseline, no regressions)
- `npm run build` → clean
- **Browser-tested** on the test server (192.168.63.101) in both locales:
  - Triggered a notification log; bell badge shows the unread count ("通知 (2 未读)" / "Notification (1 unread)")
  - Opening the dropdown clears the badge immediately, items flip to read styling, dropdown stays open
  - Reload → badge stays 0 (read state persisted server-side)
  - Per-user isolation: admin marks read (badge 0), viewer still sees their own unread count
  - zh and en both render the dropdown subject text + aria-label correctly

Closes #48
