### PR TITLE
fix(web,api): scan-tasks search goes server-side so other pages are reachable (#54)

### DIFF
--- a/db/queries/scan_tasks.sql
+++ b/db/queries/scan_tasks.sql
@@ -23,6 +23,19 @@ FROM scan_tasks
 ORDER BY id
 LIMIT ? OFFSET ?;
 
+-- name: ListScanTasksSearch :many
+-- Optional case-insensitive substring search over name + targets. The first
+-- param is the raw search term; when it is '' the (? = '') short-circuits to
+-- TRUE so this behaves like ListScanTasks (no filter). INSTR() is used instead
+-- of LIKE so the search term needs no escaping (literal %/_ are not wildcards)
+-- and we pass the same value to both columns + the empty-check.
+-- CountScanTasksSearch below MUST use the same WHERE clause so totals match.
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+FROM scan_tasks
+WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)
+ORDER BY id
+LIMIT ? OFFSET ?;
+
 -- name: UpdateScanTask :one
 UPDATE scan_tasks
 SET name = ?, targets = ?, cron_expr = ?, pipeline_config = ?, global_labels = ?,
@@ -52,3 +65,10 @@ WHERE enabled = 1;
 -- name: CountScanTasks :one
 SELECT COUNT(*)
 FROM scan_tasks;
+
+-- name: CountScanTasksSearch :one
+-- Mirrors ListScanTasksSearch's WHERE clause so the pagination total reflects
+-- the active search (not the unfiltered row count).
+SELECT COUNT(*)
+FROM scan_tasks
+WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0);

--- a/internal/api/handler/scanner_task.go
+++ b/internal/api/handler/scanner_task.go
@@ -54,8 +54,9 @@ func (h *ScannerTaskHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 
 	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
+	search := q.Get("search")
 
-	tasks, total, err := h.service.ListTasks(r.Context(), int(limit), int(offset))
+	tasks, total, err := h.service.ListTasks(r.Context(), search, int(limit), int(offset))
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to list scan tasks")
 		return

--- a/internal/db/scan_tasks.sql.go
+++ b/internal/db/scan_tasks.sql.go
@@ -22,6 +22,27 @@ func (q *Queries) CountScanTasks(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const countScanTasksSearch = `-- name: CountScanTasksSearch :one
+SELECT COUNT(*)
+FROM scan_tasks
+WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)
+`
+
+type CountScanTasksSearchParams struct {
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+}
+
+// Mirrors ListScanTasksSearch's WHERE clause so the pagination total reflects
+// the active search (not the unfiltered row count).
+func (q *Queries) CountScanTasksSearch(ctx context.Context, arg CountScanTasksSearchParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countScanTasksSearch, arg.Column1, arg.LOWER, arg.LOWER_2)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createScanTask = `-- name: CreateScanTask :one
 
 INSERT INTO scan_tasks (name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, enabled)
@@ -176,6 +197,72 @@ type ListScanTasksParams struct {
 
 func (q *Queries) ListScanTasks(ctx context.Context, arg ListScanTasksParams) ([]ScanTask, error) {
 	rows, err := q.db.QueryContext(ctx, listScanTasks, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ScanTask{}
+	for rows.Next() {
+		var i ScanTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Targets,
+			&i.CronExpr,
+			&i.PipelineConfig,
+			&i.GlobalLabels,
+			&i.Timeout,
+			&i.ConcurrentHosts,
+			&i.Enabled,
+			&i.LastRunAt,
+			&i.NextRunAt,
+			&i.LastRunStatus,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listScanTasksSearch = `-- name: ListScanTasksSearch :many
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+FROM scan_tasks
+WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)
+ORDER BY id
+LIMIT ? OFFSET ?
+`
+
+type ListScanTasksSearchParams struct {
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+	Limit   int64       `json:"limit"`
+	Offset  int64       `json:"offset"`
+}
+
+// Optional case-insensitive substring search over name + targets. The first
+// param is the raw search term; when it is ” the (? = ”) short-circuits to
+// TRUE so this behaves like ListScanTasks (no filter). INSTR() is used instead
+// of LIKE so the search term needs no escaping (literal %/_ are not wildcards)
+// and we pass the same value to both columns + the empty-check.
+// CountScanTasksSearch below MUST use the same WHERE clause so totals match.
+func (q *Queries) ListScanTasksSearch(ctx context.Context, arg ListScanTasksSearchParams) ([]ScanTask, error) {
+	rows, err := q.db.QueryContext(ctx, listScanTasksSearch,
+		arg.Column1,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.Limit,
+		arg.Offset,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/scannerv2/taskservice/taskservice.go
+++ b/internal/service/scannerv2/taskservice/taskservice.go
@@ -90,8 +90,11 @@ func (s *Service) GetTask(ctx context.Context, id int64) (domain.ScanTaskRespons
 	return toTaskResponse(task), nil
 }
 
-// ListTasks returns a page of tasks + total count.
-func (s *Service) ListTasks(ctx context.Context, limit, offset int) ([]domain.ScanTaskResponse, int64, error) {
+// ListTasks returns a page of tasks + total count, optionally filtered by a
+// case-insensitive substring search over name + targets. An empty search
+// string disables the filter (matches the old behaviour) — both the list and
+// the count use the same search term so pagination totals stay consistent.
+func (s *Service) ListTasks(ctx context.Context, search string, limit, offset int) ([]domain.ScanTaskResponse, int64, error) {
 	if limit < 20 {
 		limit = 20
 	}
@@ -101,11 +104,21 @@ func (s *Service) ListTasks(ctx context.Context, limit, offset int) ([]domain.Sc
 	if offset < 0 {
 		offset = 0
 	}
-	tasks, err := s.queries.ListScanTasks(ctx, db.ListScanTasksParams{Limit: int64(limit), Offset: int64(offset)})
+	tasks, err := s.queries.ListScanTasksSearch(ctx, db.ListScanTasksSearchParams{
+		Column1: search, // raw search term, used for the (? = '' OR ...) short-circuit
+		LOWER:   search, // substring matched against lower(name)
+		LOWER_2: search, // substring matched against lower(targets)
+		Limit:   int64(limit),
+		Offset:  int64(offset),
+	})
 	if err != nil {
 		return nil, 0, err
 	}
-	total, err := s.queries.CountScanTasks(ctx)
+	total, err := s.queries.CountScanTasksSearch(ctx, db.CountScanTasksSearchParams{
+		Column1: search,
+		LOWER:   search,
+		LOWER_2: search,
+	})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/service/scannerv2/taskservice/taskservice_test.go
+++ b/internal/service/scannerv2/taskservice/taskservice_test.go
@@ -105,17 +105,76 @@ func TestListTasks_PaginationClamping(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// total reflects all 3 regardless of limit/offset.
-	tasks, total, err := svc.ListTasks(ctx, 5, 0) // limit<20 → clamped to 20
+	tasks, total, err := svc.ListTasks(ctx, "", 5, 0) // limit<20 → clamped to 20
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Len(t, tasks, 3)
 	// offset beyond the set → empty page, total unchanged.
-	tasks, total, err = svc.ListTasks(ctx, 20, 100)
+	tasks, total, err = svc.ListTasks(ctx, "", 20, 100)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Empty(t, tasks)
 	// the seeding also sanity-checks CreateScanTask isn't dropping rows
 	_ = queries
+}
+
+// TestListTasks_Search verifies server-side substring search over name + targets:
+// a non-empty search narrows both the returned page and the total count, an
+// empty search disables the filter, and the match is case-insensitive + works
+// against either column.
+func TestListTasks_Search(t *testing.T) {
+	svc, _ := setupSvc(t)
+	ctx := context.Background()
+
+	// Seed tasks with distinct names + targets so each search term hits exactly one.
+	reqs := []domain.ScanTaskRequest{
+		{Name: "nightly-lan", Targets: "192.168.1.0/24", CronExpr: "0 2 * * *", Timeout: 60, ConcurrentHosts: 16, PipelineConfig: domain.PipelineConfig{ICMP: domain.ICMPConfig{Enabled: true, Timeout: 2}}},
+		{Name: "weekly-cameras", Targets: "10.0.0.0/24", CronExpr: "0 3 * * 0", Timeout: 60, ConcurrentHosts: 16, PipelineConfig: domain.PipelineConfig{ICMP: domain.ICMPConfig{Enabled: true, Timeout: 2}}},
+		{Name: "iot-sweep", Targets: "172.16.0.0/24", CronExpr: "0 4 * * *", Timeout: 60, ConcurrentHosts: 16, PipelineConfig: domain.PipelineConfig{ICMP: domain.ICMPConfig{Enabled: true, Timeout: 2}}},
+	}
+	for _, r := range reqs {
+		_, err := svc.CreateTask(ctx, r)
+		require.NoError(t, err)
+	}
+
+	// Empty search → all 3 (filter disabled).
+	tasks, total, err := svc.ListTasks(ctx, "", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, tasks, 3)
+
+	// Search by name substring → 1 match, total=1.
+	tasks, total, err = svc.ListTasks(ctx, "cameras", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "weekly-cameras", tasks[0].Name)
+
+	// Search by targets substring → 1 match (the 172.16 row).
+	tasks, total, err = svc.ListTasks(ctx, "172.16", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "iot-sweep", tasks[0].Name)
+
+	// Case-insensitive: "LAN" matches "nightly-lan".
+	tasks, total, err = svc.ListTasks(ctx, "LAN", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "nightly-lan", tasks[0].Name)
+
+	// No match → empty page, total=0.
+	tasks, total, err = svc.ListTasks(ctx, "nonexistent-term", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), total)
+	require.Empty(t, tasks)
+
+	// A term matching MULTIPLE columns/rows ("0.0/24" is in two targets) → total=2.
+	tasks, total, err = svc.ListTasks(ctx, "0.0/24", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, tasks, 2)
 }
 
 // TestDeleteTask verifies deletion and that the deleted ID is then not-found.

--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -34,16 +34,33 @@
 	// --- Pagination ---
 	let offset = $state(0);
 	const limit = 20;
-	// --- Search ---
+	// --- Search (server-side) ---
+	// searchInput is the live textbox value; searchQuery is the term committed to
+	// the backend after a 400ms debounce. The old client-side filter only searched
+	// the current 20-row page, so tasks on other pages were unreachable. Server-
+	// side search matches how devices/+page.svelte does it.
+	let searchInput = $state('');
 	let searchQuery = $state('');
+	let searchTimer: ReturnType<typeof setTimeout> | null = null;
 
-	let filteredTasks = $derived.by<ScannerTask[]>(() => {
-		if (!searchQuery.trim()) return tasks;
-		const q = searchQuery.toLowerCase();
-		return tasks.filter(t =>
-			t.name.toLowerCase().includes(q) || t.targets.toLowerCase().includes(q)
-		);
-	});
+	// onSearchInput debounces the search box: 400ms after the last keystroke the
+	// term is committed to searchQuery and a backend fetch fires. Clearing the
+	// box commits an empty search immediately so "clear" feels responsive.
+	function onSearchInput() {
+		if (searchTimer) clearTimeout(searchTimer);
+		const v = searchInput.trim();
+		if (v === '') {
+			searchQuery = '';
+			offset = 0;
+			fetchTasks();
+			return;
+		}
+		searchTimer = setTimeout(() => {
+			searchQuery = v;
+			offset = 0;
+			fetchTasks();
+		}, 400);
+	}
 
 	// --- Form modal ---
 	let formOpen = $state(false);
@@ -93,6 +110,7 @@
 			clearTimeout(timer);
 		}
 		pollingTimers.clear();
+		if (searchTimer) clearTimeout(searchTimer);
 	});
 
 	// --- Data fetching ---
@@ -100,8 +118,12 @@
 		loading = true;
 		error = '';
 		try {
+			const params = new URLSearchParams();
+			if (searchQuery) params.set('search', searchQuery);
+			params.set('limit', String(limit));
+			params.set('offset', String(offset));
 			const res = await api.get<{ tasks: ScannerTask[]; total: number }>(
-				`/scanner/tasks?limit=${limit}&offset=${offset}`
+				`/scanner/tasks?${params}`
 			);
 			tasks = res.tasks || [];
 			total = res.total || 0;
@@ -396,8 +418,9 @@
 			+ {m['scanner.New Task']()}
 		</button>
 	</div>
-	<!-- Search -->
-	{#if tasks.length > 0}
+	<!-- Search (server-side). Keep the box visible while a search is active even
+	     if the current page is empty, so the user can edit/clear the query. -->
+	{#if tasks.length > 0 || searchQuery}
 	<div class="relative mb-4">
 		<svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none"
 			fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -406,7 +429,8 @@
 		</svg>
 		<input
 			type="text"
-			bind:value={searchQuery}
+			bind:value={searchInput}
+			oninput={onSearchInput}
 			placeholder={m['scanner.Search Tasks']()}
 			class="pl-10 pr-4 py-2 w-full max-w-sm bg-surface border border-border rounded-lg text-sm text-text
 				placeholder:text-text-muted/40 focus:border-primary focus:outline-none"
@@ -426,7 +450,7 @@
 		<PageSkeleton type="table" />
 	{:else}
 		<!-- Empty state -->
-			{#if filteredTasks.length === 0 && tasks.length > 0}
+			{#if tasks.length === 0 && searchQuery}
 				<EmptyState
 					title={m['common.No Results']()}
 					description={m['scanner.No Tasks Match']({ query: searchQuery })}
@@ -454,7 +478,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each filteredTasks as task}
+						{#each tasks as task}
 							<tr class="border-b border-border last:border-b-0 hover:bg-border/30 transition-colors">
 								<!-- Name -->
 								<td class="px-4 py-3 text-sm font-medium text-text">{task.name}</td>


### PR DESCRIPTION
## Summary

The scan-tasks page filtered only the **current 20-row page** client-side (`filteredTasks` derived off `tasks`), so any task on page 2+ was permanently unreachable by search. Pushed search to the server, matching how `devices/+page.svelte` already does it.

## Backend (search support added at all 3 layers — there was none)

- **2 new sqlc queries** `ListScanTasksSearch` / `CountScanTasksSearch` with an optional `WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)`. `INSTR()` instead of `LIKE` so the search term needs no escaping (literal `%`/`_` aren't wildcards). Empty search short-circuits the clause to TRUE (== old behaviour). List and count share the same WHERE so pagination totals reflect the search. (`LIKE ... ESCAPE '\'` was rejected because sqlc's SQLite parser doesn't accept the `ESCAPE` clause.)
- `taskservice.ListTasks` signature gains a `search string`; handler `ListTasks` reads `?search=`. The Service keeps using `*db.Queries` (no constructor/routes refactor needed).

## Frontend (mirrors `devices/+page.svelte` server-search pattern)

- Split `searchQuery` into `searchInput` (live textbox) + `searchQuery` (committed), 400ms debounce. Committing resets `offset = 0`; clearing fires immediately. **Pagination no longer resets the search** (`fetchTasks` always re-reads `searchQuery`).
- Removed the client-side `filteredTasks` derived; the table renders `tasks` directly (the server already filtered).
- Search box stays visible while a search is active even if the current page is empty, so the user can edit/clear the query.

## Tests

- `+TestListTasks_Search`: empty search (filter disabled), name-substring match, targets-substring match, case-insensitive match, no-match (total=0), and multi-match (total>1).
- Existing `TestListTasks_PaginationClamping` updated for the new `ListTasks(ctx, search, limit, offset)` signature (passes `""` to preserve old behaviour).

## Verification

- `sqlc compile` clean, `go test ./...` all pass (incl. new search test)
- `gofmt -l` + `goimports -l` both empty
- `npm test` → 142/142 pass; `npx svelte-check` → 38 errors (baseline, no regressions); `npm run build` → clean
- **Browser-tested** on the test server with 25 seeded scan tasks:
  - **Cross-page search**: from page 1, searching a page-2 task name (`omega`) finds it
  - **Search + pagination**: a broad search (`192.168`, 25 matches) paginates correctly across page 1 → page 2, search preserved
  - **Clear search**: returns the full list (page 1, "next page" reappears)
  - **No match**: shows the "No Results" empty state (not blank)
  - No JS console errors

Closes #54
