### PR TITLE
fix(web,api): dedicated PATCH endpoint for channel enabled toggle (#53)

### DIFF
--- a/db/queries/notifications.sql
+++ b/db/queries/notifications.sql
@@ -24,6 +24,15 @@ SET name = ?, type = ?, config = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
 RETURNING *;
 
+-- name: SetChannelEnabled :one
+-- Single-field UPDATE for the dedicated PATCH /channels/{id} toggle endpoint.
+-- Writing only `enabled` (not the full row) makes the intent explicit and
+-- avoids any GET-then-write race on name/type/config. See service.SetChannelEnabled.
+UPDATE notification_channels
+SET enabled = ?, updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+RETURNING *;
+
 -- name: DeleteChannel :exec
 DELETE FROM notification_channels WHERE id = ?;
 

--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -142,6 +142,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 		r.Get("/", notificationHandler.ListChannels)
 		r.Get("/{id}", notificationHandler.GetChannel)
 		r.Put("/{id}", notificationHandler.UpdateChannel)
+		r.Patch("/{id}", notificationHandler.SetChannelEnabled)
 		r.Delete("/{id}", notificationHandler.DeleteChannel)
 		r.Post("/{id}/test", notificationHandler.TestChannel)
 	})
@@ -234,6 +235,18 @@ func authPost(t *testing.T, url, token, body string) *http.Response {
 func authPut(t *testing.T, url, token, body string) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest("PUT", url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// authPatch performs an authenticated PATCH request with JSON body.
+func authPatch(t *testing.T, url, token, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("PATCH", url, bytes.NewBufferString(body))
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -148,6 +148,48 @@ func (h *NotificationHandler) UpdateChannel(w http.ResponseWriter, r *http.Reque
 	Success(w, h.maskChannelPassword(resp))
 }
 
+// SetChannelEnabled handles PATCH /api/v1/notification/channels/{id}.
+// Dedicated toggle endpoint: the UI's on/off switch sends only {enabled},
+// and the service routes it to a single-field UPDATE so name/type/config
+// (and the masked SMTP password) are never rewritten. Contrast with PUT,
+// which the edit form uses to replace the full channel body.
+func (h *NotificationHandler) SetChannelEnabled(w http.ResponseWriter, r *http.Request) {
+	id, err := h.parseID(w, r)
+	if err != nil {
+		return
+	}
+
+	var req domain.SetChannelEnabledRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	resp, err := h.svc.SetChannelEnabled(r.Context(), id, req.Enabled)
+	if err != nil {
+		if errors.Is(err, service.ErrChannelNotFound) {
+			Error(w, http.StatusNotFound, "notification channel not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to update notification channel")
+		return
+	}
+
+	userID, _, ok := middleware.GetUserFromContext(r)
+	if ok {
+		h.auditRepo.Log(r.Context(), repository.AuditLog{
+			UserID:       &userID,
+			Action:       "admin.notification.channel.enable",
+			ResourceType: "notification_channel",
+			ResourceID:   strconv.FormatInt(id, 10),
+			IPAddress:    r.RemoteAddr,
+			UserAgent:    r.UserAgent(),
+		})
+	}
+
+	Success(w, h.maskChannelPassword(resp))
+}
+
 // DeleteChannel handles DELETE /api/v1/notification/channels/{id}
 func (h *NotificationHandler) DeleteChannel(w http.ResponseWriter, r *http.Request) {
 	id, err := h.parseID(w, r)

--- a/internal/api/handler/notification_test.go
+++ b/internal/api/handler/notification_test.go
@@ -106,6 +106,84 @@ func TestNotificationChannel_EmailPasswordMasked(t *testing.T) {
 	require.Equal(t, "smtp.example.com", configResp["host"])
 }
 
+// TestNotificationChannel_SetEnabled exercises the dedicated PATCH toggle
+// endpoint. The contract this guards: toggling `enabled` via PATCH must NOT
+// rewrite name/type/config — in particular the masked SMTP password must stay
+// the real value in the DB, never the `"*****"` mask that would be written if
+// someone naively did a GET-then-full-PUT round-trip. This is the data
+// corruption #53 was worried about; the dedicated endpoint sidesteps it.
+func TestNotificationChannel_SetEnabled(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+	token := loginAsAdmin(t, server)
+
+	// --- Webhook channel: toggle should leave config.url untouched ---
+	whBody := `{"name":"WH","type":"webhook","config":{"url":"https://hooks.example/x"},"enabled":true}`
+	resp := authPost(t, server.URL+"/api/v1/notification/channels", token, whBody)
+	require.Equal(t, 201, resp.StatusCode)
+	var whCreated map[string]interface{}
+	decodeJSON(t, resp, &whCreated)
+	whID := idToString(whCreated["id"])
+
+	// Toggle off then back on via PATCH.
+	resp = authPatch(t, server.URL+"/api/v1/notification/channels/"+whID, token, `{"enabled":false}`)
+	require.Equal(t, 200, resp.StatusCode)
+	var off map[string]interface{}
+	decodeJSON(t, resp, &off)
+	require.Equal(t, false, off["enabled"])
+	require.Equal(t, "WH", off["name"], "name must survive a toggle")
+
+	resp = authPatch(t, server.URL+"/api/v1/notification/channels/"+whID, token, `{"enabled":true}`)
+	require.Equal(t, 200, resp.StatusCode)
+	var back map[string]interface{}
+	decodeJSON(t, resp, &back)
+	require.Equal(t, true, back["enabled"])
+
+	// DB ground truth: config.url unchanged after two toggles.
+	var whConfig string
+	err := db.QueryRow("SELECT config FROM notification_channels WHERE id = ?", whCreated["id"]).Scan(&whConfig)
+	require.NoError(t, err)
+	require.Contains(t, whConfig, "https://hooks.example/x", "webhook url must survive toggles")
+
+	// PATCH a missing channel → 404 (ErrChannelNotFound, not 500).
+	resp = authPatch(t, server.URL+"/api/v1/notification/channels/9999", token, `{"enabled":true}`)
+	require.Equal(t, 404, resp.StatusCode)
+
+	// --- Email channel: the real corruption-risk path ---
+	// A GET-then-PUT full-body round-trip would write the masked password
+	// ("*****") back over the real one. The dedicated PATCH must NOT do that.
+	emailConfig := map[string]string{
+		"host": "smtp.example.com", "port": "587", "username": "u@example.com",
+		"password": "supersecret", "from": "n@example.com", "to": "a@example.com",
+	}
+	cfgJSON, _ := json.Marshal(emailConfig)
+	emailBody, _ := json.Marshal(map[string]interface{}{
+		"name": "Email", "type": "email", "config": json.RawMessage(cfgJSON), "enabled": true,
+	})
+	resp = authPost(t, server.URL+"/api/v1/notification/channels", token, string(emailBody))
+	require.Equal(t, 201, resp.StatusCode)
+	var emCreated map[string]interface{}
+	decodeJSON(t, resp, &emCreated)
+
+	// Toggle the email channel off.
+	resp = authPatch(t, server.URL+"/api/v1/notification/channels/"+idToString(emCreated["id"]), token, `{"enabled":false}`)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// DB ground truth: the REAL password must still be in the DB (not "*****").
+	var emConfig string
+	err = db.QueryRow("SELECT config FROM notification_channels WHERE id = ?", emCreated["id"]).Scan(&emConfig)
+	require.NoError(t, err)
+	require.Contains(t, emConfig, "supersecret", "real SMTP password must survive an enabled toggle")
+	require.NotContains(t, emConfig, `"*****"`, "masked placeholder must never be written back to the DB")
+
+	// And the API response masks it (defense-in-depth check).
+	var toggled map[string]interface{}
+	decodeJSON(t, resp, &toggled)
+	emRespCfg, ok := toggled["config"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "*****", emRespCfg["password"], "API still masks the password in responses")
+}
+
 func TestNotificationChannel_CreateMissingName(t *testing.T) {
 	server, db := setupTestServer(t)
 	insertTestAdmin(t, db)

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -725,6 +725,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Get("/", notificationHandler.ListChannels)
 		r.Get("/{id}", notificationHandler.GetChannel)
 		r.Put("/{id}", notificationHandler.UpdateChannel)
+		r.Patch("/{id}", notificationHandler.SetChannelEnabled)
 		r.Delete("/{id}", notificationHandler.DeleteChannel)
 		r.Post("/{id}/test", notificationHandler.TestChannel)
 	})

--- a/internal/db/notifications.sql.go
+++ b/internal/db/notifications.sql.go
@@ -414,6 +414,36 @@ func (q *Queries) MarkAllNotificationLogsRead(ctx context.Context, arg MarkAllNo
 	return result.RowsAffected()
 }
 
+const setChannelEnabled = `-- name: SetChannelEnabled :one
+UPDATE notification_channels
+SET enabled = ?, updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+RETURNING id, name, type, config, enabled, created_at, updated_at
+`
+
+type SetChannelEnabledParams struct {
+	Enabled int64 `json:"enabled"`
+	ID      int64 `json:"id"`
+}
+
+// Single-field UPDATE for the dedicated PATCH /channels/{id} toggle endpoint.
+// Writing only `enabled` (not the full row) makes the intent explicit and
+// avoids any GET-then-write race on name/type/config. See service.SetChannelEnabled.
+func (q *Queries) SetChannelEnabled(ctx context.Context, arg SetChannelEnabledParams) (NotificationChannel, error) {
+	row := q.db.QueryRowContext(ctx, setChannelEnabled, arg.Enabled, arg.ID)
+	var i NotificationChannel
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Type,
+		&i.Config,
+		&i.Enabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const updateChannel = `-- name: UpdateChannel :one
 UPDATE notification_channels
 SET name = ?, type = ?, config = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -38,6 +38,16 @@ type UpdateChannelRequest struct {
 	Enabled *bool            `json:"enabled,omitempty"`
 }
 
+// SetChannelEnabledRequest is the body of the dedicated
+// PATCH /notification/channels/{id} toggle endpoint. Unlike the generic PUT
+// (UpdateChannelRequest), it changes only `enabled` — server-side this routes
+// to a single-field UPDATE so name/type/config are never touched. This avoids
+// the data-corruption footgun where a client GET-then-PUT with a full body
+// would write the masked SMTP password (`"*****"`) back over the real one.
+type SetChannelEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 // Response types
 
 type ChannelResponse struct {

--- a/internal/service/heartbeat_store.go
+++ b/internal/service/heartbeat_store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"mibee-steward/internal/db"
@@ -37,11 +38,12 @@ import (
 // Reads (history, stats, isDue) go through the same *sql.DB via sqlc Queries,
 // so the read path is unchanged from the caller's perspective.
 type HeartbeatStore struct {
-	db      *sql.DB     // dedicated connection to heartbeat.db
-	queries *db.Queries // sqlc queries bound to the dedicated connection
-	ch      chan resultRow
-	cancel  context.CancelFunc
-	done    chan struct{}
+	db       *sql.DB     // dedicated connection to heartbeat.db
+	queries  *db.Queries // sqlc queries bound to the dedicated connection
+	ch       chan resultRow
+	cancelMu sync.Mutex
+	cancel   context.CancelFunc
+	done     chan struct{}
 }
 
 // resultRow is one heartbeat probe result pending a batched write.
@@ -130,9 +132,16 @@ func OpenHeartbeatStore(dbPath string) (*HeartbeatStore, error) {
 }
 
 // Start launches the background flush goroutine that batches buffered results
-// into periodic multi-row INSERTs.
+// into periodic multi-row INSERTs. The cancel func is assigned synchronously
+// (before the goroutine launches) under the mutex, so a concurrent Close() —
+// which NewRouter's caller (e.g. a test invoking Stop() right after NewRouter
+// returns) may issue while this Start() is still racing onto its goroutine —
+// never observes an unset cancel. Mirrors HeartbeatService.Start's pattern.
 func (s *HeartbeatStore) Start(ctx context.Context) {
-	ctx, s.cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancelMu.Lock()
+	s.cancel = cancel
+	s.cancelMu.Unlock()
 	go s.flushLoop(ctx)
 }
 
@@ -243,8 +252,11 @@ func (s *HeartbeatStore) commitBatch(ctx context.Context, rows []resultRow) erro
 // Close cancels the flush loop, waits for it to finish (including the final
 // drain), then closes the DB connection.
 func (s *HeartbeatStore) Close() error {
-	if s.cancel != nil {
-		s.cancel()
+	s.cancelMu.Lock()
+	cancel := s.cancel
+	s.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 	<-s.done // wait for flushLoop to exit (does its final drain)
 	return s.db.Close()

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -143,6 +143,37 @@ func (s *NotificationService) UpdateChannel(ctx context.Context, id int64, req d
 	return &resp, nil
 }
 
+// SetChannelEnabled toggles a channel's enabled flag via a single-field UPDATE
+// (no name/type/config are rewritten). This is the backend for the dedicated
+// PATCH /channels/{id} endpoint, used by the UI toggle — it keeps the toggle
+// path from ever re-writing the masked SMTP password back to the DB.
+func (s *NotificationService) SetChannelEnabled(ctx context.Context, id int64, enabled bool) (*domain.ChannelResponse, error) {
+	// Probe existence first so the caller gets the same ErrChannelNotFound → 404
+	// semantics as UpdateChannel (SetChannelEnabled SQL would otherwise return
+	// sql.ErrNoRows on the RETURNING scan, indistinguishable from a generic error).
+	if _, err := s.q.GetChannelByID(ctx, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrChannelNotFound
+		}
+		return nil, fmt.Errorf("failed to get channel: %w", err)
+	}
+
+	enabledInt := int64(0)
+	if enabled {
+		enabledInt = 1
+	}
+	ch, err := s.q.SetChannelEnabled(ctx, db.SetChannelEnabledParams{
+		Enabled: enabledInt,
+		ID:      id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set channel enabled: %w", err)
+	}
+
+	resp := toChannelResponse(ch)
+	return &resp, nil
+}
+
 // DeleteChannel deletes a notification channel by ID.
 func (s *NotificationService) DeleteChannel(ctx context.Context, id int64) error {
 	err := s.q.DeleteChannel(ctx, id)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -645,6 +645,8 @@
 		"Channel Created": "Notification channel created successfully",
 		"Channel Updated": "Notification channel updated successfully",
 		"Channel Deleted": "Notification channel deleted successfully",
+		"Channel Enabled": "Notification channel enabled",
+		"Channel Disabled": "Notification channel disabled",
 		"Channel Not Found": "Notification channel not found",
 		"Test Dispatched": "Test notification dispatched",
 		"Test Disabled": "Cannot test a disabled channel",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -645,6 +645,8 @@
 		"Channel Created": "通知渠道创建成功",
 		"Channel Updated": "通知渠道更新成功",
 		"Channel Deleted": "通知渠道删除成功",
+		"Channel Enabled": "通知渠道已启用",
+		"Channel Disabled": "通知渠道已禁用",
 		"Channel Not Found": "通知渠道未找到",
 		"Test Dispatched": "测试通知已发送",
 		"Test Disabled": "无法测试已禁用的渠道",

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -70,6 +70,8 @@ export const api = {
 		request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
 	put: <T>(path: string, body: unknown) =>
 		request<T>(path, { method: 'PUT', body: JSON.stringify(body) }),
+	patch: <T>(path: string, body: unknown) =>
+		request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
 	delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 	// download fetches a binary (CSV/JSON export, file download) and returns it
 	// as a Blob. Goes through the same auth/CSRF/401 handling as request(), so

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -217,8 +217,14 @@
 	}
 
 	async function toggleEnabled(channel: Channel) {
+		// Dedicated PATCH endpoint — writes only `enabled` (single-field UPDATE),
+		// so name/type/config (and any SMTP password) are never rewritten. The
+		// generic PUT is reserved for the edit form, which intentionally replaces
+		// the full body.
+		const target = !channel.enabled;
 		try {
-			await api.put(`/notification/channels/${channel.id}`, { enabled: !channel.enabled });
+			await api.patch(`/notification/channels/${channel.id}`, { enabled: target });
+			addToast('success', target ? m["notifications.Channel Enabled"]() : m["notifications.Channel Disabled"]());
 			fetchChannels();
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));


### PR DESCRIPTION
## Summary

Resolves #53.

**Investigation finding (important):** #53's premise was incorrect. The backend `UpdateChannelRequest` uses all-pointer fields with `omitempty`, and `service.UpdateChannel` does a partial merge — so the UI toggle sending `{enabled}` through PUT did **not** damage config. The fix proposed in the issue body (GET-then-PUT-full-body) would have been actively **harmful**: `maskChannelPassword` returns the SMTP password as `"*****"` in responses, so a full-body round-trip would write that mask back over the real password in the DB.

Chose a dedicated endpoint instead — semantic clarity, full separation of concerns.

## Changes

**Backend** — dedicated single-field UPDATE for the toggle:
- \`db/queries/notifications.sql\`: new \`SetChannelEnabled\` query (\`UPDATE ... SET enabled=? ...\`)
- \`internal/db/notifications.sql.go\`: sqlc-generated (\`sqlc generate\`)
- \`internal/service/notification_service.go\`: \`SetChannelEnabled(ctx, id, enabled)\` — probe-then-update with same \`ErrChannelNotFound\` semantics as \`UpdateChannel\`
- \`internal/api/handler/notification.go\`: \`SetChannelEnabled\` handler (mirrors \`UpdateChannel\` structure, audit action \`admin.notification.channel.enable\`)
- \`internal/domain/notification.go\`: \`SetChannelEnabledRequest{Enabled bool}\`
- \`internal/api/routes/routes.go\`: \`r.Patch("/{id}", ...)\` in the existing \`RequireAdmin\` group

**Frontend** — toggle uses the dedicated endpoint:
- \`web/src/lib/api/client.ts\`: \`api.patch()\` helper
- \`web/src/routes/settings/notifications/+page.svelte\`: \`toggleEnabled\` now PATCHes + shows success toast
- \`web/messages/{en,zh}.json\`: \`notifications.Channel Enabled\` / \`Channel Disabled\`

The edit form **keeps using PUT** — full-body replace is the correct semantic there (editing is meant to replace the whole channel body).

**Drive-by fix (pre-existing race, surfaced by this PR's CI):**
- \`internal/service/heartbeat_store.go\`: guard \`HeartbeatStore.cancel\` with a mutex. \`TestScannerIntegration\` flaked under \`-race\` — \`routes.go:643\` runs \`go heartbeatSvc.Start()\`, and inside that goroutine \`HeartbeatStore.Start\` wrote \`s.cancel\` while the test (calling \`Stop → Close\` right after \`NewRouter\` returned) read it. The sibling \`HeartbeatService.Start\` already guards its cancel under \`cancelMu\`; \`HeartbeatStore\` now mirrors that pattern. Unrelated to the notification change but blocking this PR's CI.

## Test coverage

\`TestNotificationChannel_SetEnabled\` guards the contract end-to-end:
- webhook \`config.url\` survives off→on toggle
- **email channel password stays the real value in the DB (not \`"*****"\`)** — this is the actual corruption risk #53 was worried about, now locked down by a test
- missing id → 404 (not 500)
- API response still masks the password (defense-in-depth)

## Verification

- [x] \`go vet ./...\` + \`go test -race ./internal/...\` (incl. new test) — green
- [x] \`go test -race -count=15 ./internal/api/routes/\` + \`count=3 ./internal/service/\` — green (race fix verified)
- [x] \`sqlc compile\` — green
- [x] \`gofmt\` / \`goimports\` — clean
- [x] \`npm test\` (153 pass) + \`npm run build\` — green
- [x] Deployed to 192.168.63.101 + browser-tested (agent-browser):
  - Created email channel with real password \`supersecret-real-pw\`, toggled off→on via UI
  - DB inspection after toggle: real password intact (not \`"*****"\`)
  - Webhook url intact after off→on round-trip
  - Success toasts render correctly (通知渠道已启用 / 通知渠道已禁用)
  - Test data cleaned up after

🤖 Generated with [ZCode](https://z.ai/code)