### PR TITLE
fix(web,api): scan-results sort goes server-side so it spans pages (#55)

### DIFF
--- a/internal/api/handler/scanner_result.go
+++ b/internal/api/handler/scanner_result.go
@@ -10,6 +10,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"encoding/csv"
 	"encoding/json"
@@ -28,11 +29,25 @@ import (
 // ScannerResultHandler handles HTTP requests for scan result and run queries.
 type ScannerResultHandler struct {
 	queries *db.Queries
+	conn    db.DBTX
+	// conn is the raw connection used by listResultsSorted — sqlc can't express
+	// the dynamic ORDER BY the sort-aware list needs, so that one query is raw
+	// SQL with a whitelist-controlled column (mirrors repository/device.go).
 }
 
 // NewScannerResultHandler creates a new ScannerResultHandler.
-func NewScannerResultHandler(queries *db.Queries) *ScannerResultHandler {
-	return &ScannerResultHandler{queries: queries}
+func NewScannerResultHandler(queries *db.Queries, conn db.DBTX) *ScannerResultHandler {
+	return &ScannerResultHandler{queries: queries, conn: conn}
+}
+
+// scanResultSortWhitelist maps a client-supplied sort token to the real column
+// (or SQL expression) used in ORDER BY. Any token not in this map falls back to
+// "scanned_at". This is the SQL-injection guard: only these literals ever reach
+// ORDER BY, never raw user input (mirrors repository/device.go sortWhitelist).
+var scanResultSortWhitelist = map[string]string{
+	"ip":     "ip",
+	"status": "alive",                    // the "Status" column reflects the alive flag
+	"ports":  "json_array_length(ports)", // the "Ports Count" column renders ports.length
 }
 
 // ListResults handles GET /api/v1/scanner/results
@@ -73,18 +88,34 @@ func (h *ScannerResultHandler) ListResults(w http.ResponseWriter, r *http.Reques
 		aliveVal = 0
 	}
 
-	results, err := h.queries.ListScanResults(r.Context(), db.ListScanResultsParams{
-		Column1: taskID,
-		TaskID:  taskID,
-		Column3: ipFilter,
-		Ip:      ipFilter,
-		Column5: aliveSentinel,
-		Alive:   aliveVal,
-		Limit:   limit,
-		Offset:  offset,
-	})
+	// Server-side sort. With no sort token the query keeps its default
+	// (scanned_at DESC) via the sqlc ListScanResults path — zero behavior
+	// change. With a sort token we route through listResultsSorted (raw SQL),
+	// which sorts the WHOLE filtered set before LIMIT/OFFSET, so a header click
+	// reorders globally rather than just the visible page slice (#55).
+	sortBy := q.Get("sort")
+	order := q.Get("order")
+
+	var (
+		results []db.ScanResult
+		err     error
+	)
+	if sortBy != "" {
+		results, err = h.listResultsSorted(r.Context(), taskID, ipFilter, aliveSentinel, aliveVal, sortBy, order, limit, offset)
+	} else {
+		results, err = h.queries.ListScanResults(r.Context(), db.ListScanResultsParams{
+			Column1: taskID,
+			TaskID:  taskID,
+			Column3: ipFilter,
+			Ip:      ipFilter,
+			Column5: aliveSentinel,
+			Alive:   aliveVal,
+			Limit:   limit,
+			Offset:  offset,
+		})
+	}
 	if err != nil {
-		slog.Error("ListScanResults failed", "task_id", taskID, "ip", ipFilter, "alive", q.Get("alive"), "limit", limit, "offset", offset, "error", err)
+		slog.Error("ListScanResults failed", "task_id", taskID, "ip", ipFilter, "alive", q.Get("alive"), "sort", sortBy, "order", order, "limit", limit, "offset", offset, "error", err)
 		Error(w, http.StatusInternalServerError, "failed to list scan results")
 		return
 	}
@@ -118,6 +149,74 @@ func (h *ScannerResultHandler) ListResults(w http.ResponseWriter, r *http.Reques
 		Results: resp,
 		Total:   int(total),
 	})
+}
+
+// listResultsSorted runs the same WHERE/LIMIT/OFFSET as ListScanResults but
+// with a whitelist-controlled ORDER BY, so a sort applies across the whole
+// filtered set (not just the visible page slice). sqlc can't express the
+// dynamic ORDER BY, hence the raw SQL — the column is resolved from
+// scanResultSortWhitelist (never interpolated raw from user input), and every
+// user value (task_id/ip/alive/limit/offset) is still bound as a `?` param.
+// The SELECT column order MUST match db.ScanResult's Scan order (see
+// ListScanResults in internal/db/scan_results.sql.go).
+func (h *ScannerResultHandler) listResultsSorted(
+	ctx context.Context,
+	taskID int64, ipFilter string, aliveSentinel, aliveVal int64,
+	sortBy, order string, limit, offset int64,
+) ([]db.ScanResult, error) {
+	col := scanResultSortWhitelist[sortBy]
+	if col == "" {
+		col = "scanned_at"
+	}
+	dir := "ASC"
+	if order == "desc" {
+		dir = "DESC"
+	}
+
+	query := `SELECT id, task_id, run_id, ip, alive, rtt_ms, ports, services, snmp_data, prometheus_detected, prometheus_url, node_exporter_detected, node_exporter_url, node_exporter_data, scanned_at
+		FROM scan_results
+		WHERE (? = 0 OR task_id = ?)
+		  AND (? = '' OR ip LIKE ?)
+		  AND (? < 0 OR alive = ?)
+		ORDER BY ` + col + " " + dir + `
+		LIMIT ? OFFSET ?`
+
+	rows, err := h.conn.QueryContext(ctx, query,
+		taskID, taskID,
+		ipFilter, ipFilter,
+		aliveSentinel, aliveVal,
+		limit, offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := []db.ScanResult{}
+	for rows.Next() {
+		var i db.ScanResult
+		if err := rows.Scan(
+			&i.ID,
+			&i.TaskID,
+			&i.RunID,
+			&i.Ip,
+			&i.Alive,
+			&i.RttMs,
+			&i.Ports,
+			&i.Services,
+			&i.SnmpData,
+			&i.PrometheusDetected,
+			&i.PrometheusUrl,
+			&i.NodeExporterDetected,
+			&i.NodeExporterUrl,
+			&i.NodeExporterData,
+			&i.ScannedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	return items, rows.Err()
 }
 
 // GetResult handles GET /api/v1/scanner/results/{id}

--- a/internal/api/handler/scanner_result_test.go
+++ b/internal/api/handler/scanner_result_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package handler_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/handler"
+	"mibee-steward/internal/db"
+)
+
+// insertScanResultsForSort seeds one scan_task plus a set of scan_results with
+// deliberately varied ip / alive / ports-array-length so each sort key resolves
+// to a distinct first row. Returns the task_id the rows belong to.
+func insertScanResultsForSort(t *testing.T, d *sql.DB) int64 {
+	t.Helper()
+	_, err := d.Exec(
+		`INSERT INTO scan_tasks (name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, enabled)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
+		"sort-test", "192.168.1.0/24", "0 3 * * *", "{}", "{}", 30, 10,
+	)
+	require.NoError(t, err)
+
+	var taskID int64
+	err = d.QueryRow("SELECT last_insert_rowid()").Scan(&taskID)
+	require.NoError(t, err)
+
+	// Rows chosen so each sort key has an unambiguous global winner:
+	//   ip asc    -> "192.168.1.10"  (lexicographically smallest)
+	//   status    -> alive=1 sorts first under desc
+	//   ports desc -> the row with 3 ports sorts first
+	type row struct {
+		ip    string
+		alive bool
+		ports string // JSON array literal
+	}
+	rows := []row{
+		{"192.168.1.50", true, `[]`},          // alive, 0 ports
+		{"192.168.1.10", false, `[80,443]`},   // dead, 2 ports  (smallest ip)
+		{"192.168.1.99", true, `[22,80,443]`}, // alive, 3 ports (most ports)
+	}
+	for _, r := range rows {
+		alive := 0
+		if r.alive {
+			alive = 1
+		}
+		_, err := d.Exec(
+			`INSERT INTO scan_results (task_id, ip, alive, ports, services)
+			VALUES (?, ?, ?, ?, '{}')`,
+			taskID, r.ip, alive, r.ports,
+		)
+		require.NoError(t, err)
+	}
+	return taskID
+}
+
+// scanResultFirstIP runs ListResults with the given query and returns the IP of
+// the first result row (the global top of the sorted set, page 0).
+func scanResultFirstIP(t *testing.T, h *handler.ScannerResultHandler, query string) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/v1/scanner/results?"+query, nil)
+	w := httptest.NewRecorder()
+	h.ListResults(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Results []struct {
+			IP string `json:"ip"`
+		} `json:"results"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.NotEmpty(t, resp.Results, "expected at least one result for query %q", query)
+	return resp.Results[0].IP
+}
+
+// TestScannerResults_Sort verifies the server-side sort contract (#55):
+// a column sort reorders the WHOLE filtered set before pagination, and the
+// sort token is whitelist-controlled (an unknown/evil token falls back to the
+// default scanned_at order rather than being interpolated into SQL).
+func TestScannerResults_Sort(t *testing.T) {
+	d := setupSDDB(t)
+	taskID := insertScanResultsForSort(t, d)
+	queries := db.New(d)
+	h := handler.NewScannerResultHandler(queries, d)
+
+	// sort=ip asc -> globally smallest IP first (not just the inserted order).
+	require.Equal(t, "192.168.1.10", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=10"))
+
+	// sort=ip desc -> globally largest IP first.
+	require.Equal(t, "192.168.1.99", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=desc&limit=10"))
+
+	// sort=status desc -> an alive host first (alive=1 outranks alive=0 under desc).
+	first := scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=status&order=desc&limit=10")
+	require.True(t, first == "192.168.1.50" || first == "192.168.1.99",
+		"status desc should put an alive host first, got %s", first)
+
+	// sort=ports desc -> the row with 3 ports first.
+	require.Equal(t, "192.168.1.99", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ports&order=desc&limit=10"))
+
+	// No sort -> default scanned_at DESC (behavior unchanged). Just assert it
+	// returns all rows; the exact order is insertion/scanned_at-dependent.
+	req := httptest.NewRequest("GET", "/api/v1/scanner/results?task_id="+itoa(taskID)+"&limit=10", nil)
+	w := httptest.NewRecorder()
+	h.ListResults(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var allResp struct {
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&allResp))
+	require.Equal(t, 3, allResp.Total, "all 3 seeded rows should be visible without a sort")
+
+	// SQL-injection / unknown token must NOT be interpolated into ORDER BY — it
+	// falls back to the default. If it were interpolated, this query would error
+	// (500) or reorder unexpectedly. Assert it returns 200 + all rows.
+	evilReq := httptest.NewRequest("GET", "/api/v1/scanner/results?task_id="+itoa(taskID)+"&sort=evil%27--&order=asc&limit=10", nil)
+	evilW := httptest.NewRecorder()
+	h.ListResults(evilW, evilReq)
+	require.Equal(t, http.StatusOK, evilW.Code, "unknown sort token must fall back safely, not error")
+}
+
+// TestScannerResults_SortPagination verifies the sort is global across pages:
+// with limit=1 the second page (offset=1) holds the globally-2nd row under the
+// sort, not the 2nd row of some client-side slice.
+func TestScannerResults_SortPagination(t *testing.T) {
+	d := setupSDDB(t)
+	taskID := insertScanResultsForSort(t, d)
+	queries := db.New(d)
+	h := handler.NewScannerResultHandler(queries, d)
+
+	// sort=ip asc, page size 1: page 0 = smallest, page 1 = middle, page 2 = largest.
+	require.Equal(t, "192.168.1.10", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=1&offset=0"))
+	require.Equal(t, "192.168.1.50", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=1&offset=1"))
+	require.Equal(t, "192.168.1.99", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=1&offset=2"))
+}
+
+// itoa is a tiny local int->string helper to avoid pulling in strconv just for
+// query-string building in the table-driven asserts above.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -458,7 +458,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	scanTaskService := scannerv2task.New(scanQueries, scanScheduler)
 	scannerHandler := handler.NewScannerHandler(v2Engine, scanRunner)
 	scannerTaskHandler := handler.NewScannerTaskHandler(scanTaskService)
-	scannerResultHandler := handler.NewScannerResultHandler(scanQueries)
+	scannerResultHandler := handler.NewScannerResultHandler(scanQueries, dbConn)
 	r.Route("/api/v1/scanner", func(r chi.Router) {
 		r.Use(middleware.RequireAdmin)
 		// Rate-limited scan trigger endpoints (per-IP, 10/min default)

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -86,7 +86,11 @@
 
 	// --- Expandable rows ---
 	let expandedResultId = $state<number | null>(null);
-	// --- Sorting ---
+	// --- Sorting (server-side) ---
+	// The sort is applied by the backend across the WHOLE filtered set, not
+	// just the visible page slice — a header click refetches from page 0 with
+	// ?sort=&order= so the global order is correct and pagination stays in sync
+	// (#55). Mirrors devices/+page.svelte's onSortChange.
 	let sortColumn = $state<'ip' | 'status' | 'ports' | null>(null);
 	let sortDirection = $state<'asc' | 'desc'>('asc');
 
@@ -97,29 +101,9 @@
 			sortColumn = column;
 			sortDirection = 'asc';
 		}
+		resultsOffset = 0;
+		fetchResults();
 	}
-
-	let sortedResults = $derived.by<ScanResult[]>(() => {
-		if (!sortColumn) return results;
-		const sorted = [...results].sort((a, b) => {
-			let cmp = 0;
-			if (sortColumn === 'ip') {
-				cmp = a.ip.localeCompare(b.ip);
-			} else if (sortColumn === 'status') {
-				cmp = Number(a.alive) - Number(b.alive);
-			} else if (sortColumn === 'ports') {
-				// The column is labelled "Ports Count" and renders ports.length,
-				// so sort by that — previously this keyed on 'rtt' and sorted by
-				// rtt_ms, disagreeing with both the header label and the primary
-				// cell value the user sees.
-				const countA = parseJSON<PortEntry[]>(a.ports)?.length ?? 0;
-				const countB = parseJSON<PortEntry[]>(b.ports)?.length ?? 0;
-				cmp = countA - countB;
-			}
-			return sortDirection === 'asc' ? cmp : -cmp;
-		});
-		return sorted;
-	});
 
 	// --- Tab ---
 	let activeTab = $state<'results' | 'runs'>('results');
@@ -195,6 +179,12 @@
 		// which made the "Showing X–Y of N" line and page counts wrong.
 		if (aliveFilter === 'alive') params.set('alive', '1');
 		else if (aliveFilter === 'dead') params.set('alive', '0');
+		// Server-side sort: the backend reorders the whole filtered set before
+		// pagination, so a column sort is global (not just the visible slice).
+		if (sortColumn) {
+			params.set('sort', sortColumn);
+			params.set('order', sortDirection);
+		}
 		params.set('limit', String(limit));
 		params.set('offset', String(resultsOffset));
 
@@ -469,7 +459,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each sortedResults as result}
+						{#each results as result}
 							{@const ports = parseJSON<PortEntry[]>(result.ports)}
 							{@const services = parseJSON<ServiceEntry[]>(result.services)}
 							{@const snmp = parseJSON<SNMPEntry>(result.snmp_data)}


### PR DESCRIPTION
## Summary

Resolves #55.

The scan-results column sort was client-side — it only reordered the visible 20-row slice, but the header arrows implied a global sort. Moving it server-side (mirroring \`devices/+page.svelte\`) makes a header click reorder the whole filtered set before pagination.

## Changes

**Backend** (raw-SQL + whitelist, the established pattern for dynamic ORDER BY — sqlc can't express it, same as \`repository/device.go\`):
- \`internal/api/handler/scanner_result.go\`: \`ScannerResultHandler\` gains a raw \`db.DBTX\` conn (mirrors \`NetworkHandler\`'s queries+conn pair); new \`scanResultSortWhitelist\` (\`ip\`→\`ip\`, \`status\`→\`alive\`, \`ports\`→\`json_array_length(ports)\`) is the SQL-injection guard; new \`listResultsSorted\` runs the same WHERE/LIMIT/OFFSET as \`ListScanResults\` but with a whitelist-controlled ORDER BY
- \`ListResults\` reads \`?sort=&order=\` and routes to \`listResultsSorted\` when set; **no sort keeps the sqlc path** (scanned_at DESC — zero behavior change)
- \`internal/api/routes/routes.go\`: constructor now takes \`(scanQueries, dbConn)\`

**Frontend** (\`web/src/routes/devices/scan-results/+page.svelte\`):
- \`toggleSort\` now refetches from page 0 after committing the sort (was: mutate state only)
- \`fetchResults\` sends \`sort\`/\`order\`; the \`sortedResults\` derived is removed (table iterates server-returned \`results\`)

## Test coverage

\`TestScannerResults_Sort\` + \`TestScannerResults_SortPagination\` lock the contract:
- global sort: page 0/1/2 hold the globally-1st/2nd/3rd row under \`sort=ip asc\` (not a client slice)
- each sort key resolves correctly (\`ip\`, \`status\`→alive, \`ports\`→port-count)
- **evil/unknown sort token falls back to scanned_at safely** (no 500, no injection) — the whitelist guard

## Verification

- [x] \`go vet\` + \`go test -race ./internal/...\` (incl. new tests) — green
- [x] \`sqlc compile\` — green (no query changes)
- [x] \`gofmt\` / \`goimports\` — clean
- [x] \`npm test\` (153 pass) + \`npm run build\` — green
- [x] Deployed to 192.168.63.101 + browser-tested (agent-browser) + curl-verified:
  - IP sort asc: page 1 = \`.1, .10, .100, .101, .102...\` (global), header shows ↑
  - Cross-page contiguous: page1 ends \`.102\`, page2 starts \`.103\` (no overlap, global order preserved)
  - Direction toggle: click again → ↓, rows descending (\`.254, .251, .248...\`)
  - Ports sort desc: ↓ active, port counts descending (7 → 6 → 6 → 5...)
  - No JS errors during session

🤖 Generated with [ZCode](https://z.ai/code)