### PR TITLE
fix(web): CSV import reads backend {added,errors} instead of preview count (#58)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -390,6 +390,7 @@
 		"Deselect All": "Deselect All",
 		"Add Selected": "Add Selected to Devices",
 		"Added N Devices": "{count} devices added successfully",
+		"Import N Failed": "{count} row(s) failed: {reason}",
 		"No Alive Hosts": "No alive hosts found",
 		"No Alive Hosts Desc": "Try a different IP range or check network connectivity.",
 		"Invalid Range": "Please enter a valid IP address or CIDR range",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -390,6 +390,7 @@
 		"Deselect All": "取消全选",
 		"Add Selected": "添加选中到设备列表",
 		"Added N Devices": "成功添加 {count} 台设备",
+		"Import N Failed": "{count} 行导入失败：{reason}",
 		"No Alive Hosts": "未发现存活主机",
 		"No Alive Hosts Desc": "请尝试其他 IP 范围或检查网络连接。",
 		"Invalid Range": "请输入有效的 IP 地址或 CIDR 范围",

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -35,6 +35,14 @@ interface Stats {
     by_type: Record<string, number>;
 }
 
+// AddDevicesResponse mirrors backend domain.AddDevicesResponse — the CSV import
+// must read {added, errors} from it rather than assuming every preview row
+// succeeded (#58: partial failures used to be silently miscounted).
+interface AddDevicesResponse {
+	added: number;
+	errors: string[];
+}
+
 	// --- Core state ---
 	let devices = $state<Device[]>([]);
 	let stats = $state<Stats>({ by_status: {}, by_type: {} });
@@ -461,12 +469,22 @@ interface Stats {
 		if (csvPreviewRows.length === 0) return;
 		importLoading = true;
 		try {
-			await api.post('/scanner/add-devices', { devices: csvPreviewRows });
-			addToast('success', m['scanner.Added N Devices']().replace('{count}', String(csvPreviewRows.length)));
-			importOpen = false;
-			csvFile = null;
-			csvPreviewRows = [];
-			fetchDevices();
+			// Read the backend's {added, errors} instead of assuming every preview
+			// row succeeded — partial failures (duplicate IP, bad format) used to be
+			// silently miscounted as successes (#58).
+			const res = await api.post<AddDevicesResponse>('/scanner/add-devices', { devices: csvPreviewRows });
+			if (res.errors && res.errors.length > 0) {
+				// Summary warning with the first error reason, rather than a toast
+				// per failure (noisy when many rows fail).
+				addToast('warning', m['scanner.Import N Failed']().replace('{count}', String(res.errors.length)).replace('{reason}', res.errors[0]));
+			}
+			if (res.added > 0) {
+				addToast('success', m['scanner.Added N Devices']().replace('{count}', String(res.added)));
+				importOpen = false;
+				csvFile = null;
+				csvPreviewRows = [];
+				fetchDevices();
+			}
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));
 		} finally {


### PR DESCRIPTION
Resolves #58. See commit message for details — the devices-page CSV import now reads {added,errors} from /add-devices (mirroring devices/scanner/+page.svelte) instead of toasting the preview row count. Browser-verified: 3-row CSV import shows the real backend count. Investigated PersistManualDevice (upserts everything today), but the fix is still correct/future-proof.