### PR TITLE
feat(web): device detail edit/delete entry via shared DeviceEditModal (#57)

### DIFF
--- a/web/src/lib/components/DeviceEditModal.svelte
+++ b/web/src/lib/components/DeviceEditModal.svelte
@@ -1,0 +1,303 @@
+<!--
+  SPDX-License-Identifier: AGPL-3.0-or-later
+
+  Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+  This file is part of MiBee Steward, distributed under the GNU Affero General
+  Public License v3.0 or later. A commercial license is available for use cases
+  the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+-->
+
+<!-- DeviceEditModal — shared device create/edit form used by both the devices
+     list page and the device detail page (#57). Owns its own form state +
+     validation + submit; the caller just toggles `open`, passes a `device`
+     (null for create, non-null for edit), and supplies an `onSaved` refresh
+     callback. Extracted verbatim from the list page's inline form to keep one
+     source of truth for the device field set + validation. -->
+
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import Modal from '$lib/components/Modal.svelte';
+	import LoadingButton from '$lib/components/LoadingButton.svelte';
+	import { m } from '$lib/i18n-paraglide';
+	import { addToast } from '$lib/stores/toast';
+	import type { Device } from '$lib/types';
+	import { getErrorMessage } from '$lib/utils/error';
+	import { deviceSchema, validateField, validateForm } from '$lib/utils/validation';
+
+	let {
+		open = $bindable(false),
+		device = null,
+		onSaved
+	}: {
+		open?: boolean;
+		device?: Device | null;
+		onSaved?: () => void;
+	} = $props();
+
+	// Form field state (mirrors the former list-page formXxx vars).
+	let formName = $state('');
+	let formType = $state('pc');
+	let formBrand = $state('');
+	let formModel = $state('');
+	let formLocation = $state('');
+	let formPurpose = $state('');
+	let formIpAddress = $state('');
+	let formMacAddress = $state('');
+	let formSerialNumber = $state('');
+	let formPurchaseDate = $state('');
+	let formWarrantyExpiry = $state('');
+	let formTags = $state('');
+	let formError = $state('');
+	let formLoading = $state(false);
+	let fieldErrors = $state<Record<string, string>>({});
+	// Tracks whether we're editing an existing device (vs creating). Mirrors the
+	// list page's `editingDevice` — kept separate from the `device` prop so the
+	// form mode is stable across re-renders even if the caller updates `device`.
+	let editing = $state<Device | null>(null);
+
+	function resetForm() {
+		formName = '';
+		formType = 'pc';
+		formBrand = '';
+		formModel = '';
+		formLocation = '';
+		formPurpose = '';
+		formIpAddress = '';
+		formMacAddress = '';
+		formSerialNumber = '';
+		formPurchaseDate = '';
+		formWarrantyExpiry = '';
+		formTags = '';
+		formError = '';
+		fieldErrors = {};
+		editing = null;
+	}
+
+	// Hydrate the form whenever the modal opens. device=non-null ⇒ edit (prefill
+	// from the device), device=null ⇒ create (blank). Reads `device` at open
+	// time so the caller can set it before toggling `open` true. Using
+	// $effect.pre so the form is ready before the modal body renders.
+	$effect(() => {
+		if (open) {
+			if (device) {
+				editing = device;
+				formName = device.name;
+				formType = device.type || 'pc';
+				formBrand = device.brand || '';
+				formModel = device.model || '';
+				formLocation = device.location || '';
+				formPurpose = device.purpose || '';
+				formIpAddress = device.ip_address || '';
+				formMacAddress = device.mac_address || '';
+				formSerialNumber = device.serial_number || '';
+				formPurchaseDate = device.purchase_date || '';
+				formWarrantyExpiry = device.warranty_expiry || '';
+				formTags = device.tags || '';
+				formError = '';
+				fieldErrors = {};
+			} else {
+				resetForm();
+			}
+		}
+	});
+
+	function handleBlur(field: string, value: string) {
+		const result = validateField(deviceSchema, field as keyof typeof deviceSchema._type, value);
+		if (result.valid) {
+			const { [field]: _, ...rest } = fieldErrors;
+			fieldErrors = rest;
+		} else {
+			fieldErrors = { ...fieldErrors, [field]: result.error! };
+		}
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		formLoading = true;
+		formError = '';
+
+		const body = {
+			name: formName,
+			type: formType,
+			brand: formBrand,
+			model: formModel,
+			location: formLocation,
+			purpose: formPurpose,
+			ip_address: formIpAddress,
+			mac_address: formMacAddress,
+			serial_number: formSerialNumber,
+			purchase_date: formPurchaseDate,
+			warranty_expiry: formWarrantyExpiry,
+			tags: formTags
+		};
+
+		const validation = validateForm(deviceSchema, body);
+		if (!validation.valid) {
+			fieldErrors = validation.errors;
+			formLoading = false;
+			return;
+		}
+
+		try {
+			if (editing) {
+				await api.put(`/devices/${editing.id}`, body);
+				addToast('success', m['devices.Updated']());
+			} else {
+				await api.post('/devices', body);
+				addToast('success', m['devices.Created']());
+			}
+			open = false;
+			resetForm();
+			onSaved?.();
+		} catch (err: unknown) {
+			const msg = getErrorMessage(err);
+			formError = msg;
+			addToast('error', msg);
+		} finally {
+			formLoading = false;
+		}
+	}
+</script>
+
+<Modal bind:open title={editing ? m['devices.Edit Device']() : m['devices.Create Device']()} maxWidth="42rem" onClose={resetForm}>
+	{#if formError}
+		<div class="mb-4 px-4 py-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
+			{formError}
+		</div>
+	{/if}
+
+	<form onsubmit={handleSubmit} class="grid grid-cols-2 gap-4">
+		<!-- Name -->
+		<div class="col-span-2">
+			<label class="block text-xs text-muted mb-1">{m['devices.Device Name']()} *</label>
+			<input
+				bind:value={formName}
+				onblur={() => handleBlur('name', formName)}
+				required
+				class="input {fieldErrors.name ? '!border-error' : ''}"
+			/>
+			{#if fieldErrors.name}
+				<p class="text-xs text-error mt-1">{fieldErrors.name}</p>
+			{/if}
+		</div>
+
+		<!-- Type -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Type']()} *</label>
+			<select
+				bind:value={formType}
+				onblur={() => handleBlur('type', formType)}
+				class="input"
+			>
+				<option value="pc">{m['devices.PC']()}</option>
+				<option value="embedded">{m['devices.Embedded']()}</option>
+				<option value="iot">{m['devices.IoT']()}</option>
+				<option value="server">{m['devices.Server']()}</option>
+				<option value="switch">{m['devices.Switch']()}</option>
+				<option value="router">{m['devices.Router']()}</option>
+				<option value="firewall">{m['devices.Firewall']()}</option>
+				<option value="nas">{m['devices.NAS']()}</option>
+				<option value="camera">{m['devices.Camera']()}</option>
+				<option value="phone">{m['devices.Phone']()}</option>
+				<option value="printer">{m['devices.Printer']()}</option>
+				<option value="other">{m['devices.Other']()}</option>
+			</select>
+			{#if fieldErrors.type}
+				<p class="text-xs text-error mt-1">{fieldErrors.type}</p>
+			{/if}
+		</div>
+
+		<!-- Brand -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Brand']()}</label>
+			<input bind:value={formBrand}
+				class="input" />
+		</div>
+
+		<!-- Model -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Model']()}</label>
+			<input bind:value={formModel}
+				class="input" />
+		</div>
+
+		<!-- Location -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Location']()}</label>
+			<input bind:value={formLocation}
+				class="input" />
+		</div>
+
+		<!-- Purpose -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Purpose']()}</label>
+			<input bind:value={formPurpose}
+				class="input" />
+		</div>
+
+		<!-- IP Address -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.IP Address']()}</label>
+			<input
+				bind:value={formIpAddress}
+				onblur={() => handleBlur('ip_address', formIpAddress)}
+				placeholder="192.168.1.100"
+				class="input font-mono {fieldErrors.ip_address ? '!border-error' : ''}"
+			/>
+			{#if fieldErrors.ip_address}
+				<p class="text-xs text-error mt-1">{fieldErrors.ip_address}</p>
+			{/if}
+		</div>
+
+		<!-- MAC Address -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.MAC Address']()}</label>
+			<input
+				bind:value={formMacAddress}
+				onblur={() => handleBlur('mac_address', formMacAddress)}
+				placeholder="AA:BB:CC:DD:EE:FF"
+				class="input font-mono {fieldErrors.mac_address ? '!border-error' : ''}"
+			/>
+			{#if fieldErrors.mac_address}
+				<p class="text-xs text-error mt-1">{fieldErrors.mac_address}</p>
+			{/if}
+		</div>
+
+		<!-- Serial Number -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Serial Number']()}</label>
+			<input bind:value={formSerialNumber}
+				class="input font-mono" />
+		</div>
+
+		<!-- Purchase Date -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Purchase Date']()}</label>
+			<input type="date" bind:value={formPurchaseDate}
+				class="input" />
+		</div>
+
+		<!-- Warranty Expiry -->
+		<div>
+			<label class="block text-xs text-muted mb-1">{m['devices.Warranty Expiry']()}</label>
+			<input type="date" bind:value={formWarrantyExpiry}
+				class="input" />
+		</div>
+
+		<!-- Tags -->
+		<div class="col-span-2">
+			<label class="block text-xs text-muted mb-1">{m['devices.Tags']()}</label>
+			<input bind:value={formTags} placeholder="server,production,rack-a"
+				class="input" />
+		</div>
+
+		<!-- Submit -->
+		<div class="col-span-2 flex gap-3 pt-2">
+		<LoadingButton type="submit" loading={formLoading} variant="primary" label={m['common.Save']()} />
+			<button type="button" onclick={() => { open = false; resetForm(); }} class="btn btn-secondary">
+				{m['common.Cancel']()}
+			</button>
+		</div>
+	</form>
+</Modal>

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -16,12 +16,12 @@
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { escapeHtml, escapeAttr } from '$lib/utils';
-	import { deviceSchema, validateField, validateForm } from '$lib/utils/validation';
 	import type { Device, LinkedDoc, Network } from '$lib/types';
 	import { ChevronDown, ChevronRight, Download, Upload, Plus, List, Share2 } from '@lucide/svelte';
 
 	import Modal from '$lib/components/Modal.svelte';
 	import LoadingButton from '$lib/components/LoadingButton.svelte';
+	import DeviceEditModal from '$lib/components/DeviceEditModal.svelte';
 	import DeviceTopologyView from '$lib/components/DeviceTopologyView.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import DataTable from '$lib/components/DataTable.svelte';
@@ -89,26 +89,12 @@ interface AddDevicesResponse {
 	let sortDir = $state<'asc' | 'desc'>('asc');
 
 	// --- Form modal ---
-	let formOpen = $state(false);
-	let editingDevice = $state<Device | null>(null);
-	let formError = $state('');
-	let formLoading = $state(false);
+	// The device create/edit form lives in <DeviceEditModal> (shared with the
+	// detail page). This page just toggles `editOpen` and supplies the device to
+	// edit (null ⇒ create mode). onSaved refreshes the list after a save.
+	let editOpen = $state(false);
+	let editTarget = $state<Device | null>(null);
 
-	let formName = $state('');
-	let formType = $state('pc');
-	let formBrand = $state('');
-	let formModel = $state('');
-	let formLocation = $state('');
-	let formPurpose = $state('');
-	let formIpAddress = $state('');
-	let formMacAddress = $state('');
-	let formSerialNumber = $state('');
-	let formPurchaseDate = $state('');
-	let formWarrantyExpiry = $state('');
-	let formTags = $state('');
-
-	// --- Inline validation ---
-	let fieldErrors = $state<Record<string, string>>({});
 
 	// --- Delete confirmation ---
 	let deleteOpen = $state(false);
@@ -162,7 +148,7 @@ interface AddDevicesResponse {
 		// failure just leaves the dropdown empty — the list still works).
 		api.get<Network[]>('/networks').then((n) => { networks = n || []; }).catch(() => {});
 		pollTimer = setInterval(() => {
-			if (!formOpen && !deleteOpen && !batchDeleteOpen && !batchStatusOpen && !importOpen && !linkOpen) {
+			if (!editOpen && !deleteOpen && !batchDeleteOpen && !batchStatusOpen && !importOpen && !linkOpen) {
 				void refreshDevicesSilent();
 			}
 		}, POLL_MS);
@@ -493,104 +479,19 @@ interface AddDevicesResponse {
 	}
 
 	// --- Form helpers ---
-	function resetForm() {
-		formName = '';
-		formType = 'pc';
-		formBrand = '';
-		formModel = '';
-		formLocation = '';
-		formPurpose = '';
-		formIpAddress = '';
-		formMacAddress = '';
-		formSerialNumber = '';
-		formPurchaseDate = '';
-		formWarrantyExpiry = '';
-		formTags = '';
-		formError = '';
-		fieldErrors = {};
-		editingDevice = null;
-	}
-
+	// The form state/validation/submit moved into <DeviceEditModal>. These two
+	// wrappers keep the existing call sites (openCreate/openEdit) unchanged:
+	// they just toggle the shared modal open with the right target.
 	function openCreate() {
-		resetForm();
-		formOpen = true;
+		editTarget = null;
+		editOpen = true;
 	}
 
 	function openEdit(device: Device) {
-		editingDevice = device;
-		formName = device.name;
-		formType = device.type || 'pc';
-		formBrand = device.brand || '';
-		formModel = device.model || '';
-		formLocation = device.location || '';
-		formPurpose = device.purpose || '';
-		formIpAddress = device.ip_address || '';
-		formMacAddress = device.mac_address || '';
-		formSerialNumber = device.serial_number || '';
-		formPurchaseDate = device.purchase_date || '';
-		formWarrantyExpiry = device.warranty_expiry || '';
-		formTags = device.tags || '';
-		formError = '';
-		fieldErrors = {};
-		formOpen = true;
+		editTarget = device;
+		editOpen = true;
 	}
 
-	function handleBlur(field: string, value: string) {
-		const result = validateField(deviceSchema, field as keyof typeof deviceSchema._type, value);
-		if (result.valid) {
-			const { [field]: _, ...rest } = fieldErrors;
-			fieldErrors = rest;
-		} else {
-			fieldErrors = { ...fieldErrors, [field]: result.error! };
-		}
-	}
-
-	async function handleSubmit(e: Event) {
-		e.preventDefault();
-		formLoading = true;
-		formError = '';
-
-		const body = {
-			name: formName,
-			type: formType,
-			brand: formBrand,
-			model: formModel,
-			location: formLocation,
-			purpose: formPurpose,
-			ip_address: formIpAddress,
-			mac_address: formMacAddress,
-			serial_number: formSerialNumber,
-			purchase_date: formPurchaseDate,
-			warranty_expiry: formWarrantyExpiry,
-			tags: formTags
-		};
-
-		const validation = validateForm(deviceSchema, body);
-		if (!validation.valid) {
-			fieldErrors = validation.errors;
-			formLoading = false;
-			return;
-		}
-
-		try {
-			if (editingDevice) {
-				await api.put(`/devices/${editingDevice.id}`, body);
-				addToast('success', m['devices.Updated']());
-			} else {
-				await api.post('/devices', body);
-				addToast('success', m['devices.Created']());
-			}
-			formOpen = false;
-			resetForm();
-			fetchDevices();
-		} catch (err: unknown) {
-			const msg = getErrorMessage(err);
-			formError = msg;
-			addToast('error', msg);
-		} finally {
-			formLoading = false;
-		}
-	}
 
 	// --- Delete ---
 	function openDelete(device: Device) {
@@ -1201,148 +1102,10 @@ interface AddDevicesResponse {
 	{/if}
 </div>
 
-<!-- Create/Edit Modal -->
-<Modal bind:open={formOpen} title={editingDevice ? m['devices.Edit Device']() : m['devices.Create Device']()} maxWidth="42rem" onClose={resetForm}>
-	{#if formError}
-		<div class="mb-4 px-4 py-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
-			{formError}
-		</div>
-	{/if}
-
-	<form onsubmit={handleSubmit} class="grid grid-cols-2 gap-4">
-		<!-- Name -->
-		<div class="col-span-2">
-			<label class="block text-xs text-muted mb-1">{m['devices.Device Name']()} *</label>
-			<input
-				bind:value={formName}
-				onblur={() => handleBlur('name', formName)}
-				required
-				class="input {fieldErrors.name ? '!border-error' : ''}"
-			/>
-			{#if fieldErrors.name}
-				<p class="text-xs text-error mt-1">{fieldErrors.name}</p>
-			{/if}
-		</div>
-
-		<!-- Type -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Type']()} *</label>
-			<select
-				bind:value={formType}
-				onblur={() => handleBlur('type', formType)}
-				class="input"
-			>
-				<option value="pc">{m['devices.PC']()}</option>
-				<option value="embedded">{m['devices.Embedded']()}</option>
-				<option value="iot">{m['devices.IoT']()}</option>
-				<option value="server">{m['devices.Server']()}</option>
-				<option value="switch">{m['devices.Switch']()}</option>
-				<option value="router">{m['devices.Router']()}</option>
-				<option value="firewall">{m['devices.Firewall']()}</option>
-				<option value="nas">{m['devices.NAS']()}</option>
-				<option value="camera">{m['devices.Camera']()}</option>
-				<option value="phone">{m['devices.Phone']()}</option>
-				<option value="printer">{m['devices.Printer']()}</option>
-				<option value="other">{m['devices.Other']()}</option>
-			</select>
-			{#if fieldErrors.type}
-				<p class="text-xs text-error mt-1">{fieldErrors.type}</p>
-			{/if}
-		</div>
-
-		<!-- Brand -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Brand']()}</label>
-			<input bind:value={formBrand}
-				class="input" />
-		</div>
-
-		<!-- Model -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Model']()}</label>
-			<input bind:value={formModel}
-				class="input" />
-		</div>
-
-		<!-- Location -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Location']()}</label>
-			<input bind:value={formLocation}
-				class="input" />
-		</div>
-
-		<!-- Purpose -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Purpose']()}</label>
-			<input bind:value={formPurpose}
-				class="input" />
-		</div>
-
-		<!-- IP Address -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.IP Address']()}</label>
-			<input
-				bind:value={formIpAddress}
-				onblur={() => handleBlur('ip_address', formIpAddress)}
-				placeholder="192.168.1.100"
-				class="input font-mono {fieldErrors.ip_address ? '!border-error' : ''}"
-			/>
-			{#if fieldErrors.ip_address}
-				<p class="text-xs text-error mt-1">{fieldErrors.ip_address}</p>
-			{/if}
-		</div>
-
-		<!-- MAC Address -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.MAC Address']()}</label>
-			<input
-				bind:value={formMacAddress}
-				onblur={() => handleBlur('mac_address', formMacAddress)}
-				placeholder="AA:BB:CC:DD:EE:FF"
-				class="input font-mono {fieldErrors.mac_address ? '!border-error' : ''}"
-			/>
-			{#if fieldErrors.mac_address}
-				<p class="text-xs text-error mt-1">{fieldErrors.mac_address}</p>
-			{/if}
-		</div>
-
-		<!-- Serial Number -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Serial Number']()}</label>
-			<input bind:value={formSerialNumber}
-				class="input font-mono" />
-		</div>
-
-		<!-- Purchase Date -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Purchase Date']()}</label>
-			<input type="date" bind:value={formPurchaseDate}
-				class="input" />
-		</div>
-
-		<!-- Warranty Expiry -->
-		<div>
-			<label class="block text-xs text-muted mb-1">{m['devices.Warranty Expiry']()}</label>
-			<input type="date" bind:value={formWarrantyExpiry}
-				class="input" />
-		</div>
-
-		<!-- Tags -->
-		<div class="col-span-2">
-			<label class="block text-xs text-muted mb-1">{m['devices.Tags']()}</label>
-			<input bind:value={formTags} placeholder="server,production,rack-a"
-				class="input" />
-		</div>
-
-		<!-- Submit -->
-		<div class="col-span-2 flex gap-3 pt-2">
-		<LoadingButton type="submit" loading={formLoading} variant="primary" label={m['common.Save']()} />
-			<button type="button" onclick={() => { formOpen = false; resetForm(); }} class="btn btn-secondary">
-				{m['common.Cancel']()}
-			</button>
-		</div>
-	</form>
-</Modal>
+<!-- Create/Edit Modal — the form lives in the shared DeviceEditModal component
+     (also used by the device detail page). This page toggles it open with a
+     target device (null ⇒ create) and refreshes the list on save. -->
+<DeviceEditModal bind:open={editOpen} device={editTarget} onSaved={fetchDevices} />
 
 <!-- Delete confirmation -->
 <ConfirmDialog

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -13,7 +13,9 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 	import { addToast } from '$lib/stores/toast';
+	import { auth } from '$lib/stores/auth';
 	import { getErrorMessage } from '$lib/utils/error';
 	import type { Device, System, DeviceNeighbor, TLSPortCerts } from '$lib/types';
 	import type { EChartsOption } from '$lib/charts/echarts';
@@ -22,6 +24,7 @@
 
 	import Modal from '$lib/components/Modal.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import DeviceEditModal from '$lib/components/DeviceEditModal.svelte';
 	import SystemCard from '$lib/components/SystemCard.svelte';
 	import PageSkeleton from '$lib/components/PageSkeleton.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
@@ -79,9 +82,16 @@
 	let formMetricsEnabled = $state(false);
 	let formTags = $state('');
 
-	// --- Delete state ---
+	// --- Delete state (device-systems) ---
 	let deleteOpen = $state(false);
 	let deleteTarget = $state<System | null>(null);
+
+	// --- Device edit/delete (the device itself, in the header) ---
+	// Edit reuses the shared <DeviceEditModal> (same form as the list page);
+	// delete uses a ConfirmDialog then returns to the list. Admin-only (#57).
+	let editOpen = $state(false);
+	let deviceDeleteOpen = $state(false);
+	let isAdmin = $derived($auth.user?.role === 'admin');
 
 	// --- Heartbeat trend state ---
 	let trendLoading = $state(false);
@@ -529,6 +539,18 @@
 		}
 	}
 
+	// Delete the device itself (header "Delete" button). On success the device
+	// is gone, so navigate back to the list rather than refreshing this page.
+	async function confirmDeviceDelete() {
+		try {
+			await api.delete(`/devices/${deviceId}`);
+			addToast('success', m['devices.Deleted']());
+			goto('/devices');
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+		}
+	}
+
 	// --- Helpers ---
 	function statusDotClass(status: string): string {
 		if (status === 'online') return 'bg-success animate-pulse-green';
@@ -755,6 +777,16 @@
 						</span>
 					{/if}
 				</div>
+				{#if isAdmin}
+					<div class="flex items-center gap-2">
+						<button onclick={() => editOpen = true} class="btn btn-secondary text-sm">
+							{m['common.Edit']()}
+						</button>
+						<button onclick={() => deviceDeleteOpen = true} class="btn text-sm text-error hover:bg-error/10 border border-error/30">
+							{m['common.Delete']()}
+						</button>
+					</div>
+				{/if}
 			</div>
 				<div class="device-meta">
 					{#if device.ip_address}
@@ -1775,6 +1807,17 @@
 	bind:open={certModalOpen}
 	portCerts={certModalPort}
 	onClose={() => { certModalPort = null; }}
+/>
+
+<!-- Device edit (shared form with the list page) + delete. Header buttons (#57). -->
+<DeviceEditModal bind:open={editOpen} device={device} onSaved={fetchDevice} />
+<ConfirmDialog
+	bind:open={deviceDeleteOpen}
+	title={m['devices.Delete Device']()}
+	message={`${m['common.Are you sure?']()} "${device?.name ?? ''}"`}
+	confirmLabel={m['common.Delete']()}
+	confirmVariant="danger"
+	onConfirm={confirmDeviceDelete}
 />
 
 <style>


### PR DESCRIPTION
## Summary

Resolves #57.

The device detail page had no edit/delete entry — changing a field meant going back to the list, finding the row, using its action menu. This adds edit/delete buttons to the detail header and extracts the device form into a shared component so both pages stay in sync.

## Changes

**New: `web/src/lib/components/DeviceEditModal.svelte`** — the device create/edit form extracted from the list page. Props: `open` (bindable), `device` (null ⇒ create, non-null ⇒ edit), `onSaved` (caller's refresh callback). Owns its own form state + Zod validation (`deviceSchema`) + submit. A `$effect` hydrates the form whenever the modal opens.

**`web/src/routes/devices/+page.svelte` (list)** — migration: drops ~250 lines of inline form state/handlers/markup, replaced by one `<DeviceEditModal>` call. `openEdit`/`openCreate` become thin wrappers that set the target + toggle open. The delete flow is untouched (stays inline). Net: the form now lives in one place.

**`web/src/routes/devices/detail/[id]/+page.svelte` (detail)** — new:
- admin-gated **Edit** / **Delete** buttons in the header (right side of the title flex)
- Edit opens the shared modal prefilled with the current device; `onSaved={fetchDevice}` refreshes the page on save
- Delete shows a `ConfirmDialog` (with the device name), then `DELETE /devices/{id}` + `goto('/devices')`

## Verification

- [x] `npm test` (153 pass) + `npm run build` — green
- [x] Deployed to 192.168.63.101 + browser-tested (agent-browser):
  - **List page edit (regression)**: edit modal opens prefilled (e.g. "orangepi-zero3") — the component extraction didn't break the list page
  - **Detail page**: header shows Edit/Delete buttons (admin)
  - **Detail edit**: modal prefilled with current device; renamed → saved → page heading updated (fetchDevice refresh worked); reverted
  - **Detail delete**: ConfirmDialog shows device name; confirm → redirected to list; DB confirms device removed
  - No JS errors during the session

🤖 Generated with [ZCode](https://z.ai/code)