### PR TITLE
fix(web,api): server-side search on users/audit/changes/documents so it survives pagination (#64)

### DIFF
--- a/db/queries/audit_queries.sql
+++ b/db/queries/audit_queries.sql
@@ -15,6 +15,7 @@ WHERE (? = 0 OR user_id = ?)
   AND (? = '' OR resource_type = ?)
   AND (? = '' OR created_at >= ?)
   AND (? = '' OR created_at <= ?)
+  AND (? = '' OR INSTR(lower(action), lower(?)) > 0 OR INSTR(lower(resource_type), lower(?)) > 0 OR INSTR(lower(ip_address), lower(?)) > 0)
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;
 
@@ -24,7 +25,8 @@ WHERE (? = 0 OR user_id = ?)
   AND (? = '' OR action = ?)
   AND (? = '' OR resource_type = ?)
   AND (? = '' OR created_at >= ?)
-  AND (? = '' OR created_at <= ?);
+  AND (? = '' OR created_at <= ?)
+  AND (? = '' OR INSTR(lower(action), lower(?)) > 0 OR INSTR(lower(resource_type), lower(?)) > 0 OR INSTR(lower(ip_address), lower(?)) > 0);
 
 -- name: DeleteAuditLogsOlderThan :execrows
 -- Retention sweep: prune audit rows older than the cutoff. Batched deletion is

--- a/db/queries/change_log.sql
+++ b/db/queries/change_log.sql
@@ -18,6 +18,7 @@ FROM change_log
 WHERE (? = 0 OR network_id = ?)
   AND (? = '' OR change_type = ?)
   AND (? = '' OR entity_type = ?)
+  AND (? = '' OR INSTR(lower(change_type), lower(?)) > 0 OR INSTR(lower(entity_type), lower(?)) > 0)
 ORDER BY detected_at DESC
 LIMIT ? OFFSET ?;
 
@@ -26,7 +27,8 @@ SELECT COUNT(*)
 FROM change_log
 WHERE (? = 0 OR network_id = ?)
   AND (? = '' OR change_type = ?)
-  AND (? = '' OR entity_type = ?);
+  AND (? = '' OR entity_type = ?)
+  AND (? = '' OR INSTR(lower(change_type), lower(?)) > 0 OR INSTR(lower(entity_type), lower(?)) > 0);
 
 -- name: DeleteChangeLogOlderThanBatched :execrows
 -- Retention sweep. Deletes rows older than the cutoff in batches to avoid

--- a/db/queries/documents.sql
+++ b/db/queries/documents.sql
@@ -18,10 +18,18 @@ FROM documents
 WHERE id = ?;
 
 -- name: ListDocuments :many
+-- Search is a substring match across title/description/type (case-insensitive).
+-- INSTR pattern (see ListUsers for rationale).
 SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
 FROM documents
+WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?;
+
+-- name: CountDocuments :one
+-- Mirrors ListDocuments WHERE so the page total reflects the active search.
+SELECT COUNT(*) FROM documents
+WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0);
 
 -- name: UpdateDocument :one
 UPDATE documents

--- a/db/queries/users.sql
+++ b/db/queries/users.sql
@@ -28,10 +28,21 @@ FROM users
 WHERE username = ?;
 
 -- name: ListUsers :many
+-- Search is a substring match across username/email (case-insensitive). The
+-- sentinel pattern (? = '' OR ...) means an empty search returns all rows.
+-- INSTR(lower(...), lower(?)) is used because sqlc's SQLite parser rejects
+-- `LIKE ? ESCAPE '\' (see scan_tasks.sql for the same pattern).
 SELECT id, username, email, password_hash, role, created_at, updated_at, failed_login_attempts, locked_until, password_changed_at, must_change_password
 FROM users
+WHERE (? = '' OR INSTR(lower(username), lower(?)) > 0 OR INSTR(lower(email), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?;
+
+-- name: CountUsers :one
+-- Mirrors the ListUsers WHERE so the page total reflects the active search
+-- (previously Total was len(page) = page size, which broke pagination counts).
+SELECT COUNT(*) FROM users
+WHERE (? = '' OR INSTR(lower(username), lower(?)) > 0 OR INSTR(lower(email), lower(?)) > 0);
 
 -- name: UpdateUser :one
 UPDATE users

--- a/internal/api/handler/audit.go
+++ b/internal/api/handler/audit.go
@@ -72,6 +72,7 @@ func (h *AuditHandler) List(w http.ResponseWriter, r *http.Request) {
 		ResourceType: resourceType,
 		DateFrom:     dateFrom,
 		DateTo:       dateTo,
+		Search:       r.URL.Query().Get("search"),
 		Limit:        int32(limit),
 		Offset:       int32(offset),
 	}

--- a/internal/api/handler/changes.go
+++ b/internal/api/handler/changes.go
@@ -93,6 +93,8 @@ func (h *ChangeLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if entityType != "" {
 		entitySentinel = "1"
 	}
+	// Search: substring across change_type/entity_type. Empty ⇒ no filter.
+	searchVal := q.Get("search")
 
 	rows, err := h.queries.ListChangeLog(r.Context(), db.ListChangeLogParams{
 		Column1:    netSentinel,
@@ -101,6 +103,9 @@ func (h *ChangeLogHandler) List(w http.ResponseWriter, r *http.Request) {
 		ChangeType: changeType,
 		Column5:    entitySentinel,
 		EntityType: entityType,
+		Column7:    searchVal,
+		LOWER:      searchVal,
+		LOWER_2:    searchVal,
 		Limit:      limit,
 		Offset:     offset,
 	})
@@ -115,6 +120,9 @@ func (h *ChangeLogHandler) List(w http.ResponseWriter, r *http.Request) {
 		ChangeType: changeType,
 		Column5:    entitySentinel,
 		EntityType: entityType,
+		Column7:    searchVal,
+		LOWER:      searchVal,
+		LOWER_2:    searchVal,
 	})
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to count changes")

--- a/internal/api/handler/document.go
+++ b/internal/api/handler/document.go
@@ -104,8 +104,9 @@ func (h *DocumentHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
+	search := q.Get("search")
 
-	resp, err := h.svc.List(r.Context(), limit, offset)
+	resp, err := h.svc.List(r.Context(), search, limit, offset)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to list documents")
 		return

--- a/internal/api/handler/user.go
+++ b/internal/api/handler/user.go
@@ -353,6 +353,7 @@ func (h *UserHandler) ForceChangePassword(w http.ResponseWriter, r *http.Request
 func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	limit, _ := strconv.ParseInt(r.URL.Query().Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(r.URL.Query().Get("offset"), 10, 64)
+	search := r.URL.Query().Get("search")
 
 	if limit <= 0 {
 		limit = 20
@@ -361,7 +362,7 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		limit = 100
 	}
 
-	resp, err := h.svc.ListUsers(r.Context(), limit, offset)
+	resp, err := h.svc.ListUsers(r.Context(), search, limit, offset)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to list users")
 		return

--- a/internal/db/audit_queries.sql.go
+++ b/internal/db/audit_queries.sql.go
@@ -17,6 +17,7 @@ WHERE (? = 0 OR user_id = ?)
   AND (? = '' OR resource_type = ?)
   AND (? = '' OR created_at >= ?)
   AND (? = '' OR created_at <= ?)
+  AND (? = '' OR INSTR(lower(action), lower(?)) > 0 OR INSTR(lower(resource_type), lower(?)) > 0 OR INSTR(lower(ip_address), lower(?)) > 0)
 `
 
 type CountAuditLogsParams struct {
@@ -30,6 +31,10 @@ type CountAuditLogsParams struct {
 	CreatedAt    *time.Time  `json:"created_at"`
 	Column9      interface{} `json:"column_9"`
 	CreatedAt_2  *time.Time  `json:"created_at_2"`
+	Column11     interface{} `json:"column_11"`
+	LOWER        string      `json:"LOWER"`
+	LOWER_2      string      `json:"LOWER_2"`
+	LOWER_3      string      `json:"LOWER_3"`
 }
 
 func (q *Queries) CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) (int64, error) {
@@ -44,6 +49,10 @@ func (q *Queries) CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) 
 		arg.CreatedAt,
 		arg.Column9,
 		arg.CreatedAt_2,
+		arg.Column11,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.LOWER_3,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -96,6 +105,7 @@ WHERE (? = 0 OR user_id = ?)
   AND (? = '' OR resource_type = ?)
   AND (? = '' OR created_at >= ?)
   AND (? = '' OR created_at <= ?)
+  AND (? = '' OR INSTR(lower(action), lower(?)) > 0 OR INSTR(lower(resource_type), lower(?)) > 0 OR INSTR(lower(ip_address), lower(?)) > 0)
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?
 `
@@ -111,6 +121,10 @@ type ListAuditLogsParams struct {
 	CreatedAt    *time.Time  `json:"created_at"`
 	Column9      interface{} `json:"column_9"`
 	CreatedAt_2  *time.Time  `json:"created_at_2"`
+	Column11     interface{} `json:"column_11"`
+	LOWER        string      `json:"LOWER"`
+	LOWER_2      string      `json:"LOWER_2"`
+	LOWER_3      string      `json:"LOWER_3"`
 	Limit        int64       `json:"limit"`
 	Offset       int64       `json:"offset"`
 }
@@ -135,6 +149,10 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		arg.CreatedAt,
 		arg.Column9,
 		arg.CreatedAt_2,
+		arg.Column11,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.LOWER_3,
 		arg.Limit,
 		arg.Offset,
 	)

--- a/internal/db/change_log.sql.go
+++ b/internal/db/change_log.sql.go
@@ -16,6 +16,7 @@ FROM change_log
 WHERE (? = 0 OR network_id = ?)
   AND (? = '' OR change_type = ?)
   AND (? = '' OR entity_type = ?)
+  AND (? = '' OR INSTR(lower(change_type), lower(?)) > 0 OR INSTR(lower(entity_type), lower(?)) > 0)
 `
 
 type CountChangeLogParams struct {
@@ -25,6 +26,9 @@ type CountChangeLogParams struct {
 	ChangeType string      `json:"change_type"`
 	Column5    interface{} `json:"column_5"`
 	EntityType string      `json:"entity_type"`
+	Column7    interface{} `json:"column_7"`
+	LOWER      string      `json:"LOWER"`
+	LOWER_2    string      `json:"LOWER_2"`
 }
 
 func (q *Queries) CountChangeLog(ctx context.Context, arg CountChangeLogParams) (int64, error) {
@@ -35,6 +39,9 @@ func (q *Queries) CountChangeLog(ctx context.Context, arg CountChangeLogParams) 
 		arg.ChangeType,
 		arg.Column5,
 		arg.EntityType,
+		arg.Column7,
+		arg.LOWER,
+		arg.LOWER_2,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -121,6 +128,7 @@ FROM change_log
 WHERE (? = 0 OR network_id = ?)
   AND (? = '' OR change_type = ?)
   AND (? = '' OR entity_type = ?)
+  AND (? = '' OR INSTR(lower(change_type), lower(?)) > 0 OR INSTR(lower(entity_type), lower(?)) > 0)
 ORDER BY detected_at DESC
 LIMIT ? OFFSET ?
 `
@@ -132,6 +140,9 @@ type ListChangeLogParams struct {
 	ChangeType string      `json:"change_type"`
 	Column5    interface{} `json:"column_5"`
 	EntityType string      `json:"entity_type"`
+	Column7    interface{} `json:"column_7"`
+	LOWER      string      `json:"LOWER"`
+	LOWER_2    string      `json:"LOWER_2"`
 	Limit      int64       `json:"limit"`
 	Offset     int64       `json:"offset"`
 }
@@ -144,6 +155,9 @@ func (q *Queries) ListChangeLog(ctx context.Context, arg ListChangeLogParams) ([
 		arg.ChangeType,
 		arg.Column5,
 		arg.EntityType,
+		arg.Column7,
+		arg.LOWER,
+		arg.LOWER_2,
 		arg.Limit,
 		arg.Offset,
 	)

--- a/internal/db/documents.sql.go
+++ b/internal/db/documents.sql.go
@@ -9,6 +9,31 @@ import (
 	"context"
 )
 
+const countDocuments = `-- name: CountDocuments :one
+SELECT COUNT(*) FROM documents
+WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
+`
+
+type CountDocumentsParams struct {
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+	LOWER_3 string      `json:"LOWER_3"`
+}
+
+// Mirrors ListDocuments WHERE so the page total reflects the active search.
+func (q *Queries) CountDocuments(ctx context.Context, arg CountDocumentsParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countDocuments,
+		arg.Column1,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.LOWER_3,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createDocument = `-- name: CreateDocument :one
 
 INSERT INTO documents (title, type, url, file_path, file_size, mime_type, description)
@@ -100,17 +125,31 @@ func (q *Queries) GetDocument(ctx context.Context, id int64) (Document, error) {
 const listDocuments = `-- name: ListDocuments :many
 SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
 FROM documents
+WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?
 `
 
 type ListDocumentsParams struct {
-	Limit  int64 `json:"limit"`
-	Offset int64 `json:"offset"`
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+	LOWER_3 string      `json:"LOWER_3"`
+	Limit   int64       `json:"limit"`
+	Offset  int64       `json:"offset"`
 }
 
+// Search is a substring match across title/description/type (case-insensitive).
+// INSTR pattern (see ListUsers for rationale).
 func (q *Queries) ListDocuments(ctx context.Context, arg ListDocumentsParams) ([]Document, error) {
-	rows, err := q.db.QueryContext(ctx, listDocuments, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listDocuments,
+		arg.Column1,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.LOWER_3,
+		arg.Limit,
+		arg.Offset,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -10,6 +10,26 @@ import (
 	"time"
 )
 
+const countUsers = `-- name: CountUsers :one
+SELECT COUNT(*) FROM users
+WHERE (? = '' OR INSTR(lower(username), lower(?)) > 0 OR INSTR(lower(email), lower(?)) > 0)
+`
+
+type CountUsersParams struct {
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+}
+
+// Mirrors the ListUsers WHERE so the page total reflects the active search
+// (previously Total was len(page) = page size, which broke pagination counts).
+func (q *Queries) CountUsers(ctx context.Context, arg CountUsersParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countUsers, arg.Column1, arg.LOWER, arg.LOWER_2)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createUser = `-- name: CreateUser :one
 
 INSERT INTO users (username, email, password_hash, role, failed_login_attempts, locked_until, must_change_password)
@@ -149,17 +169,31 @@ func (q *Queries) GetUserByUsername(ctx context.Context, username string) (User,
 const listUsers = `-- name: ListUsers :many
 SELECT id, username, email, password_hash, role, created_at, updated_at, failed_login_attempts, locked_until, password_changed_at, must_change_password
 FROM users
+WHERE (? = '' OR INSTR(lower(username), lower(?)) > 0 OR INSTR(lower(email), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?
 `
 
 type ListUsersParams struct {
-	Limit  int64 `json:"limit"`
-	Offset int64 `json:"offset"`
+	Column1 interface{} `json:"column_1"`
+	LOWER   string      `json:"LOWER"`
+	LOWER_2 string      `json:"LOWER_2"`
+	Limit   int64       `json:"limit"`
+	Offset  int64       `json:"offset"`
 }
 
+// Search is a substring match across username/email (case-insensitive). The
+// sentinel pattern (? = ” OR ...) means an empty search returns all rows.
+// INSTR(lower(...), lower(?)) is used because sqlc's SQLite parser rejects
+// `LIKE ? ESCAPE '\' (see scan_tasks.sql for the same pattern).
 func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, listUsers, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listUsers,
+		arg.Column1,
+		arg.LOWER,
+		arg.LOWER_2,
+		arg.Limit,
+		arg.Offset,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/audit.go
+++ b/internal/domain/audit.go
@@ -37,6 +37,10 @@ type AuditLogFilter struct {
 	ResourceType *string
 	DateFrom     *time.Time
 	DateTo       *time.Time
-	Limit        int32
-	Offset       int32
+	// Search is a substring match across action/resource_type/ip_address
+	// (empty = no search filter). Distinct from Action/ResourceType which are
+	// exact-match equality filters.
+	Search string
+	Limit  int32
+	Offset int32
 }

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -80,6 +80,11 @@ func (s *AuditService) List(ctx context.Context, filter domain.AuditLogFilter) (
 		dateToVal = filter.DateTo
 	}
 
+	// Search sentinel: empty string ⇒ no substring filter (the (? = '' OR ...)
+	// clause short-circuits). The search term is bound once per searched column
+	// (action/resource_type/ip_address) — see ListAuditLogs SQL.
+	searchVal := filter.Search
+
 	logs, err := s.queries.ListAuditLogs(ctx, db.ListAuditLogsParams{
 		Column1:      userIDSentinel,
 		UserID:       userIDVal,
@@ -91,6 +96,10 @@ func (s *AuditService) List(ctx context.Context, filter domain.AuditLogFilter) (
 		CreatedAt:    dateFromVal,
 		Column9:      dateToSentinel,
 		CreatedAt_2:  dateToVal,
+		Column11:     searchVal,
+		LOWER:        searchVal,
+		LOWER_2:      searchVal,
+		LOWER_3:      searchVal,
 		Limit:        int64(limit),
 		Offset:       int64(offset),
 	})
@@ -109,6 +118,10 @@ func (s *AuditService) List(ctx context.Context, filter domain.AuditLogFilter) (
 		CreatedAt:    dateFromVal,
 		Column9:      dateToSentinel,
 		CreatedAt_2:  dateToVal,
+		Column11:     searchVal,
+		LOWER:        searchVal,
+		LOWER_2:      searchVal,
+		LOWER_3:      searchVal,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -103,7 +103,7 @@ func (s *DocumentService) Get(ctx context.Context, id int64) (*domain.DocumentRe
 }
 
 // List returns documents with pagination.
-func (s *DocumentService) List(ctx context.Context, limit int64, offset int64) (*domain.DocumentListResponse, error) {
+func (s *DocumentService) List(ctx context.Context, search string, limit int64, offset int64) (*domain.DocumentListResponse, error) {
 	if limit <= 0 {
 		limit = 20
 	}
@@ -112,8 +112,12 @@ func (s *DocumentService) List(ctx context.Context, limit int64, offset int64) (
 	}
 
 	docs, err := s.queries.ListDocuments(ctx, db.ListDocumentsParams{
-		Limit:  limit,
-		Offset: offset,
+		Column1: search,
+		LOWER:   search,
+		LOWER_2: search,
+		LOWER_3: search,
+		Limit:   limit,
+		Offset:  offset,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list documents: %w", err)
@@ -124,9 +128,20 @@ func (s *DocumentService) List(ctx context.Context, limit int64, offset int64) (
 		resp = append(resp, toDocumentResponse(d))
 	}
 
+	// Total is the real match count (previously len(page)).
+	total, err := s.queries.CountDocuments(ctx, db.CountDocumentsParams{
+		Column1: search,
+		LOWER:   search,
+		LOWER_2: search,
+		LOWER_3: search,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count documents: %w", err)
+	}
+
 	return &domain.DocumentListResponse{
 		Documents: resp,
-		Total:     len(resp),
+		Total:     int(total),
 	}, nil
 }
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -342,10 +342,13 @@ func (s *UserService) AdminResetPassword(ctx context.Context, userID int64, newP
 }
 
 // ListUsers returns a paginated list of users.
-func (s *UserService) ListUsers(ctx context.Context, limit, offset int64) (*domain.ListUsersResponse, error) {
+func (s *UserService) ListUsers(ctx context.Context, search string, limit, offset int64) (*domain.ListUsersResponse, error) {
 	users, err := s.queries.ListUsers(ctx, db.ListUsersParams{
-		Limit:  limit,
-		Offset: offset,
+		Column1: search,
+		LOWER:   search,
+		LOWER_2: search,
+		Limit:   limit,
+		Offset:  offset,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list users: %w", err)
@@ -356,9 +359,20 @@ func (s *UserService) ListUsers(ctx context.Context, limit, offset int64) (*doma
 		resp = append(resp, toUserResponse(u))
 	}
 
+	// Total is the real match count (previously len(page), which capped at the
+	// page size and broke pagination when more than one page matched).
+	total, err := s.queries.CountUsers(ctx, db.CountUsersParams{
+		Column1: search,
+		LOWER:   search,
+		LOWER_2: search,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count users: %w", err)
+	}
+
 	return &domain.ListUsersResponse{
 		Users: resp,
-		Total: len(resp),
+		Total: int(total),
 	}, nil
 }
 

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -364,7 +364,7 @@ func TestListUsers(t *testing.T) {
 	registerTestUser(t, svc, "bob", "bob@example.com")
 	registerTestUser(t, svc, "charlie", "charlie@example.com")
 
-	resp, err := svc.ListUsers(context.Background(), 10, 0)
+	resp, err := svc.ListUsers(context.Background(), "", 10, 0)
 	require.NoError(t, err)
 	require.Len(t, resp.Users, 3)
 	require.Equal(t, 3, resp.Total)
@@ -377,16 +377,49 @@ func TestListUsers_Pagination(t *testing.T) {
 	registerTestUser(t, svc, "bob", "bob@example.com")
 	registerTestUser(t, svc, "charlie", "charlie@example.com")
 
-	// Get first page of 2
-	resp, err := svc.ListUsers(context.Background(), 2, 0)
+	// Get first page of 2 — Total is now the real match count (3), not the page
+	// size, so pagination counts are correct across pages.
+	resp, err := svc.ListUsers(context.Background(), "", 2, 0)
 	require.NoError(t, err)
 	require.Len(t, resp.Users, 2)
-	require.Equal(t, 2, resp.Total) // Total is len of returned users, not total count
+	require.Equal(t, 3, resp.Total)
 
 	// Get second page
-	resp, err = svc.ListUsers(context.Background(), 2, 2)
+	resp, err = svc.ListUsers(context.Background(), "", 2, 2)
 	require.NoError(t, err)
 	require.Len(t, resp.Users, 1)
+}
+
+func TestListUsers_Search(t *testing.T) {
+	svc, _ := setupUserService(t)
+
+	registerTestUser(t, svc, "alice", "alice@example.com")
+	registerTestUser(t, svc, "bob", "bob@example.com")
+	registerTestUser(t, svc, "charlie", "charlie@example.com")
+
+	// Substring match on username — "ali" matches only alice.
+	resp, err := svc.ListUsers(context.Background(), "ali", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, resp.Users, 1)
+	require.Equal(t, "alice", resp.Users[0].Username)
+	require.Equal(t, 1, resp.Total)
+
+	// Substring match on email — "example" matches all three.
+	resp, err = svc.ListUsers(context.Background(), "example", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, resp.Users, 3)
+	require.Equal(t, 3, resp.Total)
+
+	// Case-insensitive.
+	resp, err = svc.ListUsers(context.Background(), "ALICE", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, resp.Users, 1)
+
+	// No match.
+	resp, err = svc.ListUsers(context.Background(), "zzz", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, resp.Users, 0)
+	require.Equal(t, 0, resp.Total)
 }
 
 func TestRegister_AdminRole(t *testing.T) {

--- a/web/src/lib/components/DataTable.svelte
+++ b/web/src/lib/components/DataTable.svelte
@@ -54,6 +54,11 @@
 		externalSortKey = null,
 		externalSortDirection = 'none',
 		onSortChange,
+		// Controlled search: when onSearchChange is provided, the search box calls
+		// back to the parent (which refetches filtered from the server) instead of
+		// filtering the in-memory page slice. Mirrors the onSortChange server-side
+		// pattern. Without it, search stays client-side (backward-compatible).
+		onSearchChange,
 	}: {
 		columns: Column[];
 		rows: Record<string, unknown>[];
@@ -70,6 +75,7 @@
 		externalSortKey?: string | null;
 		externalSortDirection?: 'asc' | 'desc' | 'none';
 		onSortChange?: (key: string, direction: 'asc' | 'desc') => void;
+		onSearchChange?: (query: string) => void;
 	} = $props();
 
 	let sortKey = $state<string | null>(null);
@@ -96,10 +102,10 @@
 	});
 
 	const filteredRows = $derived(() => {
-		// When sorting is delegated to the server, don't re-filter client-side —
-		// the search box is also server-driven by the page, and re-filtering the
-		// already-filtered page slice would double-narrow the results.
-		if (onSortChange) return rows;
+		// Server-driven search/sort: rows already come back filtered/ordered from
+		// the backend, so don't re-filter the page slice client-side (it would
+		// double-narrow results). Mirrors the onSortChange guard.
+		if (onSortChange || onSearchChange) return rows;
 		if (!debouncedQuery || searchableKeys.length === 0) return rows;
 		const q = debouncedQuery.toLowerCase();
 		return rows.filter((row) =>
@@ -165,12 +171,13 @@
 				<input
 					type="text"
 					bind:value={searchQuery}
+					oninput={() => onSearchChange?.(searchQuery)}
 					placeholder={searchPlaceholder}
 					class="input pl-10 pr-10"
 				/>
 				{#if searchQuery}
 					<button
-						onclick={() => (searchQuery = '')}
+						onclick={() => { searchQuery = ''; onSearchChange?.(''); }}
 						class="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-text transition-colors"
 						aria-label={m['common.Clear Search']()}
 					>

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -29,6 +29,21 @@
 	let offset = $state(0);
 	const limit = 50;
 
+	// Server-side search (searchInput = live box, searchQuery = committed).
+	let searchInput = $state('');
+	let searchQuery = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function onSearchInput(value: string) {
+		searchInput = value;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			searchQuery = value;
+			offset = 0;
+			fetchAuditLogs();
+		}, 400);
+	}
+
 	// Expanded row (details viewer).
 	let expandedId = $state<number | null>(null);
 
@@ -61,6 +76,7 @@
 	const resourceTypes = ['user', 'device', 'document', 'system', 'heartbeat_config', 'notification_channel'];
 
 	onMount(() => {
+		hydrateFromUrl();
 		fetchAuditLogs();
 		fetchUsers();
 	});
@@ -86,15 +102,36 @@
 			if (filterResourceType) params.set('resource_type', filterResourceType);
 			if (filterDateFrom) params.set('date_from', filterDateFrom);
 			if (filterDateTo) params.set('date_to', filterDateTo);
+			if (searchQuery) params.set('search', searchQuery);
 			const res = await api.get<{ audit_logs: AuditLog[]; total: number }>(`/audit-logs?${params}`);
 			logs = res.audit_logs || [];
 			total = res.total || 0;
+			syncUrl();
 		} catch (err: unknown) {
 			error = getErrorMessage(err);
 			addToast('error', error);
 		} finally {
 			loading = false;
 		}
+	}
+
+	function syncUrl() {
+		const params = new URLSearchParams();
+		if (searchQuery) params.set('search', searchQuery);
+		params.set('offset', String(offset));
+		const qs = params.toString();
+		history.replaceState(null, '', qs ? `?${qs}` : '?');
+	}
+
+	function hydrateFromUrl() {
+		const sp = new URLSearchParams(window.location.search);
+		const s = sp.get('search');
+		if (s) {
+			searchInput = s;
+			searchQuery = s;
+		}
+		const o = Number(sp.get('offset'));
+		if (!Number.isNaN(o) && o >= 0) offset = o;
 	}
 
 	function applyFilters() {
@@ -403,6 +440,8 @@
 					rows={logs as unknown as Record<string, unknown>[]}
 					searchPlaceholder={m["common.Search"]() + '...'}
 					searchableKeys={['username', 'action', 'resource_type', 'ip_address']}
+					initialSearch={searchInput}
+					onSearchChange={onSearchInput}
 					emptyTitle={m["common.No Results"]()}
 					expandedRowId={expandedId ?? undefined}
 				>

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -30,6 +30,21 @@
 	let offset = $state(0);
 	const limit = 50;
 
+	// Server-side search (searchInput = live box, searchQuery = committed).
+	let searchInput = $state('');
+	let searchQuery = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function onSearchInput(value: string) {
+		searchInput = value;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			searchQuery = value;
+			offset = 0;
+			fetchChanges();
+		}, 400);
+	}
+
 	// Auth is consumed directly via the $auth store (auto-subscribed in .svelte).
 
 	// Filters
@@ -47,6 +62,7 @@
 	const changeTypes: ChangeType[] = ['device_added', 'device_changed', 'device_lost'];
 
 	onMount(() => {
+		hydrateFromUrl();
 		fetchChanges();
 		// Best-effort: populate the network filter dropdown.
 		api.get<Network[]>('/networks').then((n) => { networks = n || []; }).catch(() => {});
@@ -90,15 +106,36 @@
 			params.set('offset', String(offset));
 			if (filterNetwork) params.set('network_id', filterNetwork);
 			if (filterChangeType) params.set('change_type', filterChangeType);
+			if (searchQuery) params.set('search', searchQuery);
 			const res = await api.get<{ changes: ChangeLogEntry[]; total: number }>(`/changes?${params}`);
 			changes = res.changes || [];
 			total = res.total || 0;
+			syncUrl();
 		} catch (err: unknown) {
 			error = getErrorMessage(err);
 			addToast('error', error);
 		} finally {
 			loading = false;
 		}
+	}
+
+	function syncUrl() {
+		const params = new URLSearchParams();
+		if (searchQuery) params.set('search', searchQuery);
+		params.set('offset', String(offset));
+		const qs = params.toString();
+		history.replaceState(null, '', qs ? `?${qs}` : '?');
+	}
+
+	function hydrateFromUrl() {
+		const sp = new URLSearchParams(window.location.search);
+		const s = sp.get('search');
+		if (s) {
+			searchInput = s;
+			searchQuery = s;
+		}
+		const o = Number(sp.get('offset'));
+		if (!Number.isNaN(o) && o >= 0) offset = o;
 	}
 
 	function applyFilters() {
@@ -331,6 +368,8 @@
 					rows={changes as unknown as Record<string, unknown>[]}
 					searchPlaceholder={m['common.Search']() + '...'}
 					searchableKeys={['change_type', 'agent_id', 'entity_id']}
+					initialSearch={searchInput}
+					onSearchChange={onSearchInput}
 					emptyTitle={m['changes.No Changes']()}
 					expandedRowId={expandedId ?? undefined}
 				>

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -41,6 +41,21 @@
 	let offset = $state(0);
 	const limit = 20;
 
+	// Server-side search (searchInput = live box, searchQuery = committed).
+	let searchInput = $state('');
+	let searchQuery = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function onSearchInput(value: string) {
+		searchInput = value;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			searchQuery = value;
+			offset = 0;
+			fetchDocuments();
+		}, 400);
+	}
+
 	// URL form modal
 	let urlModalOpen = $state(false);
 	let formTitle = $state('');
@@ -67,7 +82,10 @@
 	let previewOpen = $state(false);
 	let previewDoc = $state<Document | null>(null);
 
-	onMount(fetchDocuments);
+	onMount(() => {
+		hydrateFromUrl();
+		fetchDocuments();
+	});
 
 	async function fetchDocuments() {
 		loading = true;
@@ -76,15 +94,36 @@
 			const params = new URLSearchParams();
 			params.set('limit', String(limit));
 			params.set('offset', String(offset));
+			if (searchQuery) params.set('search', searchQuery);
 			const res = await api.get<{ documents: Document[]; total: number }>(`/documents?${params}`);
 			documents = res.documents || [];
 			total = res.total || 0;
+			syncUrl();
 		} catch (err: unknown) {
 			error = getErrorMessage(err);
 			addToast('error', error);
 		} finally {
 			loading = false;
 		}
+	}
+
+	function syncUrl() {
+		const params = new URLSearchParams();
+		if (searchQuery) params.set('search', searchQuery);
+		params.set('offset', String(offset));
+		const qs = params.toString();
+		history.replaceState(null, '', qs ? `?${qs}` : '?');
+	}
+
+	function hydrateFromUrl() {
+		const sp = new URLSearchParams(window.location.search);
+		const s = sp.get('search');
+		if (s) {
+			searchInput = s;
+			searchQuery = s;
+		}
+		const o = Number(sp.get('offset'));
+		if (!Number.isNaN(o) && o >= 0) offset = o;
 	}
 
 	// --- URL form ---
@@ -410,6 +449,8 @@
 				rows={documents as unknown as Record<string, unknown>[]}
 				searchableKeys={['title', 'description', 'type']}
 				searchPlaceholder={m["common.Search"]() + '...'}
+				initialSearch={searchInput}
+				onSearchChange={onSearchInput}
 				emptyTitle={m["common.No Results"]()}
 			/>
 		</div>

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -43,6 +43,22 @@
 	let offset = $state(0);
 	const limit = 20;
 
+	// Server-side search: searchInput (live box) vs searchQuery (committed,
+	// sent to backend). Split + debounce so typing doesn't refetch per keystroke.
+	let searchInput = $state('');
+	let searchQuery = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function onSearchInput(value: string) {
+		searchInput = value;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			searchQuery = value;
+			offset = 0;
+			fetchUsers();
+		}, 400);
+	}
+
 	// Auth is consumed directly via the $auth store (auto-subscribed in .svelte).
 
 	// Modal state
@@ -70,6 +86,7 @@
 	let touched = $state<Record<string, boolean>>({});
 
 	onMount(() => {
+		hydrateFromUrl();
 		fetchUsers();
 	});
 
@@ -80,9 +97,11 @@
 			const params = new URLSearchParams();
 			params.set('limit', String(limit));
 			params.set('offset', String(offset));
+			if (searchQuery) params.set('search', searchQuery);
 			const res = await api.get<{ users: User[]; total: number }>(`/users?${params}`);
 			users = res.users || [];
 			total = res.total || 0;
+			syncUrl();
 		} catch (err: unknown) {
 			// Inline banner only on initial load — a parallel toast here was
 			// noisy double-notification for a single failure.
@@ -90,6 +109,25 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	function syncUrl() {
+		const params = new URLSearchParams();
+		if (searchQuery) params.set('search', searchQuery);
+		params.set('offset', String(offset));
+		const qs = params.toString();
+		history.replaceState(null, '', qs ? `?${qs}` : '?');
+	}
+
+	function hydrateFromUrl() {
+		const sp = new URLSearchParams(window.location.search);
+		const s = sp.get('search');
+		if (s) {
+			searchInput = s;
+			searchQuery = s;
+		}
+		const o = Number(sp.get('offset'));
+		if (!Number.isNaN(o) && o >= 0) offset = o;
 	}
 
 	function resetForm() {
@@ -331,6 +369,8 @@
 						rows={users as unknown as Record<string, unknown>[]}
 						searchPlaceholder={m["common.Search"]() + '...'}
 						searchableKeys={['username', 'email', 'role']}
+						initialSearch={searchInput}
+						onSearchChange={onSearchInput}
 						emptyTitle={m["common.No Results"]()}
 					/>
 				</div>


### PR DESCRIPTION
## Summary

Resolves #64.

The DataTable search on users/audit/changes/documents was client-side — it only filtered the visible page slice, so paginating refetched an unfiltered page and the search term was effectively lost. This moves search server-side (mirroring `devices/+page.svelte`): the parent owns the search state and sends `?search=` to the backend, which filters across the whole result set before pagination.

## Changes

**Backend** (4 endpoints, `INSTR(lower(col), lower(?))` pattern — sqlc can't do `LIKE ? ESCAPE`, same approach as the existing scan-tasks search):
- **users**: `ListUsers` gains a WHERE on username/email; **new `CountUsers`** query
- **documents**: `ListDocuments` gains a WHERE on title/description/type; **new `CountDocuments`**
- **audit**: `ListAuditLogs`/`CountAuditLogs` gain a search clause (action/resource_type/ip_address); new `AuditLogFilter.Search` field
- **changes**: `ListChangeLog`/`CountChangeLog` gain a search clause (change_type/entity_type)

**Drive-by fix** (uncovered by this work): `users`/`documents` `Total` was `len(page)` (page size), not the real match count — pagination counts were wrong whenever more than one page existed. Both now use the new `CountX` queries for an accurate total.

**Frontend**:
- `DataTable.svelte`: optional `onSearchChange` callback + `initialSearch`; when the callback is present the component stops client-side filtering (server already filtered) — mirrors the existing `onSortChange` server pattern. Without the callback, old client-side behavior is unchanged (backward-compatible).
- `users`/`audit`/`changes`/`documents`: lift `searchInput`/`searchQuery` into the page (400ms debounce, reset offset on change), send `?search=`, sync the term to the URL (`?search=`) so deep links + pagination share state.

## Test coverage

- `TestListUsers_Search` (new): substring on username, substring on email, case-insensitive, no-match
- `TestListUsers_Pagination` updated: `Total` is now the real count (3), not the page size (2)

## Verification

- [x] `go vet` + `go test -race ./internal/...` — green (incl. new search test)
- [x] `sqlc compile` — green
- [x] `gofmt` / `goimports` — clean
- [x] `npm test` (153 pass) + `npm run build` — green
- [x] Deployed to 192.168.63.101 + curl-verified all 4 endpoints (`?search=` returns filtered rows + accurate total; e.g. audit `search=login` → total 2490, all `auth.login.success`)
- [x] Browser-tested (agent-browser) on audit page: type "login" → filters to login events → **paginate to page 2 → search term persists, rows still filtered** (the core #64 fix) → clear search → full list restored. No JS errors.

🤖 Generated with [ZCode](https://z.ai/code)