### PR TITLE
fix(web): NotificationBell pauses in background tabs + backs off on failure (#67)

### DIFF
--- a/web/src/lib/components/NotificationBell.svelte
+++ b/web/src/lib/components/NotificationBell.svelte
@@ -42,7 +42,9 @@
 	let marking = $state(false);
 	let containerRef: HTMLDivElement | undefined = $state();
 
-	async function fetchNotifications() {
+	// Returns true on success, false on failure — the poll loop uses this to
+	// back off when the backend is unreachable (avoids hammering a dead server).
+	async function fetchNotifications(): Promise<boolean> {
 		try {
 			loading = true;
 			const res = await api.get<NotificationLogsResponse>(
@@ -50,8 +52,11 @@
 			);
 			notifications = res.logs ?? [];
 			unreadCount = res.total ?? 0;
+			return true;
 		} catch {
-			// Silently fail — non-critical UI
+			// Silently fail — non-critical UI (the poll loop backs off, and the
+			// next user interaction retries).
+			return false;
 		} finally {
 			loading = false;
 		}
@@ -110,19 +115,51 @@
 	}
 
 	onMount(() => {
-		if ($auth.token) {
-			fetchNotifications();
-		}
+		const BASE_INTERVAL = 60_000; // normal cadence when the server is healthy
+		const BACKOFF_INTERVAL = 5 * 60_000; // back off after consecutive failures
+		let consecutiveFailures = 0;
+		let timeoutId: ReturnType<typeof setTimeout> | null = null;
+		let stopped = false;
 
-		const interval = setInterval(() => {
+		const scheduleNext = () => {
+			if (stopped) return;
+			// Back off on repeated failures so a down backend isn't hammered every
+			// 60s; reset to the base cadence as soon as a fetch succeeds.
+			const delay = consecutiveFailures > 0 ? BACKOFF_INTERVAL : BASE_INTERVAL;
+			timeoutId = setTimeout(poll, delay);
+		};
+
+		const poll = async () => {
 			if ($auth.token) {
-				fetchNotifications();
+				const ok = await fetchNotifications();
+				consecutiveFailures = ok ? 0 : consecutiveFailures + 1;
 			}
-		}, 60_000);
+			scheduleNext();
+		};
 
+		// Pause polling while the tab is hidden (no point fetching notifications
+		// the user can't see), and refresh immediately on return so the badge is
+		// current when they focus the tab again.
+		const onVisibilityChange = () => {
+			if (document.visibilityState === 'visible') {
+				if (timeoutId) clearTimeout(timeoutId);
+				consecutiveFailures = 0; // give the server a fresh chance on focus
+				poll();
+			} else if (timeoutId) {
+				clearTimeout(timeoutId);
+				timeoutId = null;
+			}
+		};
+
+		if ($auth.token) {
+			poll();
+		}
+		document.addEventListener('visibilitychange', onVisibilityChange);
 		document.addEventListener('click', handleClickOutside);
 		return () => {
-			clearInterval(interval);
+			stopped = true;
+			if (timeoutId) clearTimeout(timeoutId);
+			document.removeEventListener('visibilitychange', onVisibilityChange);
 			document.removeEventListener('click', handleClickOutside);
 		};
 	});


### PR DESCRIPTION
## Summary

Resolves #67.

The notification bell polled `/notification/logs` every 60s unconditionally — it kept hitting the backend while the tab was hidden (wasted requests for notifications the user couldn't see) and never backed off when the server was unreachable (hammering a dead backend every minute).

## Changes (`web/src/lib/components/NotificationBell.svelte`)

- **visibilitychange**: pause the poll loop when the tab is hidden; on regaining visibility, refresh immediately and resume — so the badge is current when the user focuses the tab again.
- **error backoff**: track consecutive failures and stretch the interval from 60s → 5min until a fetch succeeds (then reset to 60s). Implemented via a `setTimeout` recursion instead of a fixed `setInterval` so the delay can vary per cycle.
- `fetchNotifications` now returns a success boolean so the loop can count failures.

## Verification

- [x] `npm test` (153 pass) + `npm run build` — green
- [x] Deployed to 192.168.63.101 + browser-tested (agent-browser): bell still loads notifications on the dashboard, dropdown opens and shows the empty-state + "View All" link — **no regression** from the poll refactor. No JS errors.

**Note on the pause/backoff paths:** the tab-visibility and server-failure scenarios aren't directly simulable in browser automation (can't background the tab or kill the backend mid-session cleanly), but the logic is straightforward and reviewed — `visibilitychange` is a standard API and the backoff is a simple failure counter feeding the `setTimeout` delay.

🤖 Generated with [ZCode](https://z.ai/code)