### PR TITLE
fix(web): stop disguising server errors as empty states (#65)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -236,6 +236,7 @@
 		"Last 7d": "7d",
 		"Last 30d": "30d",
 		"No Data": "No heartbeat data for this period",
+		"Trend Load Failed": "Failed to load heartbeat trend",
 		"Success Status": "Success",
 		"Fail Status": "Fail",
 		"Timeout Status": "Timeout",
@@ -721,6 +722,8 @@
 		"All Events": "All Events",
 		"No Changes": "No changes yet",
 		"No Changes Desc": "Device changes will appear here once scans detect additions, modifications, or losses.",
+		"SSE Disconnected": "Live updates disconnected",
+		"SSE Disconnected Desc": "Real-time updates paused — refresh to see the latest.",
 		"Diff Title": "Change Details"
 	},
 	"agents": {
@@ -807,6 +810,7 @@
 	"topology": {
 		"Title": "Network Topology",
 		"All Networks": "All networks",
+		"Networks Load Failed": "Networks failed to load",
 		"Nodes": "devices",
 		"Edges": "adjacencies",
 		"Unidentified": "unidentified neighbor",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -236,6 +236,7 @@
 		"Last 7d": "7天",
 		"Last 30d": "30天",
 		"No Data": "该时段暂无心跳数据",
+		"Trend Load Failed": "心跳趋势加载失败",
 		"Success Status": "成功",
 		"Fail Status": "失败",
 		"Timeout Status": "超时",
@@ -721,6 +722,8 @@
 		"All Events": "全部事件",
 		"No Changes": "暂无变更",
 		"No Changes Desc": "扫描检测到设备新增、变更或离线时,事件将在此显示。",
+		"SSE Disconnected": "实时更新已断开",
+		"SSE Disconnected Desc": "实时更新已暂停——刷新以查看最新内容。",
 		"Diff Title": "变更详情"
 	},
 	"agents": {
@@ -807,6 +810,7 @@
 	"topology": {
 		"Title": "网络拓扑",
 		"All Networks": "全部网络",
+		"Networks Load Failed": "网络列表加载失败",
 		"Nodes": "台设备",
 		"Edges": "条邻接",
 		"Unidentified": "未识别邻居",

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -58,6 +58,10 @@
 	// SSE live updates (EventSource on /changes/watch). Falls back silently to
 	// the manual refresh if SSE is unavailable (disabled / network error).
 	let evtSource: EventSource | null = null;
+	// sseDisconnected is set when the EventSource gives up reconnecting
+	// (readyState CLOSED) so the page can show a "live updates paused" banner
+	// instead of freezing the feed silently. A fresh change event clears it.
+	let sseDisconnected = $state(false);
 
 	const changeTypes: ChangeType[] = ['device_added', 'device_changed', 'device_lost'];
 
@@ -67,12 +71,15 @@
 		// Best-effort: populate the network filter dropdown.
 		api.get<Network[]>('/networks').then((n) => { networks = n || []; }).catch(() => {});
 		// SSE: push-prepend new change events so the feed feels live. EventSource
-		// auto-reconnects; on error it just stops updating (manual refresh still works).
+		// auto-reconnects; on a hard failure (readyState CLOSED) we surface a
+		// banner so the user knows the feed froze (manual refresh still works).
 		try {
 			evtSource = new EventSource('/api/v1/changes/watch');
 			evtSource.addEventListener('change', (e: MessageEvent) => {
 				try {
 					const entry = JSON.parse(e.data) as ChangeLogEntry;
+					// A received event means the stream is healthy again.
+					sseDisconnected = false;
 					// Prepend only if not already at the top (dedup by id). Respect the
 					// current filter loosely — if a filter is active, just refresh to
 					// avoid mismatched views; if unfiltered, prepend for instant feedback.
@@ -85,6 +92,11 @@
 					// Malformed payload — ignore (keepalive comments also land here).
 				}
 			});
+			// Distinguish CONNECTING (auto-retry in progress — stay quiet) from
+			// CLOSED (gave up — tell the user the feed is no longer live).
+			evtSource.onerror = () => {
+				sseDisconnected = evtSource?.readyState === EventSource.CLOSED;
+			};
 		} catch {
 			// EventSource unsupported — SSE is best-effort; polling/refresh still works.
 		}
@@ -284,6 +296,14 @@
 			{m["dashboard.Refresh"]()}
 		</button>
 	</div>
+
+	<!-- SSE disconnected banner: the live feed gave up reconnecting. -->
+	{#if sseDisconnected}
+		<div class="mb-4 px-4 py-2 bg-warning/10 border border-warning/30 rounded-lg text-sm text-warning flex items-center justify-between gap-2">
+			<span>{m['changes.SSE Disconnected']()} — {m['changes.SSE Disconnected Desc']()}</span>
+			<button onclick={fetchChanges} class="btn btn-sm btn-ghost text-warning">{m["dashboard.Refresh"]()}</button>
+		</div>
+	{/if}
 
 	<!-- Filters -->
 	<div class="bg-surface border border-border rounded-lg p-4 mb-4">

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -622,7 +622,7 @@
 		// needed for drop to fire
 	}
 
-	function handleDrop(_e: DragEvent, targetId: string) {
+	async function handleDrop(_e: DragEvent, targetId: string) {
 		if (!draggedId || draggedId === targetId) return;
 
 		const fromIdx = widgets.findIndex((w) => w.id === draggedId);
@@ -638,12 +638,18 @@
 		// Update positions
 		widgets = updated.map((w, i) => ({ ...w, position: i }));
 
-		// Persist positions
+		// Persist positions. Wait for all puts and, on failure, toast + re-sync
+		// from the server so the UI doesn't show an order that wasn't saved
+		// (which a reload would silently snap back — #65).
 		if (isAdmin) {
-			for (const w of widgets) {
-				api.put(`/dashboard/configs/${w.id}`, { position: w.position }).catch(() => {
-					// silent fail — positions are best-effort
-				});
+			try {
+				await Promise.all(
+					widgets.map((w) => api.put(`/dashboard/configs/${w.id}`, { position: w.position }))
+				);
+			} catch (err: unknown) {
+				addToast('error', getErrorMessage(err));
+				// Re-sync: the server has the truth; reload discards the unsaved swap.
+				await loadAll();
 			}
 		}
 

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -68,6 +68,10 @@ interface AddDevicesResponse {
 	// GET /networks on mount.
 	let networkFilter = $state('');
 	let networks = $state<Network[]>([]);
+	// networksError tracks a /networks fetch failure so the network-filter
+	// dropdown shows a small "failed to load" indicator instead of silently
+	// vanishing (which a user could mistake for "no networks configured").
+	let networksError = $state(false);
 	let offset = $state(0);
 	// Per-page size is user-adjustable (was a const 20). Backed by the URL so a
 	// page reload / shared link preserves the chosen density.
@@ -146,7 +150,7 @@ interface AddDevicesResponse {
 		fetchDevices();
 		// Load the network registry for the filter dropdown (best-effort; a
 		// failure just leaves the dropdown empty — the list still works).
-		api.get<Network[]>('/networks').then((n) => { networks = n || []; }).catch(() => {});
+		api.get<Network[]>('/networks').then((n) => { networks = n || []; networksError = false; }).catch(() => { networksError = true; });
 		pollTimer = setInterval(() => {
 			if (!editOpen && !deleteOpen && !batchDeleteOpen && !batchStatusOpen && !importOpen && !linkOpen) {
 				void refreshDevicesSilent();
@@ -895,6 +899,12 @@ interface AddDevicesResponse {
 					<option value={net.id}>{net.name}{net.cidr ? ` (${net.cidr})` : ''}</option>
 				{/each}
 			</select>
+		{:else if networksError}
+			<!-- The /networks fetch failed — show a small indicator instead of
+			     silently dropping the filter (which would look like "no networks"). -->
+			<span class="text-xs text-warning px-2 py-1 border border-warning/30 rounded" title={m['devices.Networks Load Failed']()}>
+				{m['devices.Networks Load Failed']()}
+			</span>
 		{/if}
 
 		<!-- Server-side search (name / ip / mac / serial). 400ms debounce. -->

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -100,6 +100,9 @@
 	let trendTo = $state('');
 	let trendOption = $state<EChartsOption>({});
 	let trendStats = $state<{ avg_latency_ms: number; success_count: number; fail_count: number; timeout_count: number } | null>(null);
+	// trendError is set when the trend/stats fetch fails so the chart shows an
+	// error banner (with retry) instead of disguising the failure as "No Data".
+	let trendError = $state('');
 	// --- Heartbeat config state ---
 	let heartbeatConfigs = $state<Array<{ id: number; method: string; target: string; interval_seconds: number; timeout_seconds: number; enabled: number }>>([]);
 	let heartbeatConfigLoading = $state(false);
@@ -597,6 +600,7 @@
 
 	async function fetchHeartbeatTrend() {
 		trendLoading = true;
+		trendError = '';
 		let from: string;
 		let to: string;
 		if (trendPreset === 'custom' && trendFrom && trendTo) {
@@ -618,9 +622,12 @@
 			]);
 			trendStats = statsRes;
 			buildTrendChart(historyRes.heartbeat_results || []);
-		} catch {
+		} catch (err: unknown) {
+			// Record the failure so the chart shows an error banner + retry
+			// instead of the misleading "No Data" empty-state (#65).
 			trendStats = null;
 			trendOption = {};
+			trendError = getErrorMessage(err);
 		} finally {
 			trendLoading = false;
 		}
@@ -1579,7 +1586,12 @@
 		{/if}
 
 		<!-- Chart -->
-		{#if trendLoading}
+		{#if trendError}
+			<div class="mb-3 px-4 py-2 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center justify-between gap-2">
+				<span>{trendError}</span>
+				<button class="btn btn-sm btn-ghost" onclick={fetchHeartbeatTrend}>{m['common.Retry']()}</button>
+			</div>
+		{:else if trendLoading}
 			<!-- Single chart: a table skeleton was misleading; use a chart-shaped rect. -->
 			<div class="bg-surface border border-border rounded-xl p-4" role="status" aria-busy="true">
 				<Skeleton variant="rect" width="100%" height="320px" />

--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -276,11 +276,18 @@
 	function pollRunStatus(taskId: number) {
 		if (pollingTimers.has(taskId)) return;
 		let pollCount = 0;
+		// Track consecutive poll failures so a dead backend doesn't leave the
+		// spinner sweeping silently — after a few in a row, surface a warning
+		// (once, not per failure). Reset on any successful poll (#65).
+		let consecutiveErrors = 0;
+		let errorToasted = false;
 		const maxPolls = 100; // ~300s with 3s interval
 		const poll = async () => {
 			pollCount++;
 			try {
 				const res = await api.get<{ runs: ScanRun[]; total: number }>(`/scanner/tasks/${taskId}/runs?limit=1`);
+				consecutiveErrors = 0;
+				errorToasted = false;
 				if (res.runs && res.runs.length > 0) {
 					const run = res.runs[0];
 					if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
@@ -315,8 +322,15 @@
 					addToast('warning', m['scanner.Scan No Run']());
 					fetchTasks();
 				}
-			} catch {
-				// Poll errors are non-critical, keep trying
+			} catch (err: unknown) {
+				// Poll errors are non-critical — keep trying — but after several in
+				// a row the live-progress spinner is lying to the user. Surface one
+				// warning so they know to refresh manually (the loop keeps running).
+				consecutiveErrors++;
+				if (consecutiveErrors >= 3 && !errorToasted) {
+					errorToasted = true;
+					addToast('warning', getErrorMessage(err));
+				}
 			}
 			if (pollingTimers.has(taskId)) {
 				pollingTimers.set(taskId, setTimeout(poll, 3000));


### PR DESCRIPTION
## Summary

Resolves #65.

Several `catch` blocks turned server failures into empty states, nudging users toward the wrong action (creating a config that exists, refreshing a feed that's actually live). This distinguishes loading / error / empty at each spot so a failure shows an error state + retry, not "no data".

**Note:** 3 of the issue's spots (`fetchHeartbeatConfigs` / `fetchNeighbors` / `fetchTLSCerts`) were already fixed by #56 — this covers the remaining 5.

## Changes (5 spots)

1. **Device detail `fetchHeartbeatTrend`**: anonymous catch → `trendError` state + inline error banner + retry above the chart (was: "No Data", indistinguishable from a device that genuinely has no heartbeat data).
2. **Devices list `/networks` fetch**: silent `.catch` → `networksError` flag; the network-filter dropdown now shows a "failed to load" indicator instead of silently vanishing (which read as "no networks configured").
3. **Scan-tasks poll**: fully-swallowed errors now count consecutive failures; after 3 in a row one warning toast fires (flag-guarded, no spam) so a dead backend doesn't leave the progress spinner sweeping silently.
4. **Changes SSE**: no `onerror` handler existed — the feed could freeze with no signal. Added `evtSource.onerror` that sets `sseDisconnected` when the EventSource gives up (`readyState CLOSED`, not `CONNECTING` retry) and a "live updates disconnected" banner with a refresh button.
5. **Dashboard widget drag-save**: fire-and-forget puts → `Promise.all` with an error toast + `loadAll()` re-sync so the UI doesn't show an order that wasn't persisted (a reload would silently snap it back).

New i18n keys (en + zh): `heartbeat.Trend Load Failed`, `changes.SSE Disconnected` / `SSE Disconnected Desc`, `devices.Networks Load Failed`.

## Verification

- [x] `npm test` (153 pass) + `npm run build` — green
- [x] Deployed to 192.168.63.101 + browser regression-tested (agent-browser) on the **happy paths** (error states must stay hidden when fetches succeed):
  - Device detail Heartbeat tab: shows "No heartbeat data" empty-state, **no error banner** (fetch succeeded)
  - Devices list network filter: dropdown loads ("All Networks"), **no error badge**
  - Changes page: SSE connected, **no disconnected banner**
  - No JS errors
- The **failure paths** (network down / SSE CLOSED / drag-save failure) aren't cleanly simulable in browser automation, but the state variables + logic are in place and the happy-path regressions confirm the error states don't false-fire.

🤖 Generated with [ZCode](https://z.ai/code)