### PR TITLE
fix(audit): data-driven filter dropdowns + accessible export menu (#68)

### DIFF
--- a/db/queries/audit_queries.sql
+++ b/db/queries/audit_queries.sql
@@ -28,6 +28,17 @@ WHERE (? = 0 OR user_id = ?)
   AND (? = '' OR created_at <= ?)
   AND (? = '' OR INSTR(lower(action), lower(?)) > 0 OR INSTR(lower(resource_type), lower(?)) > 0 OR INSTR(lower(ip_address), lower(?)) > 0);
 
+-- name: DistinctAuditActions :many
+-- Facets for the audit page filter dropdowns. Distinct values are pulled
+-- straight from the table (rather than a hardcoded list in the frontend) so a
+-- new action emitted by the backend shows up automatically. idx_audit_logs_action
+-- makes the DISTINCT scan cheap; resource_type is unindexed but the table is
+-- retention-bounded (90d default) so the scan is bounded too.
+SELECT DISTINCT action FROM audit_logs ORDER BY action;
+
+-- name: DistinctAuditResourceTypes :many
+SELECT DISTINCT resource_type FROM audit_logs ORDER BY resource_type;
+
 -- name: DeleteAuditLogsOlderThan :execrows
 -- Retention sweep: prune audit rows older than the cutoff. Batched deletion is
 -- done in Go (DELETE rowid IN (SELECT ... LIMIT ?)) to avoid a single giant

--- a/internal/api/handler/audit.go
+++ b/internal/api/handler/audit.go
@@ -85,3 +85,15 @@ func (h *AuditHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	Success(w, resp)
 }
+
+// Facets handles GET /api/v1/audit-logs/facets — returns the distinct action
+// and resource_type values currently in the table, for the audit page filter
+// dropdowns (so the dropdowns always match what the backend actually emits).
+func (h *AuditHandler) Facets(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.Facets(r.Context())
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to load audit facets")
+		return
+	}
+	Success(w, resp)
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -568,6 +568,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.RequireAdmin)
 		r.Get("/api/v1/audit-logs", auditHandler.List)
+		r.Get("/api/v1/audit-logs/facets", auditHandler.Facets)
 		r.Get("/api/v1/audit-logs/export", exportHandler.ExportAuditLogs)
 	})
 

--- a/internal/db/audit_queries.sql.go
+++ b/internal/db/audit_queries.sql.go
@@ -96,6 +96,65 @@ func (q *Queries) DeleteAuditLogsOlderThanBatched(ctx context.Context, arg Delet
 	return result.RowsAffected()
 }
 
+const distinctAuditActions = `-- name: DistinctAuditActions :many
+SELECT DISTINCT action FROM audit_logs ORDER BY action
+`
+
+// Facets for the audit page filter dropdowns. Distinct values are pulled
+// straight from the table (rather than a hardcoded list in the frontend) so a
+// new action emitted by the backend shows up automatically. idx_audit_logs_action
+// makes the DISTINCT scan cheap; resource_type is unindexed but the table is
+// retention-bounded (90d default) so the scan is bounded too.
+func (q *Queries) DistinctAuditActions(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, distinctAuditActions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var action string
+		if err := rows.Scan(&action); err != nil {
+			return nil, err
+		}
+		items = append(items, action)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const distinctAuditResourceTypes = `-- name: DistinctAuditResourceTypes :many
+SELECT DISTINCT resource_type FROM audit_logs ORDER BY resource_type
+`
+
+func (q *Queries) DistinctAuditResourceTypes(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, distinctAuditResourceTypes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var resource_type string
+		if err := rows.Scan(&resource_type); err != nil {
+			return nil, err
+		}
+		items = append(items, resource_type)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAuditLogs = `-- name: ListAuditLogs :many
 
 SELECT id, user_id, action, resource_type, resource_id, ip_address, user_agent, details, created_at

--- a/internal/domain/audit.go
+++ b/internal/domain/audit.go
@@ -30,6 +30,15 @@ type AuditLogListResponse struct {
 	Total     int                `json:"total"`
 }
 
+// AuditFacetsResponse holds the distinct values currently present in the
+// audit_logs table, used to populate the audit page's action / resource-type
+// filter dropdowns. Sourced from the DB (not a hardcoded list) so newly emitted
+// actions appear without a frontend change.
+type AuditFacetsResponse struct {
+	Actions       []string `json:"actions"`
+	ResourceTypes []string `json:"resource_types"`
+}
+
 // AuditLogFilter represents filtering parameters for audit log queries.
 type AuditLogFilter struct {
 	UserID       *int64

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -138,6 +138,32 @@ func (s *AuditService) List(ctx context.Context, filter domain.AuditLogFilter) (
 	}, nil
 }
 
+// Facets returns the distinct action and resource_type values currently
+// present in audit_logs, for populating the audit page filter dropdowns.
+// Both lists come back empty (not an error) when the table has no rows.
+func (s *AuditService) Facets(ctx context.Context) (*domain.AuditFacetsResponse, error) {
+	actions, err := s.queries.DistinctAuditActions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resourceTypes, err := s.queries.DistinctAuditResourceTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// sqlc returns a non-nil empty slice for `:many` with no rows, but be
+	// defensive so the JSON encodes as [] not null.
+	if actions == nil {
+		actions = []string{}
+	}
+	if resourceTypes == nil {
+		resourceTypes = []string{}
+	}
+	return &domain.AuditFacetsResponse{
+		Actions:       actions,
+		ResourceTypes: resourceTypes,
+	}, nil
+}
+
 // toAuditLogResponse converts a db.AuditLog to a domain.AuditLogResponse.
 func toAuditLogResponse(log db.AuditLog) domain.AuditLogResponse {
 	createdAt := time.Time{}

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -240,3 +240,37 @@ func TestAudit_EmptyResult(t *testing.T) {
 	require.Len(t, resp.AuditLogs, 0)
 	require.Equal(t, 0, resp.Total)
 }
+
+// 8. Facets: distinct + sorted actions and resource_types for the dropdowns.
+func TestAudit_Facets(t *testing.T) {
+	svc, dbConn, _ := setupAuditTest(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	uid := int64(1)
+	insertAuditLog(t, dbConn, &uid, "device.delete", "device", "1", now)
+	insertAuditLog(t, dbConn, &uid, "device.create", "device", "2", now) // dup resource_type, new action
+	insertAuditLog(t, dbConn, &uid, "auth.login.success", "auth", "3", now)
+	insertAuditLog(t, dbConn, &uid, "device.create", "device", "4", now) // dup both — must be deduped
+
+	resp, err := svc.Facets(ctx)
+	require.NoError(t, err)
+	// Actions deduped (3 distinct) and sorted ascending.
+	require.Equal(t, []string{"auth.login.success", "device.create", "device.delete"}, resp.Actions)
+	// Resource types deduped (2 distinct) and sorted.
+	require.Equal(t, []string{"auth", "device"}, resp.ResourceTypes)
+}
+
+// 8b. Facets on an empty table returns empty slices (not nil), so JSON
+// encodes as [] rather than null — keeps the dropdown logic simple.
+func TestAudit_Facets_EmptyTable(t *testing.T) {
+	svc, _, _ := setupAuditTest(t)
+	ctx := context.Background()
+
+	resp, err := svc.Facets(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Actions)
+	require.NotNil(t, resp.ResourceTypes)
+	require.Empty(t, resp.Actions)
+	require.Empty(t, resp.ResourceTypes)
+}

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -56,29 +56,22 @@
 	let filterDateFrom = $state('');
 	let filterDateTo = $state('');
 
-	// Available filter options (fetched from API or hardcoded)
+	// Available filter options, pulled from the API so the dropdowns always
+	// reflect what the backend actually emits (a new action appears here
+	// automatically — previously the list was hardcoded and drifted out of sync).
 	let users = $state<{ id: number; username: string }[]>([]);
-	const commonActions = [
-		'auth.login.success',
-		'auth.login.failure',
-		'auth.logout',
-		'auth.password.change',
-		'admin.user.create',
-		'admin.user.delete',
-		'device.create',
-		'device.update',
-		'device.delete',
-		'file.upload',
-		'file.delete',
-		'scanner.scan',
-		'scanner.add_devices'
-	];
-	const resourceTypes = ['user', 'device', 'document', 'system', 'heartbeat_config', 'notification_channel'];
+	let actions = $state<string[]>([]);
+	let resourceTypes = $state<string[]>([]);
+
+	// Export dropdown (click-toggle so it's reachable by keyboard/touch — the
+	// old group-hover:opacity-100 version was mouse-only).
+	let exportOpen = $state(false);
 
 	onMount(() => {
 		hydrateFromUrl();
 		fetchAuditLogs();
 		fetchUsers();
+		fetchFacets();
 	});
 
 	async function fetchUsers() {
@@ -87,6 +80,19 @@
 			users = res.users || [];
 		} catch {
 			// Non-critical — filter dropdown just won't populate
+		}
+	}
+
+	async function fetchFacets() {
+		// Best-effort: populate the action / resource-type dropdowns from the
+		// distinct values currently in audit_logs. On failure the dropdowns are
+		// just empty (search + the other filters still work), so stay silent.
+		try {
+			const res = await api.get<{ actions: string[]; resource_types: string[] }>('/audit-logs/facets');
+			actions = res.actions || [];
+			resourceTypes = res.resource_types || [];
+		} catch {
+			// Non-critical — dropdowns stay empty.
 		}
 	}
 
@@ -195,6 +201,8 @@
 			addToast('success', m['devices.Export']());
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));
+		} finally {
+			exportOpen = false;
 		}
 	}
 
@@ -292,23 +300,40 @@
 	<div class="flex items-center justify-between mb-6">
 		<h2 class="text-2xl font-bold text-primary">{m["audit.Audit Logs"]()}</h2>
 		<div class="flex items-center gap-2">
-			<div class="relative group">
-				<button class="px-4 py-2 border border-border text-text-muted rounded-lg
-					hover:border-primary hover:text-primary transition-colors text-sm">
+			<!-- Export dropdown (click-toggle — accessible to keyboard/touch;
+			     mirrors the pattern in devices/+page.svelte). -->
+			<div class="relative">
+				<button
+					onclick={() => (exportOpen = !exportOpen)}
+					class="px-4 py-2 border border-border text-text-muted rounded-lg
+						hover:border-primary hover:text-primary transition-colors text-sm"
+					aria-expanded={exportOpen}
+					aria-haspopup="menu"
+				>
 					{m['devices.Export']()}
 				</button>
-				<div class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg
-					opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10 min-w-[120px]"
-					style="box-shadow: var(--shadow-md);">
-					<button onclick={() => exportAuditLogs('csv')}
-						class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 rounded-t-lg">
-						{m['devices.Export CSV']()}
-					</button>
-					<button onclick={() => exportAuditLogs('json')}
-						class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 rounded-b-lg">
-						{m['devices.Export JSON']()}
-					</button>
-				</div>
+				{#if exportOpen}
+					<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+					<div class="fixed inset-0 z-10" onclick={() => (exportOpen = false)} role="presentation"></div>
+					<div
+						class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg z-20 min-w-[120px]"
+						style="box-shadow: var(--shadow-md);"
+						role="menu"
+					>
+						<button
+							onclick={() => exportAuditLogs('csv')}
+							role="menuitem"
+							class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 rounded-t-lg">
+							{m['devices.Export CSV']()}
+						</button>
+						<button
+							onclick={() => exportAuditLogs('json')}
+							role="menuitem"
+							class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 rounded-b-lg">
+							{m['devices.Export JSON']()}
+						</button>
+					</div>
+				{/if}
 			</div>
 			<button
 				onclick={fetchAuditLogs}
@@ -347,7 +372,7 @@
 						focus:border-primary focus:outline-none"
 				>
 					<option value="">{m["audit.All Actions"]()}</option>
-					{#each commonActions as a}
+					{#each actions as a}
 						<option value={a}>{a}</option>
 					{/each}
 				</select>


### PR DESCRIPTION
## Summary

Fixes points 1 and 2 of issue #68 (point 3 — escape util duplication — was already resolved in the current code; see "Scope notes" below).

## Point 1 — filter dropdowns hardcoded, drifted out of sync

The audit page's **action** and **resource-type** filter dropdowns were hardcoded lists (13 actions, 6 resource types). The backend actually emits 20+ distinct actions — `admin.notification.channel.create`, `admin.document.link`, `admin.user.batch_delete`, `file.download`, `device.alert`, etc. — **none of which were selectable in the filter**. Same problem for resource types.

Fixed by sourcing the dropdown values from the DB via a new **facets endpoint** (user-confirmed approach):

- `db/queries/audit_queries.sql` — `DistinctAuditActions` / `DistinctAuditResourceTypes` (`SELECT DISTINCT … ORDER BY …`; `idx_audit_logs_action` makes the action scan cheap)
- `sqlc generate` → `internal/db/audit_queries.sql.go`
- `service.AuditService.Facets` + `domain.AuditFacetsResponse{ Actions, ResourceTypes }`
- `handler.AuditHandler.Facets` → `GET /api/v1/audit-logs/facets` (admin group)
- `routes.go` — register the route in the existing admin-only audit group
- frontend `audit/+page.svelte` — `fetchFacets()` on mount populates `actions` / `resourceTypes` state; the hardcoded `commonActions` / `resourceTypes` constants are **deleted**. Best-effort (silent on failure — dropdowns stay empty, search + other filters still work).

A new backend action now appears in the filter automatically — no frontend change needed.

## Point 2 — export dropdown mouse-only (`group-hover`)

The export menu used `opacity-0 group-hover:opacity-100` — unreachable by keyboard/touch, no ARIA, no outside-click/Esc. Replaced with the **click-toggle pattern already used in `devices/+page.svelte`**: `exportOpen` state + `aria-expanded` + `aria-haspopup="menu"` + `fixed inset-0` overlay for outside-click close + `role="menu"`/`role="menuitem"`. Esc closes via the existing global Escape handler in `+layout.svelte`.

## Verification (deployed to 192.168.63.101 + browser-tested)

| Scenario | Result |
|---|---|
| `GET /audit-logs/facets` API | ✅ returns real distinct actions/resource_types (`admin.notification.channel.*`, `auth.login.*`, …) |
| Action dropdown | ✅ shows those real values — no stale hardcoded entries (`device.update`, `scanner.scan`, etc. gone) |
| Resource-type dropdown | ✅ shows real values (`notification_channel`, `user`) not the old hardcoded 6 |
| Export button click-toggle | ✅ `expanded=true` on click, menu shows CSV/JSON `menuitem`s |
| Outside-click close | ✅ overlay click → `expanded=false`, menu disappears |
| CSV export end-to-end | ✅ success toast, menu auto-closes (`exportOpen=false` in finally) |
| `go test ./...` | ✅ (incl. new `TestAudit_Facets` + `TestAudit_Facets_EmptyTable`) |
| `sqlc compile` | ✅ |
| `npm test` | ✅ 153/153 |

## Scope notes

- **Point 3 already done**: the issue's third point (escape util duplication) was already resolved — both `audit/+page.svelte` and `changes/+page.svelte` now render via the `html` tagged template (`web/src/lib/utils/html.ts`), which auto-escapes via `escapeHtml` (full `& < > " '` set). No local `escapeHtmlSimple` remains (the only mention is an explanatory comment in `changes/+page.svelte:273`). So no change needed there — issue acceptance criterion #3 is already satisfied.

## Tests added
- `internal/service/audit_test.go` — `TestAudit_Facets` (dedup + sort across actions/resource_types) and `TestAudit_Facets_EmptyTable` (empty slices, not nil, so JSON encodes as `[]`).

Closes #68
