### PR TITLE
fix(devices): scattered P2 fixes across devices subtree (#70)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -912,6 +912,8 @@
 		"Name Required": "Name is required",
 		"Type Required": "Type is required",
 		"Invalid IP Format": "Invalid IP address format",
+		"Invalid ID": "Invalid Device ID",
+		"Invalid ID Desc": "The device ID in the URL is not a valid number.",
 		"IP Octet Range": "Each IP octet must be 0-255",
 		"Invalid MAC Format": "Invalid MAC address (use AA:BB:CC:DD:EE:FF or AA-BB-CC-DD-EE-FF)",
 		"Username Min Length": "Username must be at least 3 characters",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -912,6 +912,8 @@
 		"Name Required": "名称为必填项",
 		"Type Required": "类型为必填项",
 		"Invalid IP Format": "IP 地址格式无效",
+		"Invalid ID": "无效的设备 ID",
+		"Invalid ID Desc": "URL 中的设备 ID 不是有效的数字。",
 		"IP Octet Range": "每个 IP 段必须为 0-255",
 		"Invalid MAC Format": "MAC 地址无效（请用 AA:BB:CC:DD:EE:FF 或 AA-BB-CC-DD-EE-FF）",
 		"Username Min Length": "用户名至少需要 3 个字符",

--- a/web/src/lib/utils/validation.ts
+++ b/web/src/lib/utils/validation.ts
@@ -163,6 +163,13 @@ function isValidOctets(ip: string): boolean {
 	return octets.length === 4 && octets.every(o => o >= 0 && o <= 255);
 }
 
+/** isValidIP checks a single IPv4 address (no CIDR/range/list). Reused by
+ *  validateScanTarget below and exported for callers that validate one IP at
+ *  a time — e.g. the CSV import preview flagging malformed rows. */
+export function isValidIP(ip: string): boolean {
+	return ipv4OctetPattern.test(ip.trim()) && isValidOctets(ip.trim());
+}
+
 /**
  * Validates scan target(s) input.
  * Accepts: single IP, CIDR notation, comma-separated list, IP ranges (1.1.1.1-10).

--- a/web/src/routes/devices/+layout.svelte
+++ b/web/src/routes/devices/+layout.svelte
@@ -12,8 +12,9 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { page } from '$app/stores';
 	import { auth } from '$lib/stores/auth';
+	import type { Snippet } from 'svelte';
 
-	let { children } = $props<{ children: () => void }>();
+	let { children } = $props<{ children: Snippet }>();
 
 	const isAdmin = $derived($auth.user?.role === 'admin');
 

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -16,6 +16,7 @@
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { escapeHtml, escapeAttr } from '$lib/utils';
+	import { isValidIP } from '$lib/utils/validation';
 	import type { Device, LinkedDoc, Network } from '$lib/types';
 	import { ChevronDown, ChevronRight, Download, Upload, Plus, List, Share2 } from '@lucide/svelte';
 
@@ -102,7 +103,7 @@ interface AddDevicesResponse {
 
 	// --- Delete confirmation ---
 	let deleteOpen = $state(false);
-	let deleteTarget = $state<Device | null>(null);
+	let deleteTarget = $state<Pick<Device, 'id' | 'name'> | null>(null);
 
 	// --- Expandable heartbeat row ---
 	let expandedDeviceId = $state<number | null>(null);
@@ -161,6 +162,20 @@ interface AddDevicesResponse {
 	onDestroy(() => {
 		if (pollTimer) clearInterval(pollTimer);
 		if (searchTimer) clearTimeout(searchTimer);
+	});
+
+	// Esc closes any open dropdown menu (Export / batch-status). The global
+	// +layout.svelte Escape handler only targets .modal-backdrop, so these
+	// click-toggle menus need their own listener. Click-outside is already
+	// handled by each menu's fixed inset-0 overlay.
+	$effect(() => {
+		function onKeydown(e: KeyboardEvent) {
+			if (e.key !== 'Escape') return;
+			if (exportOpen) { exportOpen = false; e.stopPropagation(); }
+			else if (batchStatusOpen) { batchStatusOpen = false; e.stopPropagation(); }
+		}
+		window.addEventListener('keydown', onKeydown);
+		return () => window.removeEventListener('keydown', onKeydown);
 	});
 
 	// buildParams assembles the backend query for the current view state. Shared
@@ -498,7 +513,7 @@ interface AddDevicesResponse {
 
 
 	// --- Delete ---
-	function openDelete(device: Device) {
+	function openDelete(device: Pick<Device, 'id' | 'name'>) {
 		deleteTarget = device;
 		deleteOpen = true;
 	}
@@ -791,7 +806,7 @@ interface AddDevicesResponse {
 			const device = devices.find((d) => d.id === id);
 			if (device) openLinkModal(device);
 		} else if (action === 'delete') {
-			const device = devices.find((d) => d.id === id) ?? { id, name } as Device;
+			const device = devices.find((d) => d.id === id) ?? { id, name };
 			openDelete(device);
 		}
 	}
@@ -1033,15 +1048,20 @@ interface AddDevicesResponse {
 				<button
 					onclick={() => (batchStatusOpen = !batchStatusOpen)}
 					class="btn btn-primary text-xs py-1.5"
+					aria-expanded={batchStatusOpen}
+					aria-haspopup="menu"
 				>
 					{m['devices.Batch Update Status']()}
 					<ChevronDown class="w-3 h-3" />
 				</button>
 				{#if batchStatusOpen}
-					<div class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg z-10 min-w-[140px]" style="box-shadow: var(--shadow-md);">
+					<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+					<div class="fixed inset-0 z-10" onclick={() => (batchStatusOpen = false)} role="presentation"></div>
+					<div class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg z-20 min-w-[140px]" style="box-shadow: var(--shadow-md);" role="menu">
 						{#each ['online', 'offline', 'unknown'] as status}
 							<button
 								onclick={() => { batchStatusValue = status; batchStatusOpen = false; confirmBatchStatus(); }}
+								role="menuitem"
 								class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 last:rounded-b-lg first:rounded-t-lg"
 							>
 								<span class="inline-block w-2 h-2 rounded-full mr-2 {statusDotClass(status)}"></span>
@@ -1150,8 +1170,14 @@ interface AddDevicesResponse {
 		</div>
 
 		{#if csvPreviewRows.length > 0}
+			{@const invalidIpCount = csvPreviewRows.filter((r) => !isValidIP(r.ip)).length}
 			<div>
 				<h4 class="text-sm font-medium text-text mb-2">{m['devices.Import Preview']()} ({csvPreviewRows.length} rows)</h4>
+				{#if invalidIpCount > 0}
+					<p class="text-xs text-error mb-2">
+						{m['devices.Invalid IP Format']()} — {invalidIpCount}
+					</p>
+				{/if}
 				<div class="overflow-x-auto border border-border rounded-lg max-h-60">
 					<table class="w-full text-sm">
 						<thead>
@@ -1162,9 +1188,11 @@ interface AddDevicesResponse {
 							</tr>
 						</thead>
 						<tbody>
-							{#each csvPreviewRows as row, i}
+							{#each csvPreviewRows as row, i (i)}
 								<tr class="border-b border-border last:border-b-0 hover:bg-border/30">
-									<td class="px-3 py-2 font-mono">{row.ip}</td>
+									<td class="px-3 py-2 font-mono {isValidIP(row.ip) ? '' : 'text-error'}" title={isValidIP(row.ip) ? undefined : m['devices.Invalid IP Format']()}>
+										{row.ip}
+									</td>
 									<td class="px-3 py-2">{row.name}</td>
 									<td class="px-3 py-2">{row.type}</td>
 								</tr>

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -36,6 +36,9 @@
 
 	// --- Route param ---
 	let deviceId = $derived(Number($page.params.id));
+	// A non-numeric :id (e.g. /devices/abc) yields NaN; guard it so we render a
+	// friendly EmptyState instead of firing /devices/NaN requests that 404.
+	let invalidId = $derived(!Number.isFinite(deviceId));
 
 	// --- Core state ---
 	let device = $state<Device | null>(null);
@@ -283,6 +286,11 @@
 
 	// --- Data fetching ---
 	async function fetchDevice() {
+		// Non-numeric :id — never hit the API; the EmptyState below handles it.
+		if (invalidId) {
+			deviceLoading = false;
+			return;
+		}
 		deviceLoading = true;
 		deviceError = '';
 		try {
@@ -869,7 +877,16 @@
 	     (or failed to load), show a skeleton / error+retry INSTEAD of the tab bar
 	     + tab panels. Without this, a fetchDevice failure leaves every non-Systems
 	     tab blank because their content is gated on {#if device}. -->
-	{#if deviceLoading && !device}
+	{#if invalidId}
+		<!-- Non-numeric :id — never reached the API. Offer a way back to the list. -->
+		<EmptyState
+			icon="⚠"
+			title={m["devices.Invalid ID"]()}
+			description={m["devices.Invalid ID Desc"]()}
+			actionLabel={m["navigation.Devices"]()}
+			onAction={() => goto('/devices')}
+		/>
+	{:else if deviceLoading && !device}
 		<PageSkeleton type="detail" />
 	{:else if deviceError && !device}
 		<EmptyState

--- a/web/src/routes/devices/discovery/+page.svelte
+++ b/web/src/routes/devices/discovery/+page.svelte
@@ -24,26 +24,51 @@
 
 	let status = $state<DiscoveryStatus | null>(null);
 	let loading = $state(true);
+	let refreshing = $state(false);
 	let error = $state('');
-	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	// Poll loop uses setTimeout recursion (not setInterval) so the next delay
+	// can adapt: on repeated failure the interval backs off (up to 2min) so a
+	// dead backend isn't hammered every 30s; on success it resets to 30s.
+	let pollTimer: ReturnType<typeof setTimeout> | null = null;
+	let consecutiveErrors = 0;
+	const BASE_POLL_MS = 30_000;
+	const MAX_POLL_MS = 120_000;
 
 	onMount(() => {
 		fetchStatus();
-		pollTimer = setInterval(fetchStatus, 30000);
 	});
 
 	onDestroy(() => {
-		if (pollTimer) clearInterval(pollTimer);
+		if (pollTimer) clearTimeout(pollTimer);
 	});
 
 	async function fetchStatus() {
+		// First load shows the PageSkeleton via `loading`; subsequent refreshes
+		// (manual button or poll) toggle `refreshing` so the user gets feedback
+		// without the skeleton flashing on every tick.
+		if (status) refreshing = true;
 		try {
 			status = await api.get<DiscoveryStatus>('/discovery/status');
+			error = '';
+			consecutiveErrors = 0;
 		} catch (err: unknown) {
 			error = getErrorMessage(err);
+			consecutiveErrors++;
 		} finally {
 			loading = false;
+			refreshing = false;
+			schedulePoll();
 		}
+	}
+
+	function schedulePoll() {
+		if (pollTimer) clearTimeout(pollTimer);
+		// Backoff: double the base per consecutive error, capped at MAX_POLL_MS.
+		// 0 errors → 30s, 1 → 60s, 2+ → 120s.
+		const delay = error
+			? Math.min(BASE_POLL_MS * Math.pow(2, consecutiveErrors), MAX_POLL_MS)
+			: BASE_POLL_MS;
+		pollTimer = setTimeout(fetchStatus, delay);
 	}
 
 	function formatTime(iso?: string): string {
@@ -72,10 +97,12 @@
 		</div>
 		<button
 			onclick={fetchStatus}
+			disabled={refreshing}
 			class="px-4 py-2 border border-border text-text-muted rounded-lg
-				hover:border-primary hover:text-primary transition-colors text-sm"
+				hover:border-primary hover:text-primary transition-colors text-sm
+				disabled:opacity-60 disabled:cursor-not-allowed"
 		>
-			{m['dashboard.Refresh']()}
+			{m['dashboard.Refresh']()}{#if refreshing}…{/if}
 		</button>
 	</div>
 

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -497,7 +497,7 @@
 										<span class="text-text-muted ml-1">({result.rtt_ms}{m['scanner.ms']()})</span>
 									{/if}
 								</td>
-								<td class="px-3 py-3 text-sm text-text-muted max-w-[200px] truncate">
+								<td class="px-3 py-3 text-sm text-text-muted max-w-[200px] truncate" title={Array.isArray(services) ? services.map((s) => s.service).join(', ') : undefined}>
 									{Array.isArray(services) ? services.map((s) => s.service).join(', ') || '-' : '-'}
 								</td>
 								<td class="px-3 py-3">
@@ -708,7 +708,7 @@
 								<td class="px-4 py-3 text-sm text-text-muted">{run.updated_hosts}</td>
 								<td class="px-4 py-3 text-xs text-text-muted whitespace-nowrap">{formatTime(run.started_at)}</td>
 								<td class="px-4 py-3 text-xs text-text-muted whitespace-nowrap">{formatTime(run.finished_at)}</td>
-								<td class="px-4 py-3 text-xs text-error max-w-[200px] truncate">
+								<td class="px-4 py-3 text-xs text-error max-w-[200px] truncate" title={run.error_message || ''}>
 									{run.error_message || '-'}
 								</td>
 							</tr>

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -134,7 +134,7 @@
 				const detected = new Set<string>();
 
 				// Device type
-				if (host.inferred_type && DEVICE_TYPES.includes(host.inferred_type as any)) {
+				if (host.inferred_type && (DEVICE_TYPES as readonly string[]).includes(host.inferred_type)) {
 					deviceTypes[host.ip] = host.inferred_type;
 					detected.add('type');
 				} else {


### PR DESCRIPTION
## Summary

Eight small correctness / type-safety / a11y fixes from issue #70, plus a note on what's deferred.

## Changes

### `devices/+page.svelte`
- **batch-status dropdown**: added `fixed inset-0` backdrop (outside-click close), `aria-expanded`/`aria-haspopup`, `role="menu"`/`role="menuitem"` — previously a bare absolute-positioned div, mouse-only (no Esc, no outside-click). Mirrors the Export-dropdown pattern 70 lines above (which already had the backdrop).
- **Esc closes dropdowns**: a window `keydown` listener (registered via `$effect`) closes whichever of Export / batch-status is open. The global `+layout.svelte` Escape handler only targets `.modal-backdrop`, so these click-toggle menus need their own.
- **CSV import IP validation**: malformed IP rows in the preview are flagged red, plus a "N rows invalid" summary. Reuses a new exported `isValidIP()` helper in `validation.ts` (wraps the existing `ipv4OctetPattern` + `isValidOctets`). `parseCsv` is unchanged — keeps the rows visible so the user sees what's wrong (the backend rejects them on submit anyway).
- **drop `as Device` cast**: `openDelete` + `deleteTarget` typed as `Pick<Device, 'id' | 'name'>` (the only fields the delete dialog actually uses). The `find() ?? { id, name } as Device` fallback no longer needs a cast.

### `devices/detail/[id]/+page.svelte`
- **`:id` NaN guard**: a non-numeric `:id` (e.g. `/devices/detail/abc`) now renders a friendly EmptyState + "back to device list" button, instead of firing `/devices/NaN` requests that 404. `fetchDevice` short-circuits when `invalidId`.

### `devices/scan-results/+page.svelte`
- **runs table `error_message` + services cells**: added `title=` attribute so the truncated text is readable on hover (was `max-w truncate` with no title).

### `devices/+layout.svelte`
- **fix `children` type**: `() => void` → `Snippet` (the `{@render children()}` call needs a `Snippet`, not a function — the old type was wrong but passed typecheck by accident).

### `devices/scanner/+page.svelte`
- **drop `as any` cast** on `DEVICE_TYPES.includes(inferred_type)`: use `(DEVICE_TYPES as readonly string[]).includes()` instead — type-safe, same behavior.

### `devices/discovery/+page.svelte`
- **Refresh feedback**: the Refresh button now disables + shows `…` while a refresh is in flight (was silent on subsequent refreshes — `loading` only gated the first fetch).
- **Poll backoff**: switched from `setInterval(30s)` to `setTimeout` recursion with exponential backoff on consecutive errors (30s → 60s → 120s cap). A dead backend isn't hammered every 30s; resets to 30s on success.

### i18n
- New keys `devices.Invalid ID` + `devices.Invalid ID Desc` (en + zh).

## Deferred (separate PRs)
These three items from the issue are **not** in this PR — each warrants its own design + testing:
1. **`createDefaultHeartbeatConfig` create-modal** (detail page) — needs to reuse the existing edit-config form in create-mode; medium effort.
2. **scanner results table pagination/virtualization** — needs design + `/22`-scale stress testing; medium effort. (The issue's acceptance criterion "scanner 大范围不卡" is not covered here.)
3. **`$app/stores` → `$app/state` migration** — touches every file using `$page`; it's a modernization sweep, not a bug fix, so it's tracked separately.

## Already fixed (verified, not redone)
- `/networks` error handling in `devices/+page.svelte` — already fixed by #64 (`networksError` state exists).
- Export-dropdown backdrop — already had the `fixed inset-0` overlay; this PR only adds Esc to it.

## Verification (deployed to 192.168.63.101 + browser-tested)

| Scenario | Result |
|---|---|
| batch-status dropdown opens (expanded=true, 3 menuitems) + Esc closes + overlay-click closes | ✅ |
| discovery Refresh: button disables + shows `…` while refreshing, resets after | ✅ |
| `isValidIP` logic (8/8 unit cases: valid IPs, bad octets, non-numeric, too-few-octets, boundaries, whitespace) | ✅ |
| `npm run build` | ✅ |
| `npm test` | ✅ 153/153 |
| type-only fixes (`children: Snippet`, `as any` removal) compile clean | ✅ |

Note: two browser-test scenarios (CSV-preview red-flag rendering, invalid-id EmptyState rendering) couldn't be exercised end-to-end because `agent-browser`'s synthesized file-upload doesn't trigger Svelte's `onchange` handler, and synthesized `<a>` clicks don't re-render SvelteKit's client router on unmatched paths. Both are covered by: logic unit-tested (`isValidIP` 8/8), markup compiles, the strings are present in the deployed bundle, and the valid-detail-page route still renders correctly (regression check).

Closes #70
