### PR TITLE
fix(web): lib/components P2 batch — timeouts, types, a11y, empty states (#71)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -263,6 +263,7 @@
 	},
 	"dashboard": {
 		"Dashboard": "Dashboard",
+		"Drag to Reorder": "Drag to reorder (or focus + ↑/↓ to move)",
 		"Attention Title": "Needs attention",
 		"Attention Offline": "{count} offline",
 		"Attention New": "{count} new in last scan",
@@ -356,6 +357,7 @@
 		"Retry": "Retry",
 		"Refresh": "Refresh",
 		"No Data": "No data",
+		"Pagination": "Pagination",
 		"Copy": "Copy",
 		"Copied": "Copied",
 		"Test": "Test",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -263,6 +263,7 @@
 	},
 	"dashboard": {
 		"Dashboard": "仪表盘",
+		"Drag to Reorder": "拖动重新排序（或聚焦后用 ↑/↓ 移动）",
 		"Attention Title": "需要关注",
 		"Attention Offline": "{count} 台离线",
 		"Attention New": "最近扫描新增 {count} 台",
@@ -356,6 +357,7 @@
 		"Retry": "重试",
 		"Refresh": "刷新",
 		"No Data": "暂无数据",
+		"Pagination": "分页",
 		"Copy": "复制",
 		"Copied": "已复制",
 		"Test": "测试",

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -104,9 +104,13 @@ export const api = {
 		const csrfToken = getCSRFToken();
 		const headers: Record<string, string> = {};
 		if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
+		// 60s timeout — more generous than request()'s 30s since downloads
+		// (CSV/JSON exports, file downloads) can be larger. Without this a hung
+		// or very slow response would leave the fetch pending forever (#71).
 		const res = await fetch(`${API_BASE}${path}`, {
 			credentials: 'include',
-			headers
+			headers,
+			signal: AbortSignal.timeout(60000)
 		});
 		if (res.status === 401) {
 			auth.logout();

--- a/web/src/lib/components/Chart.svelte
+++ b/web/src/lib/components/Chart.svelte
@@ -12,6 +12,7 @@
 	import { echarts, type EChartsOption } from '$lib/charts/echarts';
 	import { onMount } from 'svelte';
 	import { m } from '$lib/i18n-paraglide';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 
 	let {
 		option = $bindable(),
@@ -33,6 +34,20 @@
 	let container: HTMLDivElement | undefined = $state();
 	let instance: ReturnType<typeof echarts.init> | undefined = $state();
 	let chartError = $state(false);
+
+	// Detect an empty dataset so we can show an EmptyState instead of a blank
+	// canvas. An option is "empty" when it has no series, or every series has an
+	// empty/nonexistent data array. A blank canvas with no explanation was
+	// confusing when a query returned no rows (#71).
+	let isEmpty = $derived.by(() => {
+		const series = option?.series;
+		if (!series) return true;
+		const arr = Array.isArray(series) ? series : [series];
+		if (arr.length === 0) return true;
+		return arr.every(
+			(s) => !s || (s as { data?: unknown }).data == null || ((s as { data?: unknown[] }).data?.length ?? 0) === 0
+		);
+	});
 
 	function initChart() {
 		if (!container) return;
@@ -106,6 +121,10 @@
 {#if chartError}
 	<div class="flex items-center justify-center rounded-lg border border-error/30 bg-error/10 text-error text-sm" style="width: {width}; height: {height};">
 		<span>{m['common.Chart Unavailable']()}</span>
+	</div>
+{:else if isEmpty}
+	<div class="flex items-center justify-center" style="width: {width}; height: {height};">
+		<EmptyState title={m['common.No Data']()} />
 	</div>
 {:else}
 	<div bind:this={container} class="echarts-container" style="width: {width}; height: {height};"></div>

--- a/web/src/lib/components/DashboardWidget.svelte
+++ b/web/src/lib/components/DashboardWidget.svelte
@@ -11,26 +11,23 @@
 <script lang="ts">
 	import Chart from './Chart.svelte';
 	import type { EChartsOption } from '$lib/charts/echarts';
+	import { m } from '$lib/i18n-paraglide';
 	import { GripVertical, Pencil, Trash2 } from '@lucide/svelte';
+	import type { DashboardWidgetConfig } from '$lib/types';
 
-	interface WidgetState {
-		id: string;
-		name: string;
-		type: string;
-		data_source: string;
-		query: string;
-		refresh_interval: number;
-		position: number;
+	// Extends the shared API shape with runtime-only UI state (the ECharts
+	// option + a loading flag). Was a full re-declaration of the 10 API fields
+	// — deduped against the canonical type (#71).
+	interface WidgetState extends DashboardWidgetConfig {
 		chartOption: EChartsOption;
 		loading?: boolean;
-		created_at: string;
-		updated_at: string;
 	}
 
 	let {
 		widget,
 		onEdit,
 		onRemove,
+		onMove,
 		ondragstart,
 		ondragover,
 		ondrop
@@ -38,6 +35,7 @@
 		widget: WidgetState;
 		onEdit: (id: string) => void;
 		onRemove: (id: string) => void;
+		onMove: (id: string, direction: 'up' | 'down') => void;
 		ondragstart: (e: DragEvent, id: string) => void;
 		ondragover: (e: DragEvent) => void;
 		ondrop: (e: DragEvent, id: string) => void;
@@ -77,7 +75,26 @@
 	ondrop={handleDrop}
 >
 	<div class="widget-header">
-		<div class="widget-drag-handle" title="Drag to reorder">
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+		<div
+			class="widget-drag-handle"
+			role="button"
+			tabindex="0"
+			aria-label={m['dashboard.Drag to Reorder']()}
+			title={m['dashboard.Drag to Reorder']()}
+			onkeydown={(e) => {
+				// ArrowUp/ArrowDown move the widget one slot; mirrors the drag swap
+				// so keyboard users can reorder without a pointer (#71).
+				if (e.key === 'ArrowUp') {
+					e.preventDefault();
+					onMove(widget.id, 'up');
+				} else if (e.key === 'ArrowDown') {
+					e.preventDefault();
+					onMove(widget.id, 'down');
+				}
+			}}
+		>
 			<GripVertical class="w-[14px] h-[14px]" />
 		</div>
 		<h3 class="widget-title">{widget.name}</h3>

--- a/web/src/lib/components/HeartbeatExpandableRow.svelte
+++ b/web/src/lib/components/HeartbeatExpandableRow.svelte
@@ -17,27 +17,7 @@
 	import type { EChartsOption } from '$lib/charts/echarts';
 	import { m } from '$lib/i18n-paraglide';
 	import { LoaderCircle, HeartPulse } from '@lucide/svelte';
-
-	interface HeartbeatConfig {
-		id: number;
-		device_id: number;
-		method: string;
-		target: string;
-		interval: number;
-		timeout: number;
-		enabled: boolean;
-		snmp_community: string;
-		snmp_oid: string;
-		expected_status: number;
-	}
-
-	interface HeartbeatResult {
-		id: number;
-		config_id: number;
-		status: string;
-		latency_ms: number;
-		checked_at: string;
-	}
+	import type { HeartbeatConfig, HeartbeatResult, ProbeResultStatus } from '$lib/types';
 
 	let {
 		deviceId,
@@ -146,11 +126,18 @@
 	}
 
 	function latestForConfig(configId: number): HeartbeatResult | null {
-		const r = results.find((r) => r.config_id === configId);
-		return r ?? null;
+		// Explicitly sort by checked_at descending rather than relying on the API
+		// returning results newest-first — find() returned the first array
+		// element, which was only "latest" by implicit ordering assumption (#71).
+		// RFC3339 strings sort lexicographically = chronologically.
+		return (
+			results
+				.filter((r) => r.config_id === configId)
+				.sort((a, b) => b.checked_at.localeCompare(a.checked_at))[0] ?? null
+		);
 	}
 
-	function statusColor(status: string): string {
+	function statusColor(status: ProbeResultStatus): string {
 		if (status === 'success') return 'text-success';
 		if (status === 'fail') return 'text-error';
 		return 'text-muted';

--- a/web/src/lib/components/Pagination.svelte
+++ b/web/src/lib/components/Pagination.svelte
@@ -68,7 +68,7 @@
 </script>
 
 {#if showBar}
-	<div class="flex flex-wrap items-center justify-between gap-3 px-1 py-2">
+	<nav class="flex flex-wrap items-center justify-between gap-3 px-1 py-2" aria-label={m['common.Pagination']()}>
 		<!-- Range display + page-size selector -->
 		<div class="flex items-center gap-3">
 			<span class="text-xs text-muted whitespace-nowrap tabular-nums">
@@ -146,5 +146,5 @@
 				</div>
 			{/if}
 		</div>
-	</div>
+	</nav>
 {/if}

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 	import { Sun, Moon } from '@lucide/svelte';
+	import { browser } from '$app/environment';
 
 	function getInitialDark(): boolean {
 		const stored = localStorage.getItem('theme');
@@ -19,7 +20,10 @@
 		return !window.matchMedia('(prefers-color-scheme: light)').matches;
 	}
 
-	let dark = $state(getInitialDark());
+	// Guard the localStorage/matchMedia access for SSR/prerender — those APIs
+	// only exist in the browser. Without this, server-side rendering throws
+	// "localStorage is not defined" at component init (#71).
+	let dark = $state(browser ? getInitialDark() : false);
 
 	function toggle() {
 		dark = !dark;

--- a/web/src/lib/components/WidgetPicker.svelte
+++ b/web/src/lib/components/WidgetPicker.svelte
@@ -15,18 +15,7 @@
 	import { addToast } from '$lib/stores/toast';
 	import { api } from '$lib/api/client';
 	import { getErrorMessage } from '$lib/utils/error';
-
-	interface DashboardConfig {
-		id: string;
-		name: string;
-		type: string;
-		data_source: string;
-		query: string;
-		refresh_interval: number;
-		position: number;
-		created_at: string;
-		updated_at: string;
-	}
+	import type { DashboardWidgetConfig } from '$lib/types';
 
 	let {
 		open = $bindable(false),
@@ -34,7 +23,7 @@
 		onSaved
 	}: {
 		open?: boolean;
-		editWidget?: DashboardConfig | null;
+		editWidget?: DashboardWidgetConfig | null;
 		onSaved: () => void;
 	} = $props();
 

--- a/web/src/lib/components/scanner/LabelEditor.svelte
+++ b/web/src/lib/components/scanner/LabelEditor.svelte
@@ -11,6 +11,8 @@
 <script lang="ts">
 	import { m } from '$lib/i18n-paraglide';
 	import { X, Plus, LoaderCircle } from '@lucide/svelte';
+	import { addToast } from '$lib/stores/toast';
+	import { getErrorMessage } from '$lib/utils/error';
 
 	let {
 		labels = {},
@@ -22,7 +24,7 @@
 		labels: Record<string, string>;
 		staticLabels?: Record<string, string>;
 		dynamicLabels?: Record<string, string>;
-		onSave: (labels: Record<string, string>) => void;
+		onSave: (labels: Record<string, string>) => Promise<void> | void;
 		readonly?: boolean;
 	} = $props();
 
@@ -102,6 +104,10 @@
 		try {
 			await onSave(result);
 			hasChanges = false;
+		} catch (err: unknown) {
+			// Without this catch a rejecting onSave bubbled up uncaught — no
+			// toast, no feedback, just a console error. Surface it to the user.
+			addToast('error', getErrorMessage(err));
 		} finally {
 			saving = false;
 		}

--- a/web/src/lib/components/scanner/PipelineConfigEditor.svelte
+++ b/web/src/lib/components/scanner/PipelineConfigEditor.svelte
@@ -88,7 +88,7 @@
 
 	// --- Stages definition ---
 	interface StageDef {
-		key: string;
+		key: keyof PipelineConfig;
 		nameKey: string;
 		descKey: string;
 		icon: string;
@@ -103,12 +103,12 @@
 		{ key: 'node_exporter', nameKey: 'scanner.pipeline.stage_node_exporter', descKey: 'scanner.pipeline.stage_node_exporter_desc', icon: 'node' }
 	];
 
-	function isStageEnabled(key: string): boolean {
-		return (config as any)[key]?.enabled ?? false;
+	function isStageEnabled(key: keyof PipelineConfig): boolean {
+		return config[key]?.enabled ?? false;
 	}
 
-	function toggleStage(key: string) {
-		const stage = (config as any)[key];
+	function toggleStage(key: keyof PipelineConfig) {
+		const stage = config[key];
 		if (stage) {
 			stage.enabled = !stage.enabled;
 		}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -437,6 +437,25 @@ export interface PipelineConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Dashboard Widget (Prometheus-backed dashboard cards). The API shape is shared
+// across WidgetPicker (create/edit form), DashboardWidget (rendered card), and
+// the dashboard route's widget state. Defined once here to avoid the three-way
+// drift that existed when each file declared its own copy (#71).
+// ---------------------------------------------------------------------------
+
+export interface DashboardWidgetConfig {
+	id: string;
+	name: string;
+	type: string;
+	data_source: string;
+	query: string;
+	refresh_interval: number;
+	position: number;
+	created_at: string;
+	updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
 // Scanner Task
 // ---------------------------------------------------------------------------
 

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -26,6 +26,7 @@
 	import { scanRunStatusBadge } from '$lib/utils/badges';
 	import { auth } from '$lib/stores/auth';
 	import type { EChartsOption } from '$lib/charts/echarts';
+	import type { DashboardWidgetConfig } from '$lib/types';
 
 	interface DeviceStats {
 		by_status: { online: number; offline: number; unknown: number };
@@ -73,35 +74,19 @@
 		generated: string;
 	}
 
-	interface DashboardConfig {
-		id: string;
-		name: string;
-		type: string;
-		data_source: string;
-		query: string;
-		refresh_interval: number;
-		position: number;
-		created_at: string;
-		updated_at: string;
-	}
+	// DashboardConfig is the shared API shape (from $lib/types). The route
+	// keeps a local alias so the DashboardConfigsResponse + editingWidget types
+	// read naturally, and WidgetState extends it with runtime UI fields (#71).
+	type DashboardConfig = DashboardWidgetConfig;
 
 	interface DashboardConfigsResponse {
 		configs: DashboardConfig[];
 		total: number;
 	}
 
-	interface WidgetState {
-		id: string;
-		name: string;
-		type: string;
-		data_source: string;
-		query: string;
-		refresh_interval: number;
-		position: number;
+	interface WidgetState extends DashboardConfig {
 		chartOption: EChartsOption;
 		loading: boolean;
-		created_at: string;
-		updated_at: string;
 	}
 
 	// loading is a writable store (not $state). A bare {#if loading} backed by
@@ -656,6 +641,33 @@
 		draggedId = null;
 	}
 
+	// Keyboard reorder: move a widget up/down by one slot (mirrors the drag
+	// swap). Wired to the drag handle's arrow-key handler so keyboard users can
+	// reorder without dragging (#71).
+	async function handleMoveWidget(id: string, direction: 'up' | 'down') {
+		const fromIdx = widgets.findIndex((w) => w.id === id);
+		if (fromIdx < 0) return;
+		const toIdx = direction === 'up' ? fromIdx - 1 : fromIdx + 1;
+		if (toIdx < 0 || toIdx >= widgets.length) return;
+
+		const updated = [...widgets];
+		const temp = updated[fromIdx];
+		updated[fromIdx] = updated[toIdx];
+		updated[toIdx] = temp;
+		widgets = updated.map((w, i) => ({ ...w, position: i }));
+
+		if (isAdmin) {
+			try {
+				await Promise.all(
+					widgets.map((w) => api.put(`/dashboard/configs/${w.id}`, { position: w.position }))
+				);
+			} catch (err: unknown) {
+				addToast('error', getErrorMessage(err));
+				await loadAll();
+			}
+		}
+	}
+
 	// ── Widget actions ──
 
 	function handleAddWidget() {
@@ -835,6 +847,7 @@
 						{widget}
 						onEdit={handleEditWidget}
 						onRemove={handleRemoveWidget}
+						onMove={handleMoveWidget}
 						ondragstart={handleDragStart}
 						ondragover={handleDragOver}
 						ondrop={handleDrop}


### PR DESCRIPTION
## Summary

Resolves #71. Nine subitems across lib/components + the dashboard route.

## Changes

**True bugs (type safety / hangs / errors / SSR):**
- `client.ts`: `download()` now uses `AbortSignal.timeout(60s)` — was unbounded, a hung/large export could pend forever (`request()` already had 30s; `upload` already had `xhr.timeout`, so only download needed it)
- `scanner/PipelineConfigEditor.svelte`: dropped `(config as any)[key]` for `key: keyof PipelineConfig` (`StageDef.key` tightened too)
- `scanner/LabelEditor.svelte`: `handleSave` now catches a rejecting `onSave` and toasts (was `try/finally` no catch — errors bubbled uncaught); `onSave` type widened to `Promise<void> | void`
- `ThemeToggle.svelte`: guarded `localStorage`/`matchMedia` with a `browser` check from `\$app/environment` — SSR/prerender would throw without it
- `HeartbeatExpandableRow.svelte`: dropped local type re-definitions (which had widened `method`/`status` to `string`) in favor of the canonical `\$lib/types`; `statusColor()` tightened to `ProbeResultStatus`; `latestForConfig()` now sorts by `checked_at` desc instead of relying on API ordering
- `Chart.svelte`: empty series now renders an `EmptyState` instead of a blank canvas

**Nice-to-haves (a11y / consistency):**
- `Pagination.svelte`: outer `<div>` → `<nav aria-label=\"Pagination\">` (new `common.Pagination` i18n key)
- `DashboardWidgetConfig` type extracted to `\$lib/types`; `DashboardWidget`, `WidgetPicker`, and the dashboard route all import it (was 3 copies)
- `DashboardWidget.svelte`: drag handle now keyboard-focusable (`tabindex=0`, `role=button`, `aria-label`) with ArrowUp/ArrowDown reorder via a new `onMove` prop

## Deliberately left

- `WidgetPicker`'s hardcoded `data_source='prometheus'` — single-backend app; a selector would expose half-finished multi-backend UI.
- `auth.ts`'s local `User` type — deduping against `types.User` would require also narrowing the settings page's `Profile.role` and dropping its `as any` cast, a larger refactor deferred to avoid scope creep.

## Verification

- [x] `npm test` (153 pass) + `npm run build` — green (no type-narrowing cascades)
- [x] Deployed to 192.168.63.101 + browser-verified (agent-browser):
  - ThemeToggle: dashboard loads with **no console errors** (SSR guard works)
  - Pagination: DOM check confirms `<nav aria-label=\"分页\">`
  - No JS errors during the session
  - The type-level fixes (download timeout, `as any`, handleSave catch, HeartbeatExpandableRow types, widget-config dedup) are build/type-verified

🤖 Generated with [ZCode](https://z.ai/code)