### PR TITLE
fix(i18n): localize layout + component a11y labels (#62)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -17,7 +17,11 @@
 		"Topology": "Topology",
 		"Group Core": "Core",
 		"Group Library": "Library",
-		"Group Admin": "Administration"
+		"Group Admin": "Administration",
+		"Brand Subtitle": "Device Management",
+		"Brand Logo Alt": "MiBee logo",
+		"Skip to Content": "Skip to content",
+		"Toggle Sidebar": "Toggle sidebar"
 	},
 	"auth": {
 		"Username": "Username",
@@ -367,7 +371,14 @@
 		"Chart Unavailable": "Chart unavailable",
 		"Clear Search": "Clear search",
 		"On": "on",
-		"Off": "off"
+		"Off": "off",
+		"Switch to Light Theme": "Switch to light theme",
+		"Switch to Dark Theme": "Switch to dark theme",
+		"Toggle Theme": "Toggle theme",
+		"Switch Language": "Switch language",
+		"Close Dialog": "Close dialog",
+		"Edit Widget": "Edit widget",
+		"Remove Widget": "Remove widget"
 	},
 	"scanner": {
 		"Scanner": "Network Scanner",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -17,7 +17,11 @@
 		"Topology": "拓扑",
 		"Group Core": "核心",
 		"Group Library": "资料库",
-		"Group Admin": "管理"
+		"Group Admin": "管理",
+		"Brand Subtitle": "设备管理",
+		"Brand Logo Alt": "MiBee 图标",
+		"Skip to Content": "跳到正文",
+		"Toggle Sidebar": "切换侧边栏"
 	},
 	"auth": {
 		"Username": "用户名",
@@ -367,7 +371,14 @@
 		"Chart Unavailable": "图表不可用",
 		"Clear Search": "清除搜索",
 		"On": "开",
-		"Off": "关"
+		"Off": "关",
+		"Switch to Light Theme": "切换到浅色主题",
+		"Switch to Dark Theme": "切换到深色主题",
+		"Toggle Theme": "切换主题",
+		"Switch Language": "切换语言",
+		"Close Dialog": "关闭对话框",
+		"Edit Widget": "编辑组件",
+		"Remove Widget": "移除组件"
 	},
 	"scanner": {
 		"Scanner": "网络扫描器",

--- a/web/src/lib/components/DashboardWidget.svelte
+++ b/web/src/lib/components/DashboardWidget.svelte
@@ -99,10 +99,10 @@
 		</div>
 		<h3 class="widget-title">{widget.name}</h3>
 		<div class="widget-actions">
-			<button class="widget-action-btn" onclick={() => onEdit(widget.id)} title="Edit widget" aria-label="Edit widget">
+			<button class="widget-action-btn" onclick={() => onEdit(widget.id)} title={m['common.Edit Widget']()} aria-label={m['common.Edit Widget']()}>
 				<Pencil class="w-[14px] h-[14px]" />
 			</button>
-			<button class="widget-action-btn widget-action-danger" onclick={() => onRemove(widget.id)} title="Remove widget" aria-label="Remove widget">
+			<button class="widget-action-btn widget-action-danger" onclick={() => onRemove(widget.id)} title={m['common.Remove Widget']()} aria-label={m['common.Remove Widget']()}>
 				<Trash2 class="w-[14px] h-[14px]" />
 			</button>
 		</div>

--- a/web/src/lib/components/LanguageSwitcher.svelte
+++ b/web/src/lib/components/LanguageSwitcher.svelte
@@ -9,7 +9,7 @@
 -->
 
 <script lang="ts">
-	import { getLocale, setLocale } from '$lib/i18n-paraglide';
+	import { getLocale, setLocale, m } from '$lib/i18n-paraglide';
 
 	let lang = $state(getLocale());
 
@@ -24,7 +24,7 @@
 	onchange={handleChange}
 	class="bg-transparent border border-border rounded-md px-2 py-1.5 text-xs text-muted
 		focus:outline-none focus:border-primary transition-colors cursor-pointer"
-	aria-label="Switch language"
+		aria-label={m['common.Switch Language']()}
 >
 	<option value="zh" class="bg-surface text-text">中文</option>
 	<option value="en" class="bg-surface text-text">EN</option>

--- a/web/src/lib/components/Modal.svelte
+++ b/web/src/lib/components/Modal.svelte
@@ -174,7 +174,7 @@
 				<button
 					class="modal-close"
 					onclick={close}
-					aria-label="Close dialog"
+					aria-label={m['common.Close Dialog']()}
 				>
 					<X class="w-5 h-5" />
 				</button>

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
 	import { Sun, Moon } from '@lucide/svelte';
 	import { browser } from '$app/environment';
+	import { m } from '$lib/i18n-paraglide';
 
 	function getInitialDark(): boolean {
 		const stored = localStorage.getItem('theme');
@@ -36,8 +37,8 @@
 <button
 	onclick={toggle}
 	class="btn-icon"
-	title={dark ? 'Switch to light theme' : 'Switch to dark theme'}
-	aria-label="Toggle theme"
+		title={dark ? m['common.Switch to Light Theme']() : m['common.Switch to Dark Theme']()}
+		aria-label={m['common.Toggle Theme']()}
 >
 	{#if dark}
 		<Sun class="w-[18px] h-[18px]" />

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -161,7 +161,7 @@
 		focus:px-4 focus:py-2 focus:bg-primary focus:text-text-inverse focus:rounded-lg
 		focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary"
 >
-	Skip to content
+	{m['navigation.Skip to Content']()}
 </a>
 
 <div class="flex h-screen overflow-hidden relative">
@@ -170,7 +170,7 @@
 	<button
 		onclick={() => sidebarOpen = !sidebarOpen}
 		class="btn-icon fixed top-4 left-4 z-50 md:hidden bg-surface border border-border"
-		aria-label="Toggle sidebar"
+		aria-label={m['navigation.Toggle Sidebar']()}
 	>
 		{#if sidebarOpen}
 			<X class="w-5 h-5" />
@@ -200,10 +200,10 @@
 	>
 		<div class="p-4 border-b border-border">
 			<div class="flex items-center gap-3">
-				<img src={logo} alt="MiBee" class="w-9 h-9 shrink-0" />
+				<img src={logo} alt={m['navigation.Brand Logo Alt']()} class="w-9 h-9 shrink-0" />
 				<div>
 					<h1 class="text-xl font-bold text-primary tracking-tight leading-tight">MiBee Steward</h1>
-					<p class="text-xs text-muted">Device Management</p>
+					<p class="text-xs text-muted">{m['navigation.Brand Subtitle']()}</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Resolves #62.

## Problem
5 layout/component files had hardcoded English in user-visible attributes (aria-label / title / alt / subtitle), bypassing paraglide i18n. Screen readers and Chinese users saw English leaks in core chrome (sidebar, theme toggle, language switcher, modal close, widget actions).

## Changes
| File | Hardcoded → localized |
|------|----------------------|
| `+layout.svelte` | "Skip to content" link, "Toggle sidebar" aria-label, "MiBee" alt, "Device Management" subtitle |
| `ThemeToggle.svelte` | title + aria-label |
| `LanguageSwitcher.svelte` | aria-label |
| `Modal.svelte` | close button aria-label |
| `DashboardWidget.svelte` | edit/remove button title + aria-label (the drag handle was already localized in #71) |

## i18n keys added
- `navigation.{Brand Subtitle, Brand Logo Alt, Skip to Content, Toggle Sidebar}`
- `common.{Switch to Light/Dark Theme, Toggle Theme, Switch Language, Close Dialog, Edit/Remove Widget}`

Both `en.json` and `zh.json` updated; `npm run paraglide:gen` run.

## Verification
Deployed to 192.168.63.101, browser-tested in **both** locales:

| Element | zh | en |
|---------|----|----|
| Skip-to-content link | 跳到正文 ✅ | Skip to content ✅ |
| Brand subtitle | 设备管理 ✅ | Device Management ✅ |
| Sidebar toggle (mobile) | 切换侧边栏 ✅ | ✅ |
| Theme toggle | 切换主题 ✅ | Toggle theme ✅ |
| Language switcher | 切换语言 ✅ | Switch language ✅ |
| Modal close button | 关闭对话框 ✅ | Close dialog ✅ |
| Widget edit/remove | build + aria verified | ✅ |

- `npm run build` clean (no new svelte-check errors)
- `npm test` 153/153 pass
- No console errors after navigation

## Out of scope
- Per-page零散文案 (placeholders, toasts, table headers) → #63
- DeviceTopologyView tooltip → #61
- ChangeDiff component → #60