### PR TITLE
fix(i18n): localize DeviceTopologyView tooltip labels (#61)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -865,7 +865,13 @@
 		"Online": "online",
 		"No Subnet": "Unknown subnet",
 		"Disconnected": "disconnected",
-		"Downstream": "Downstream"
+		"Downstream": "Downstream",
+		"Tooltip Via": "Via: {proto} · port {port}",
+		"Tooltip IP": "IP",
+		"Tooltip MAC": "MAC",
+		"Tooltip Type": "Type",
+		"Tooltip Status": "Status",
+		"Tooltip Downstream": "Downstream: {count} devices"
 	},
 	"certificates": {
 		"Title": "TLS Certificates",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -865,7 +865,13 @@
 		"Online": "在线",
 		"No Subnet": "未知子网",
 		"Disconnected": "未连接",
-		"Downstream": "下挂设备"
+		"Downstream": "下挂设备",
+		"Tooltip Via": "经由：{proto} · 端口 {port}",
+		"Tooltip IP": "IP",
+		"Tooltip MAC": "MAC",
+		"Tooltip Type": "类型",
+		"Tooltip Status": "状态",
+		"Tooltip Downstream": "下挂：{count} 台设备"
 	},
 	"certificates": {
 		"Title": "TLS 证书",

--- a/web/src/lib/components/DeviceTopologyView.svelte
+++ b/web/src/lib/components/DeviceTopologyView.svelte
@@ -199,10 +199,20 @@
 						if (!v || !v.value) return '';
 						const n = v.value;
 						const gw = v.isRoot ? ` ⭐ ${escapeHtml(m['topology.Gateway']())}` : '';
+						// Tooltip labels are localized; dynamic values stay escapeHtml-wrapped
+						// (XSS-safe even though this is an {@html}-equivalent HTML string).
+						const ipLabel = escapeHtml(m['topology.Tooltip IP']());
+						const macLabel = escapeHtml(m['topology.Tooltip MAC']());
+						const typeLabelStr = escapeHtml(m['topology.Tooltip Type']());
+						const statusLabel = escapeHtml(m['topology.Tooltip Status']());
 						const portInfo = v.parentPort
-							? `<br/>Via: ${escapeHtml(v.edgeProtocol ?? '')}${v.parentPort ? ' · port ' + escapeHtml(v.parentPort) : ''}`
+							? '<br/>' + escapeHtml(m['topology.Tooltip Via']({
+								proto: String(v.edgeProtocol ?? ''),
+								port: String(v.parentPort)
+							}))
 							: '';
-						return `<b>${escapeHtml(n.name)}</b>${gw}<br/>IP: ${escapeHtml(n.ip_address || '-')}<br/>MAC: ${escapeHtml(n.mac_address || '-')}<br/>Type: ${escapeHtml(typeLabel(nodeCategory(n)))}<br/>Status: ${escapeHtml(n.status || '-')}${portInfo}<br/>Downstream: ${v.childCount} devices`;
+						const downstream = escapeHtml(m['topology.Tooltip Downstream']({ count: v.childCount }));
+						return `<b>${escapeHtml(n.name)}</b>${gw}<br/>${ipLabel}: ${escapeHtml(n.ip_address || '-')}<br/>${macLabel}: ${escapeHtml(n.mac_address || '-')}<br/>${typeLabelStr}: ${escapeHtml(typeLabel(nodeCategory(n)))}<br/>${statusLabel}: ${escapeHtml(n.status || '-')}${portInfo}<br/>${downstream}`;
 					}
 					return '';
 				}


### PR DESCRIPTION
Resolves #61.

## Problem
The ECharts tooltip on the topology tree graph hardcoded 8 English labels in its HTML formatter string: `Via:`, `port`, `IP:`, `MAC:`, `Type:`, `Status:`, `Downstream:`, `devices`. Chinese users hovering a node saw English even in zh locale.

## Changes
`DeviceTopologyView.svelte` tooltip formatter now reads localized labels via paraglide. Added 6 `topology.Tooltip *` keys (both locales), two of them parameterized:

| key | en | zh |
|-----|----|----|
| `Tooltip Via` | `Via: {proto} · port {port}` | `经由：{proto} · 端口 {port}` |
| `Tooltip Downstream` | `Downstream: {count} devices` | `下挂：{count} 台设备` |
| `Tooltip IP` / `MAC` | IP / MAC | IP / MAC *(technical abbreviations, kept as-is)* |
| `Tooltip Type` | Type | 类型 |
| `Tooltip Status` | Status | 状态 |

Dynamic values (proto, port, device fields) stay `escapeHtml`-wrapped so the localized labels compose into the existing XSS-safe tooltip HTML string.

## Verification
Deployed to 192.168.63.101, zh + en locales. The ECharts tooltip renders into a canvas-attached zrender layer that doesn't respond to synthetic mouse events in headless Chrome (confirmed: trusted CDP `Input.dispatchMouseEvent` sweep across all node pixels produced no tooltip DOM). Since the tooltip formatter is a pure function of these i18n keys, I verified the actual rendered strings by invoking the deployed paraglide message functions in-page against the live language map:

```
zh: { via: "经由：LLDP · 端口 ge-0/0/1",
      downstream: "下挂：5 台设备",
      type: "类型", status: "状态", ip: "IP", mac: "MAC", gateway: "网关" }
en: { via: "Via: LLDP · port ge-0/0/1",
      downstream: "Downstream: 5 devices",
      type: "Type", status: "Status" }
```

- `npm run build` clean (paraglide keys are typed — proves keys exist + correct arity)
- `npm test` 153/153 pass
- All 6 keys confirmed in generated paraglide chunk

## Out of scope
- Per-page零散文案 → #63
- ChangeDiff component → #60