### PR TITLE
fix(i18n): localize ChangeDiff field labels, headers, empty states (#60)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -749,7 +749,27 @@
 		"No Changes Desc": "Device changes will appear here once scans detect additions, modifications, or losses.",
 		"SSE Disconnected": "Live updates disconnected",
 		"SSE Disconnected Desc": "Real-time updates paused — refresh to see the latest.",
-		"Diff Title": "Change Details"
+		"Diff Title": "Change Details",
+		"Diff Field": "Field",
+		"Diff Before": "Before",
+		"Diff After": "After",
+		"Diff No Field Changes": "No field-level differences recorded.",
+		"Diff No Snapshot": "No snapshot data.",
+		"Diff No Data": "No data available."
+	},
+	"changefields": {
+		"name": "Name",
+		"type": "Type",
+		"brand": "Brand",
+		"model": "Model",
+		"mac_address": "MAC",
+		"ip_address": "IP",
+		"status": "Status",
+		"open_ports": "Open Ports",
+		"detected_services": "Detected Services",
+		"prometheus_url": "Prometheus URL",
+		"node_exporter_url": "Node Exporter URL",
+		"scan_attributes": "Scan Attributes"
 	},
 	"agents": {
 		"Title": "Agent Management",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -749,7 +749,27 @@
 		"No Changes Desc": "扫描检测到设备新增、变更或离线时,事件将在此显示。",
 		"SSE Disconnected": "实时更新已断开",
 		"SSE Disconnected Desc": "实时更新已暂停——刷新以查看最新内容。",
-		"Diff Title": "变更详情"
+		"Diff Title": "变更详情",
+		"Diff Field": "字段",
+		"Diff Before": "原值",
+		"Diff After": "新值",
+		"Diff No Field Changes": "未记录字段级差异。",
+		"Diff No Snapshot": "无快照数据。",
+		"Diff No Data": "无可用数据。"
+	},
+	"changefields": {
+		"name": "名称",
+		"type": "类型",
+		"brand": "品牌",
+		"model": "型号",
+		"mac_address": "MAC",
+		"ip_address": "IP",
+		"status": "状态",
+		"open_ports": "开放端口",
+		"detected_services": "识别到的服务",
+		"prometheus_url": "Prometheus 地址",
+		"node_exporter_url": "Node Exporter 地址",
+		"scan_attributes": "扫描属性"
 	},
 	"agents": {
 		"Title": "采集器管理",

--- a/web/src/lib/components/ChangeDiff.svelte
+++ b/web/src/lib/components/ChangeDiff.svelte
@@ -22,6 +22,8 @@
 	 * pretty-printed for readability.
 	 */
 
+	import { m } from '$lib/i18n-paraglide';
+
 	interface Props {
 		changeType: string;
 		beforeData?: string;
@@ -80,24 +82,26 @@
 		return fmt(v).length > 40 || fmt(v).includes('\n');
 	}
 
-	// Friendly labels for the diff field keys (the DeviceSnapshot field names).
-	const fieldLabels: Record<string, string> = {
-		name: 'Name',
-		type: 'Type',
-		brand: 'Brand',
-		model: 'Model',
-		mac_address: 'MAC',
-		ip_address: 'IP',
-		status: 'Status',
-		open_ports: 'Open Ports',
-		detected_services: 'Detected Services',
-		prometheus_url: 'Prometheus URL',
-		node_exporter_url: 'Node Exporter URL',
-		scan_attributes: 'Scan Attributes'
-	};
-
+	// Friendly labels for the diff field keys (the DeviceSnapshot field names),
+	// backed by the changefields.* i18n section so they localize. Unknown keys
+	// fall back to the raw field name rather than disappearing. The map is
+	// rebuilt on each call so a locale switch reflects immediately.
 	function labelFor(key: string): string {
-		return fieldLabels[key] ?? key;
+		const labels: Record<string, string> = {
+			name: m['changefields.name'](),
+			type: m['changefields.type'](),
+			brand: m['changefields.brand'](),
+			model: m['changefields.model'](),
+			mac_address: m['changefields.mac_address'](),
+			ip_address: m['changefields.ip_address'](),
+			status: m['changefields.status'](),
+			open_ports: m['changefields.open_ports'](),
+			detected_services: m['changefields.detected_services'](),
+			prometheus_url: m['changefields.prometheus_url'](),
+			node_exporter_url: m['changefields.node_exporter_url'](),
+			scan_attributes: m['changefields.scan_attributes']()
+		};
+		return labels[key] ?? key;
 	}
 </script>
 
@@ -105,14 +109,14 @@
 	{#if diff}
 		<!-- device_changed: field-by-field old → new comparison -->
 		{#if Object.keys(diff).length === 0}
-			<p class="text-text-muted italic text-xs">No field-level differences recorded.</p>
+			<p class="text-text-muted italic text-xs">{m['changes.Diff No Field Changes']()}</p>
 		{:else}
 			<table class="w-full text-left border-collapse">
 				<thead>
 					<tr class="border-b border-border">
-						<th class="py-1.5 pr-3 text-xs font-medium text-text-muted uppercase tracking-wide w-1/4">Field</th>
-						<th class="py-1.5 pr-3 text-xs font-medium text-text-muted uppercase tracking-wide">Before</th>
-						<th class="py-1.5 text-xs font-medium text-text-muted uppercase tracking-wide">After</th>
+						<th class="py-1.5 pr-3 text-xs font-medium text-text-muted uppercase tracking-wide w-1/4">{m['changes.Diff Field']()}</th>
+						<th class="py-1.5 pr-3 text-xs font-medium text-text-muted uppercase tracking-wide">{m['changes.Diff Before']()}</th>
+						<th class="py-1.5 text-xs font-medium text-text-muted uppercase tracking-wide">{m['changes.Diff After']()}</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -145,7 +149,7 @@
 	{:else if snapshot}
 		<!-- device_added / device_lost: full snapshot property table -->
 		{#if Object.keys(snapshot).length === 0}
-			<p class="text-text-muted italic text-xs">No snapshot data.</p>
+			<p class="text-text-muted italic text-xs">{m['changes.Diff No Snapshot']()}</p>
 		{:else}
 			<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
 				{#each Object.entries(snapshot) as [field, value]}
@@ -161,6 +165,6 @@
 			</div>
 		{/if}
 	{:else}
-		<p class="text-text-muted italic text-xs">No data available.</p>
+		<p class="text-text-muted italic text-xs">{m['changes.Diff No Data']()}</p>
 	{/if}
 </div>


### PR DESCRIPTION
Resolves #60.

## Problem
`ChangeDiff.svelte` — rendered when expanding a change-log row on `/changes` — hardcoded ~15 English strings: a `fieldLabels` map (Name/Type/Brand/Model/MAC/IP/Status/Open Ports/Detected Services/Prometheus URL/Node Exporter URL/Scan Attributes), three table headers (Field/Before/After), and three empty-state messages. Chinese users expanding a diff saw English field names.

## Changes
- New `changefields.*` i18n section: the 12 device-field labels, in both locales.
- `changes.Diff {Field,Before,After,No Field Changes,No Snapshot,No Data}`: table headers + empty states.
- `labelFor()` now resolves via the typed paraglide functions (static map rebuilt per call so a locale switch reflects immediately); unknown field keys still fall back to the raw name.

| field | en | zh |
|-------|----|----|
| name | Name | 名称 |
| type / brand / model | Type / Brand / Model | 类型 / 品牌 / 型号 |
| mac_address / ip_address | MAC / IP | MAC / IP |
| status | Status | 状态 |
| open_ports | Open Ports | 开放端口 |
| detected_services | Detected Services | 识别到的服务 |
| prometheus_url | Prometheus URL | Prometheus 地址 |
| node_exporter_url | Node Exporter URL | Node Exporter 地址 |
| scan_attributes | Scan Attributes | 扫描属性 |

## Verification
Deployed to 192.168.63.101, expanded a `device_changed` row in **both** locales:

| | headers | field labels |
|-|---------|--------------|
| zh | 字段 / 原值 / 新值 | 名称 / 类型 / 品牌 / 型号 / MAC / IP / 状态 / 开放端口 / 识别到的服务 / Prometheus 地址 / Node Exporter 地址 / 扫描属性 ✅ |
| en | FIELD / BEFORE / AFTER | Name / Type / Brand / Model / MAC / IP / Status / Open Ports / Detected Services / Prometheus URL / Node Exporter URL ✅ |

- `npm run build` clean (svelte-check passes — type-safe static map)
- `npm test` 153/153 pass
- No console errors

## Out of scope
- discovery page → #59
- per-page零散文案 → #63