### PR TITLE
fix(i18n): localize discovery funnel labels + table headers (#59)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -850,7 +850,19 @@
 		"Recorded": "Recorded",
 		"Skipped Known": "Known (skipped)",
 		"Skipped Recent": "Suppressed (recent)",
-		"Identify Failed": "Identify failed"
+		"Identify Failed": "Identify failed",
+		"Funnel Events Received": "Events Received",
+		"Funnel Suppressed Recent": "Suppressed (recent)",
+		"Funnel Known Skipped": "Known (skipped)",
+		"Funnel Identify Triggered": "Identify Triggered",
+		"Funnel Identify Alive": "Identify Alive",
+		"Funnel Identify Dead": "Identify Dead",
+		"Funnel Devices Recorded": "Devices Recorded",
+		"Col IP": "IP",
+		"Col MAC": "MAC",
+		"Col Source": "Source",
+		"Col Outcome": "Outcome",
+		"Col Time": "Time"
 	},
 	"topology": {
 		"Title": "Network Topology",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -850,7 +850,19 @@
 		"Recorded": "已记录",
 		"Skipped Known": "已知（跳过）",
 		"Skipped Recent": "已抑制（近期）",
-		"Identify Failed": "识别失败"
+		"Identify Failed": "识别失败",
+		"Funnel Events Received": "收到事件",
+		"Funnel Suppressed Recent": "已抑制（近期）",
+		"Funnel Known Skipped": "已知（跳过）",
+		"Funnel Identify Triggered": "触发识别",
+		"Funnel Identify Alive": "识别存活",
+		"Funnel Identify Dead": "识别失败（离线）",
+		"Funnel Devices Recorded": "已记录设备",
+		"Col IP": "IP",
+		"Col MAC": "MAC",
+		"Col Source": "来源",
+		"Col Outcome": "结果",
+		"Col Time": "时间"
 	},
 	"topology": {
 		"Title": "网络拓扑",

--- a/web/src/routes/devices/discovery/+page.svelte
+++ b/web/src/routes/devices/discovery/+page.svelte
@@ -78,13 +78,13 @@
 
 	let stats = $derived(status?.stats ?? {});
 	let funnel = $derived([
-		{ label: 'Events Received', value: stats.EventsReceived ?? 0, cls: 'text-text' },
-		{ label: 'Suppressed (recent)', value: stats.SuppressedRecent ?? 0, cls: 'text-accent' },
-		{ label: 'Known (skipped)', value: stats.KnownHostSkipped ?? 0, cls: 'text-text-muted' },
-		{ label: 'Identify Triggered', value: stats.IdentifyTriggered ?? 0, cls: 'text-primary' },
-		{ label: 'Identify Alive', value: stats.IdentifyAlive ?? 0, cls: 'text-success' },
-		{ label: 'Identify Dead', value: stats.IdentifyDead ?? 0, cls: 'text-error' },
-		{ label: 'Devices Recorded', value: stats.DeviceRecorded ?? 0, cls: 'text-success font-semibold' }
+		{ label: m['discovery.Funnel Events Received'](), value: stats.EventsReceived ?? 0, cls: 'text-text' },
+		{ label: m['discovery.Funnel Suppressed Recent'](), value: stats.SuppressedRecent ?? 0, cls: 'text-accent' },
+		{ label: m['discovery.Funnel Known Skipped'](), value: stats.KnownHostSkipped ?? 0, cls: 'text-text-muted' },
+		{ label: m['discovery.Funnel Identify Triggered'](), value: stats.IdentifyTriggered ?? 0, cls: 'text-primary' },
+		{ label: m['discovery.Funnel Identify Alive'](), value: stats.IdentifyAlive ?? 0, cls: 'text-success' },
+		{ label: m['discovery.Funnel Identify Dead'](), value: stats.IdentifyDead ?? 0, cls: 'text-error' },
+		{ label: m['discovery.Funnel Devices Recorded'](), value: stats.DeviceRecorded ?? 0, cls: 'text-success font-semibold' }
 	]);
 </script>
 
@@ -179,11 +179,11 @@
 					<table class="w-full text-left">
 						<thead class="bg-bg/50 border-b border-border">
 							<tr>
-								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">IP</th>
-								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">MAC</th>
-								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">Source</th>
-								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">Outcome</th>
-								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">Time</th>
+								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['discovery.Col IP']()}</th>
+								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['discovery.Col MAC']()}</th>
+								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['discovery.Col Source']()}</th>
+								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['discovery.Col Outcome']()}</th>
+								<th class="px-4 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['discovery.Col Time']()}</th>
 							</tr>
 						</thead>
 						<tbody>


### PR DESCRIPTION
Resolves #59.

## Problem
The passive discovery page (`/devices/discovery`) hardcoded 12 English strings: 7 pipeline funnel counter labels and 5 recent-discoveries table headers. Chinese users saw English in the funnel stat boxes and table.

## Already done (not by this PR)
The issue also listed `TriggerIdentify ? 'on':'off'` and `{ev.outcome}` as raw-enum leaks — both are **already** resolved by #41 (`onOffBadge` + `discoveryOutcomeBadge` in `web/src/lib/utils/badges.ts`, used on this page at L156 and L191). The header, status card, and empty states were also already localized. Only the funnel labels + table headers remained.

## Changes
`devices/discovery/+page.svelte`:
- `funnel` derived array: 7 hardcoded labels → `m['discovery.Funnel *']()`
- recent-discoveries table `<th>`: 5 hardcoded → `m['discovery.Col *']()`

New i18n keys (both locales):
| key | en | zh |
|-----|----|----|
| `Funnel Events Received` | Events Received | 收到事件 |
| `Funnel Suppressed Recent` | Suppressed (recent) | 已抑制（近期） |
| `Funnel Known Skipped` | Known (skipped) | 已知（跳过） |
| `Funnel Identify Triggered` | Identify Triggered | 触发识别 |
| `Funnel Identify Alive` | Identify Alive | 识别存活 |
| `Funnel Identify Dead` | Identify Dead | 识别失败（离线） |
| `Funnel Devices Recorded` | Devices Recorded | 已记录设备 |
| `Col IP` / `Col MAC` | IP / MAC | IP / MAC *(technical abbreviations)* |
| `Col Source` | Source | 来源 |
| `Col Outcome` | Outcome | 结果 |
| `Col Time` | Time | 时间 |

## Verification
Deployed to 192.168.63.101, browser-tested in **both** locales (read rendered DOM via CDP):

| | funnel labels | table headers |
|-|---------------|---------------|
| zh | 收到事件 / 已抑制（近期）/ 已知（跳过）/ 触发识别 / 识别存活 / 识别失败（离线）/ 已记录设备 ✅ | IP / MAC / 来源 / 结果 / 时间 ✅ |
| en | Events Received / Suppressed (recent) / Known (skipped) / Identify Triggered / Identify Alive / Identify Dead / Devices Recorded ✅ | IP / MAC / Source / Outcome / Time ✅ |

- `npm run build` clean
- `npm test` 153/153 pass
- No console errors

## Note
Encountered the stale-binary/stale-index.html deploy gotcha: the browser had cached an old `index.html` referencing old chunk hashes, so the first reload showed English despite the new binary being deployed. Resolved by ensuring the server process was restarted (not just the file replaced) so it serves fresh chunks.

## Out of scope
- per-page零散文案 → #63