### PR TITLE
fix(i18n): localize scattered English across 9 pages (#63)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -71,7 +71,8 @@
 		"error.invalid_credentials": "Invalid username or password. Please try again.",
 		"error.too_many_attempts": "Too many login attempts. Please try again later.",
 		"error.network_error": "Network error. Please check your connection and try again.",
-		"error.server_error": "Server error. Please try again later."
+		"error.server_error": "Server error. Please try again later.",
+		"Username Placeholder": "admin"
 	},
 	"devices": {
 		"Device Name": "Device Name",
@@ -157,7 +158,10 @@
 		"Printer": "Printer",
 		"Search placeholder": "Search name / IP / MAC…",
 		"Alive": "Alive",
-		"All Networks": "All Networks"
+		"All Networks": "All Networks",
+		"Collapse Row": "Collapse row",
+		"CSV Format Help": "CSV format: ip,name,type (header row required)",
+		"CSV Col IP": "IP"
 	},
 	"systems": {
 		"System Management": "System Management",
@@ -215,7 +219,9 @@
 		"no_file_selected": "No file selected",
 		"Preview": "Preview",
 		"Preview File": "Preview File",
-		"Preview Not Available": "Preview not available for this file type"
+		"Preview Not Available": "Preview not available for this file type",
+		"Restore Failed": "Restore failed",
+		"URL Placeholder": "https://..."
 	},
 	"heartbeat": {
 		"Success": "Success",
@@ -267,7 +273,7 @@
 	},
 	"dashboard": {
 		"Dashboard": "Dashboard",
-		"Drag to Reorder": "Drag to reorder (or focus + ↑/↓ to move)",
+		"Drag to Reorder": "Drag widgets to reorder",
 		"Attention Title": "Needs attention",
 		"Attention Offline": "{count} offline",
 		"Attention New": "{count} new in last scan",
@@ -306,7 +312,6 @@
 		"Add Widgets": "Add Widgets",
 		"No Widgets Desc": "Add your first widget to customize the dashboard.",
 		"Config": "Config",
-		"Drag to Reorder": "Drag widgets to reorder",
 		"Seconds": "Seconds",
 		"Line": "Line",
 		"Bar": "Bar",
@@ -378,7 +383,8 @@
 		"Switch Language": "Switch language",
 		"Close Dialog": "Close dialog",
 		"Edit Widget": "Edit widget",
-		"Remove Widget": "Remove widget"
+		"Remove Widget": "Remove widget",
+		"File": "File"
 	},
 	"scanner": {
 		"Scanner": "Network Scanner",
@@ -713,7 +719,11 @@
 		"Sent": "sent",
 		"Failed": "failed",
 		"Unread": "unread",
-		"Mark Read": "Mark as Read"
+		"Mark Read": "Mark as Read",
+		"Webhook URL Placeholder": "https://hooks.example.com/...",
+		"Header Key Placeholder": "Key",
+		"Header Value Placeholder": "Value",
+		"Add Header": "+ Add"
 	},
 	"audit": {
 		"Audit Logs": "Audit Logs",
@@ -731,7 +741,8 @@
 		"Reset": "Reset",
 		"No Logs Desc": "No audit log entries found.",
 		"Details": "Details",
-		"No Details": "No detail payload."
+		"No Details": "No detail payload.",
+		"User Agent": "User Agent"
 	},
 	"changes": {
 		"Change History": "Change History",
@@ -755,7 +766,8 @@
 		"Diff After": "After",
 		"Diff No Field Changes": "No field-level differences recorded.",
 		"Diff No Snapshot": "No snapshot data.",
-		"Diff No Data": "No data available."
+		"Diff No Data": "No data available.",
+		"Data Unavailable": "Data unavailable."
 	},
 	"changefields": {
 		"name": "Name",
@@ -810,7 +822,12 @@
 		"Acknowledged": "Acknowledged",
 		"Pending": "Pending",
 		"Done": "Done",
-		"Failed": "Failed"
+		"Failed": "Failed",
+		"Failed to Copy": "Failed to copy",
+		"Payload": "Payload",
+		"Result": "Result",
+		"Agent ID Placeholder": "e.g. agent-lan-62",
+		"Agent Name Placeholder": "e.g. Branch Beijing LAN-62"
 	},
 	"networks": {
 		"Title": "Networks",
@@ -832,7 +849,10 @@
 		"Updated": "Network updated",
 		"Deleted": "Network deleted",
 		"Delete Confirm": "Delete network",
-		"Delete Warning": "Devices on this network will have their network binding cleared."
+		"Delete Warning": "Devices on this network will have their network binding cleared.",
+		"Name Placeholder": "e.g. lan-beijing-62",
+		"Cidr Placeholder": "e.g. 192.168.62.0/24",
+		"Site Placeholder": "e.g. Beijing branch / datacenter / cloud"
 	},
 	"discovery": {
 		"Enabled": "Enabled",
@@ -957,7 +977,11 @@
 		"Health No Certs": "None",
 		"Health Not Configured": "Not configured",
 		"Health Success Rate": "{rate}% success",
-		"Health Check Certs": "View certificates"
+		"Health Check Certs": "View certificates",
+		"No IP Address": "Device has no IP address",
+		"Col MAC": "MAC",
+		"Col Protocol": "Protocol",
+		"Col Last Seen": "Last Seen"
 	},
 	"validation": {
 		"Name Required": "Name is required",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -71,7 +71,8 @@
 		"error.invalid_credentials": "用户名或密码错误，请重试。",
 		"error.too_many_attempts": "登录尝试次数过多，请稍后再试。",
 		"error.network_error": "网络错误，请检查连接后重试。",
-		"error.server_error": "服务器错误，请稍后重试。"
+		"error.server_error": "服务器错误，请稍后重试。",
+		"Username Placeholder": "admin"
 	},
 	"devices": {
 		"Device Name": "设备名称",
@@ -157,7 +158,10 @@
 		"Printer": "打印机",
 		"Search placeholder": "搜索名称 / IP / MAC…",
 		"Alive": "存活",
-		"All Networks": "所有网络"
+		"All Networks": "所有网络",
+		"Collapse Row": "折叠行",
+		"CSV Format Help": "CSV 格式：ip,name,type（需要表头行）",
+		"CSV Col IP": "IP"
 	},
 	"systems": {
 		"System Management": "系统管理",
@@ -215,7 +219,9 @@
 		"no_file_selected": "未选择文件",
 		"Preview": "预览",
 		"Preview File": "预览文件",
-		"Preview Not Available": "此文件类型不支持预览"
+		"Preview Not Available": "此文件类型不支持预览",
+		"Restore Failed": "恢复失败",
+		"URL Placeholder": "https://..."
 	},
 	"heartbeat": {
 		"Success": "成功",
@@ -267,7 +273,7 @@
 	},
 	"dashboard": {
 		"Dashboard": "仪表盘",
-		"Drag to Reorder": "拖动重新排序（或聚焦后用 ↑/↓ 移动）",
+		"Drag to Reorder": "拖拽组件以调整顺序",
 		"Attention Title": "需要关注",
 		"Attention Offline": "{count} 台离线",
 		"Attention New": "最近扫描新增 {count} 台",
@@ -306,7 +312,6 @@
 		"Add Widgets": "添加组件",
 		"No Widgets Desc": "添加第一个组件来自定义仪表盘。",
 		"Config": "配置",
-		"Drag to Reorder": "拖拽组件以调整顺序",
 		"Seconds": "秒",
 		"Line": "折线",
 		"Bar": "柱状",
@@ -378,7 +383,8 @@
 		"Switch Language": "切换语言",
 		"Close Dialog": "关闭对话框",
 		"Edit Widget": "编辑组件",
-		"Remove Widget": "移除组件"
+		"Remove Widget": "移除组件",
+		"File": "文件"
 	},
 	"scanner": {
 		"Scanner": "网络扫描器",
@@ -713,7 +719,11 @@
 		"Sent": "已发送",
 		"Failed": "失败",
 		"Unread": "未读",
-		"Mark Read": "标记已读"
+		"Mark Read": "标记已读",
+		"Webhook URL Placeholder": "https://hooks.example.com/...",
+		"Header Key Placeholder": "键名",
+		"Header Value Placeholder": "键值",
+		"Add Header": "+ 添加"
 	},
 	"audit": {
 		"Audit Logs": "审计日志",
@@ -731,7 +741,8 @@
 		"Reset": "重置",
 		"No Logs Desc": "暂无审计日志记录。",
 		"Details": "详情",
-		"No Details": "无详情数据。"
+		"No Details": "无详情数据。",
+		"User Agent": "用户代理"
 	},
 	"changes": {
 		"Change History": "变更历史",
@@ -755,7 +766,8 @@
 		"Diff After": "新值",
 		"Diff No Field Changes": "未记录字段级差异。",
 		"Diff No Snapshot": "无快照数据。",
-		"Diff No Data": "无可用数据。"
+		"Diff No Data": "无可用数据。",
+		"Data Unavailable": "数据不可用。"
 	},
 	"changefields": {
 		"name": "名称",
@@ -810,7 +822,12 @@
 		"Acknowledged": "已确认",
 		"Pending": "待处理",
 		"Done": "完成",
-		"Failed": "失败"
+		"Failed": "失败",
+		"Failed to Copy": "复制失败",
+		"Payload": "载荷",
+		"Result": "结果",
+		"Agent ID Placeholder": "例如 agent-lan-62",
+		"Agent Name Placeholder": "例如 北京分公司 LAN-62"
 	},
 	"networks": {
 		"Title": "网络",
@@ -832,7 +849,10 @@
 		"Updated": "网络已更新",
 		"Deleted": "网络已删除",
 		"Delete Confirm": "删除网络",
-		"Delete Warning": "该网络上的设备将清除其网络绑定。"
+		"Delete Warning": "该网络上的设备将清除其网络绑定。",
+		"Name Placeholder": "例如 lan-beijing-62",
+		"Cidr Placeholder": "例如 192.168.62.0/24",
+		"Site Placeholder": "例如 北京分支 / 数据中心 / 云端"
 	},
 	"discovery": {
 		"Enabled": "已启用",
@@ -957,7 +977,11 @@
 		"Health No Certs": "无",
 		"Health Not Configured": "未配置",
 		"Health Success Rate": "成功率 {rate}%",
-		"Health Check Certs": "查看证书"
+		"Health Check Certs": "查看证书",
+		"No IP Address": "该设备没有 IP 地址",
+		"Col MAC": "MAC",
+		"Col Protocol": "协议",
+		"Col Last Seen": "最近发现"
 	},
 	"validation": {
 		"Name Required": "名称为必填项",

--- a/web/src/routes/agents/+page.svelte
+++ b/web/src/routes/agents/+page.svelte
@@ -258,7 +258,7 @@
 			await navigator.clipboard.writeText(createdToken);
 			addToast('success', m['agents.Copied']());
 		} catch {
-			addToast('error', 'Failed to copy');
+			addToast('error', m['agents.Failed to Copy']());
 		}
 	}
 
@@ -512,13 +512,13 @@
 								<div class="border-t border-border bg-bg/40 px-6 py-4 space-y-3">
 									{#if cmd?.payload}
 										<div>
-											<span class="text-[10px] text-text-muted uppercase tracking-wide">Payload</span>
+											<span class="text-[10px] text-text-muted uppercase tracking-wide">{m['agents.Payload']()}</span>
 											<pre class="text-xs text-text bg-bg/50 border border-border rounded p-2 mt-1 overflow-x-auto whitespace-pre-wrap break-all max-h-40">{prettyJson(cmd.payload)}</pre>
 										</div>
 									{/if}
 									{#if cmd?.result}
 										<div>
-											<span class="text-[10px] text-text-muted uppercase tracking-wide">Result</span>
+											<span class="text-[10px] text-text-muted uppercase tracking-wide">{m['agents.Result']()}</span>
 											<pre class="text-xs text-text bg-bg/50 border border-border rounded p-2 mt-1 overflow-x-auto whitespace-pre-wrap break-all max-h-40">{prettyJson(cmd.result)}</pre>
 										</div>
 									{/if}
@@ -582,7 +582,7 @@
 			<!-- Agent ID -->
 			<div>
 				<label class="block text-xs text-text-muted mb-1">{m['agents.Agent ID']()} *</label>
-				<input bind:value={formAgentId} required placeholder="e.g. agent-lan-62" class="input" />
+				<input bind:value={formAgentId} required placeholder={m['agents.Agent ID Placeholder']()} class="input" />
 			</div>
 
 			<!-- Network -->
@@ -599,7 +599,7 @@
 			<!-- Name (optional) -->
 			<div>
 				<label class="block text-xs text-text-muted mb-1">{m['agents.Name']()}</label>
-				<input bind:value={formName} placeholder="e.g. Branch Beijing LAN-62" class="input" />
+				<input bind:value={formName} placeholder={m['agents.Agent Name Placeholder']()} class="input" />
 			</div>
 
 			<!-- Actions -->

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -475,13 +475,13 @@
 						<div class="border-t border-border bg-bg/40 px-6 py-4 space-y-3">
 							{#if log?.user_agent}
 								<div>
-									<span class="text-[10px] text-text-muted uppercase tracking-wide">User Agent</span>
+									<span class="text-[10px] text-text-muted uppercase tracking-wide">{m['audit.User Agent']()}</span>
 									<p class="font-mono text-xs text-text mt-0.5 break-all">{log.user_agent}</p>
 								</div>
 							{/if}
 							{#if log?.details}
 								<div>
-									<span class="text-[10px] text-text-muted uppercase tracking-wide">Details</span>
+									<span class="text-[10px] text-text-muted uppercase tracking-wide">{m['audit.Details']()}</span>
 									<pre class="text-xs text-text bg-bg/50 border border-border rounded p-2 mt-1 overflow-x-auto whitespace-pre-wrap break-all max-h-48">{formatDetails(log.details)}</pre>
 								</div>
 							{:else}

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -406,7 +406,7 @@
 									afterData={change.after_data}
 								/>
 							{:else}
-								<p class="text-xs text-text-muted italic">Data unavailable.</p>
+								<p class="text-xs text-text-muted italic">{m['changes.Data Unavailable']()}</p>
 							{/if}
 						</div>
 					{/snippet}

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -1089,7 +1089,7 @@ interface AddDevicesResponse {
 					<button
 						onclick={() => (expandedDeviceId = null)}
 						class="p-1 rounded hover:bg-surface-2 transition-colors text-muted"
-						aria-label="Collapse row"
+						aria-label={m['devices.Collapse Row']()}
 					>
 						<ChevronRight class="w-3.5 h-3.5 rotate-90" />
 					</button>
@@ -1166,7 +1166,7 @@ interface AddDevicesResponse {
 			<label class="block text-xs text-muted mb-1">{m['devices.Import CSV']()}</label>
 			<input type="file" accept=".csv" onchange={handleCsvFileSelect}
 				class="input" />
-			<p class="text-xs text-muted mt-1">CSV format: ip,name,type (header row required)</p>
+			<p class="text-xs text-muted mt-1">{m['devices.CSV Format Help']()}</p>
 		</div>
 
 		{#if csvPreviewRows.length > 0}
@@ -1182,7 +1182,7 @@ interface AddDevicesResponse {
 					<table class="w-full text-sm">
 						<thead>
 							<tr class="bg-surface border-b border-border text-left text-xs text-muted">
-								<th class="px-3 py-2">IP</th>
+								<th class="px-3 py-2">{m['devices.CSV Col IP']()}</th>
 								<th class="px-3 py-2">{m['devices.Device Name']()}</th>
 								<th class="px-3 py-2">{m['devices.Type']()}</th>
 							</tr>
@@ -1235,7 +1235,7 @@ interface AddDevicesResponse {
 						<div class="flex items-center gap-2 min-w-0">
 							<span class="text-xs px-1.5 py-0.5 rounded
 								{doc.type === 'url' ? 'bg-accent/10 text-accent' : 'bg-primary/10 text-primary'}">
-								{doc.type === 'url' ? 'URL' : 'File'}
+								{doc.type === 'url' ? m['documents.URL']() : m['common.File']()}
 							</span>
 							<span class="text-sm text-text truncate">{doc.title}</span>
 						</div>

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -326,7 +326,7 @@
 			try {
 				const target = device?.ip_address || '';
 				if (!target) {
-					addToast('error', 'Device has no IP address');
+					addToast('error', m['devicedetail.No IP Address']());
 					return;
 				}
 				await api.post(`/devices/${deviceId}/heartbeat-configs`, {
@@ -1213,11 +1213,11 @@
 						<thead class="bg-bg/50 border-b border-border">
 							<tr>
 								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['topology.Neighbor Device']()}</th>
-								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">MAC</th>
-								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">Protocol</th>
+								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['devicedetail.Col MAC']()}</th>
+								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['devicedetail.Col Protocol']()}</th>
 								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['topology.Local Port']()}</th>
 								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['topology.Remote Port']()}</th>
-								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">Last Seen</th>
+								<th class="px-3 py-2 text-xs font-medium text-text-muted uppercase tracking-wide">{m['devicedetail.Col Last Seen']()}</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -251,7 +251,7 @@
 						await api.post(`/documents/${target.id}/restore`, {});
 						fetchDocuments();
 					} catch {
-						addToast('error', 'Restore failed');
+						addToast('error', m['documents.Restore Failed']());
 					}
 				},
 				label: m["common.Undo"](),
@@ -342,7 +342,7 @@
 			render: (row: Record<string, unknown>) => {
 				const doc = row as unknown as Document;
 				const isUrl = doc.type === 'url';
-				const label = isUrl ? 'URL' : m["documents.File"]();
+				const label = isUrl ? m["documents.URL"]() : m["documents.File"]();
 				const cls = isUrl
 					? 'text-accent'
 					: 'text-primary';
@@ -499,7 +499,7 @@
 		</div>
 		<div>
 			<label class="block text-xs text-text-muted mb-1">{m["documents.URL"]()} *</label>
-			<input bind:value={formUrl} required type="url" placeholder="https://..."
+			<input bind:value={formUrl} required type="url" placeholder={m['documents.URL Placeholder']()}
 				class="w-full px-3 py-2 bg-bg border border-border rounded-lg text-sm text-text
 					focus:border-primary focus:outline-none font-mono" />
 		</div>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -202,7 +202,7 @@
 						id="username"
 						bind:value={username}
 						class="input py-2.5 focus:ring-1 focus:ring-primary"
-						placeholder="admin"
+						placeholder={m['auth.Username Placeholder']()}
 						required
 						autocomplete="username"
 					/>

--- a/web/src/routes/networks/+page.svelte
+++ b/web/src/routes/networks/+page.svelte
@@ -276,21 +276,21 @@
 		<!-- Name -->
 		<div>
 			<label class="block text-xs text-text-muted mb-1">{m['networks.Name']()} *</label>
-			<input bind:value={formName} required placeholder="e.g. lan-beijing-62" class="input" />
+			<input bind:value={formName} required placeholder={m['networks.Name Placeholder']()} class="input" />
 			<p class="text-xs text-text-muted mt-1">{m['networks.Name Help']()}</p>
 		</div>
 
 		<!-- CIDR -->
 		<div>
 			<label class="block text-xs text-text-muted mb-1">CIDR</label>
-			<input bind:value={formCidr} placeholder="e.g. 192.168.62.0/24" class="input font-mono" />
+			<input bind:value={formCidr} placeholder={m['networks.Cidr Placeholder']()} class="input font-mono" />
 			<p class="text-xs text-text-muted mt-1">{m['networks.Cidr Help']()}</p>
 		</div>
 
 		<!-- Site -->
 		<div>
 			<label class="block text-xs text-text-muted mb-1">{m['networks.Site']()}</label>
-			<input bind:value={formSite} placeholder="e.g. Beijing branch / datacenter / cloud" class="input" />
+			<input bind:value={formSite} placeholder={m['networks.Site Placeholder']()} class="input" />
 		</div>
 
 		<!-- Actions -->

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -327,10 +327,10 @@ function handleCancel2FASetup() {
 				<button onclick={handleThemeToggle} class="btn btn-secondary">
 					{#if theme === 'dark'}
 						<Moon class="w-4 h-4" />
-						Dark
+						{m["settings.Dark Mode"]()}
 					{:else}
 						<Sun class="w-4 h-4" />
-						Light
+						{m["settings.Light Mode"]()}
 					{/if}
 				</button>
 				<span class="text-sm text-muted">

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -439,7 +439,7 @@
 					bind:value={formUrl}
 					type="url"
 					required
-					placeholder="https://hooks.example.com/..."
+					placeholder={m["notifications.Webhook URL Placeholder"]()}
 					class="w-full px-3 py-2 bg-bg border border-border rounded-lg text-sm text-text
 						focus:outline-none focus:border-primary transition-colors"
 				/>
@@ -448,19 +448,19 @@
 				<div class="flex items-center justify-between mb-1">
 					<label class="text-xs text-text-muted">{m["notifications.Headers"]()}</label>
 					<button type="button" onclick={addHeaderRow}
-						class="text-xs text-primary hover:underline">+ Add</button>
+						class="text-xs text-primary hover:underline">{m['notifications.Add Header']()}</button>
 				</div>
 				{#each formHeaders as hdr, i}
 					<div class="flex gap-2 mb-2">
 						<input
 							bind:value={formHeaders[i].key}
-							placeholder="Key"
+							placeholder={m["notifications.Header Key Placeholder"]()}
 							class="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-sm text-text
 								focus:outline-none focus:border-primary transition-colors"
 						/>
 						<input
 							bind:value={formHeaders[i].value}
-							placeholder="Value"
+							placeholder={m["notifications.Header Value Placeholder"]()}
 							class="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-sm text-text
 								focus:outline-none focus:border-primary transition-colors"
 						/>


### PR DESCRIPTION
Resolves #63.

The i18n cluster's catch-all. An audit of the issue's cited points found **24 leak sites still present** across 9 pages (4 already fixed by prior PRs: changes Diff Title, notifications channel `${t}`, device-detail vCPU suffix, agents Token modal title). This PR fixes the remaining 24.

## Fixes by page
| page | hardcoded → localized |
|------|----------------------|
| **agents** | `'Failed to copy'` toast, `<span>Payload</span>`/`<span>Result</span>`, 2 token-form placeholders (`e.g.` → 例如, example value kept) |
| **audit** | `<span>User Agent</span>`/`<span>Details</span>` (the *table column* header was already localized; the detail-panel spans were not) |
| **changes** | `Data unavailable.` fallback |
| **settings** | theme-button Dark/Light glyphs → `settings.Dark/Light Mode` (caption beside was already localized) |
| **settings/notifications** | webhook URL placeholder, `+ Add` button, Key/Value header placeholders |
| **devices** | `Collapse row` aria-label, CSV format help, CSV preview `<th>IP</th>`, URL/File badge (File → `common.File`, URL → reuses `documents.URL`) |
| **devices/detail** | `'Device has no IP address'` toast, neighbor-table MAC/Protocol/Last Seen headers |
| **networks** | 3 create-form placeholders (`e.g.` → 例如) |
| **documents** | `'Restore failed'` toast, URL badge (reuses `documents.URL`), URL placeholder |
| **login** | username placeholder (`admin` — technical, kept in both locales) |

## Deliberately NOT changed
The `'...'` loading-ellipsis glyphs on submit buttons (`{formLoading ? '...' : m['common.Save']()}`) — `...` is a universal loading indicator, not localized content. Left as-is and documented.

## New i18n keys
Added to both `en.json`/`zh.json`: `agents.{Failed to Copy,Payload,Result,Agent ID Placeholder,Agent Name Placeholder}`, `audit.User Agent`, `changes.Data Unavailable`, `notifications.{Webhook URL Placeholder,Header Key Placeholder,Header Value Placeholder,Add Header}`, `devices.{Collapse Row,CSV Format Help,CSV Col IP}`, `devicedetail.{No IP Address,Col MAC,Col Protocol,Col Last Seen}`, `networks.{Name,Cidr,Site} Placeholder`, `documents.{Restore Failed,URL Placeholder}`, `auth.Username Placeholder`, `common.File`. Reused existing `audit.Details`, `documents.{URL,File}`, `settings.{Dark,Light} Mode` where they fit.

## Verification
Deployed to 192.168.63.101, browser-tested in zh locale (read rendered DOM via CDP for the conditionally-rendered/expanded strings):

| page | rendered |
|------|----------|
| agents | 载荷 / 结果 spans; 例如 agent-lan-62 / 例如 北京分公司 LAN-62 placeholders ✅ |
| audit | 用户代理 span ✅ |
| changes | 数据不可用。 fallback ✅ |
| settings | 深色模式 button ✅ |
| notifications | 键名 / 键值 placeholders; + 添加 button ✅ |
| networks | 例如 lan-beijing-62 / 例如 192.168.62.0/24 / 例如 北京分支 / 数据中心 / 云端 ✅ |
| devices | CSV 格式：ip,name,type（需要表头行） ✅ |
| documents / login | via locale map (documents.URL=admin kept) ✅ |

- `npm run build` clean
- `npm test` 153/153 pass
- No console errors

## Note
Hit the stale-process deploy gotcha again (the prior issue's binary was still running after upload, serving old chunks). Resolved by ensuring `systemd-run` restarts the process after the file replace, not just replacing the file.