### PR TITLE
fix(web): component a11y + cleanup — aria ids, focus, escape, chart resize (#74)

### DIFF
--- a/web/src/lib/charts/echarts.ts
+++ b/web/src/lib/charts/echarts.ts
@@ -28,6 +28,22 @@ import {
 } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
 
+// Only the chart/component modules actually used by the app are registered
+// here (tree-shaking by usage — echarts/core ships just the core). Before
+// adding a new chart type or option feature, check whether its module is
+// registered below; an unregistered component silently renders nothing.
+//
+// Commonly-needed-but-currently-unused modules (intentionally NOT registered to
+// keep the bundle lean — add the import + echarts.use() entry when a chart
+// first needs one):
+//   - DatasetComponent       (option.dataset source piping)
+//   - DataZoomComponent      (zoom/pan sliders on large series)
+//   - MarkLineComponent      (option.series.markLine reference lines)
+//   - MarkAreaComponent      (option.series.markArea shaded regions)
+//   - PolarComponent         (polar/bar-polar coordinates)
+//   - GeoComponent           (map/geo coordinates)
+//   - CalendarComponent      (calendar heatmap coordinates)
+//   - RadarComponent          (radar coordinates)
 echarts.use([
 	GaugeChart,
 	LineChart,

--- a/web/src/lib/components/CertificateModal.svelte
+++ b/web/src/lib/components/CertificateModal.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
 	import Modal from './Modal.svelte';
 	import { m } from '$lib/i18n-paraglide';
+	import { addToast } from '$lib/stores/toast';
 	import type { TLSPortCerts, CertificateInfo } from '$lib/types';
 	import { ShieldCheck, ShieldAlert, ShieldX, Copy, Check, ChevronDown } from '@lucide/svelte';
 	import { certStatus as statusOf, certDayDelta as dayDelta, fmtFingerprint } from '$lib/utils/certs';
@@ -54,8 +55,11 @@
 				if (copiedIndex === idx) copiedIndex = null;
 			}, 1500);
 		} catch {
-			// Clipboard API may be unavailable (insecure context); fall back to
-			// selecting the <pre> text. We don't auto-select to avoid jarring UX.
+			// Clipboard API is unavailable (e.g. insecure HTTP context). The copy
+			// silently did nothing — surface it so the user isn't left guessing
+			// whether the PEM was copied. The PEM text remains visible in the
+			// <pre> below for manual selection + Ctrl/Cmd+C.
+			addToast('error', m['agents.Failed to Copy']());
 		}
 	}
 

--- a/web/src/lib/components/Chart.svelte
+++ b/web/src/lib/components/Chart.svelte
@@ -12,18 +12,24 @@
 	import { echarts, type EChartsOption } from '$lib/charts/echarts';
 	import { onMount } from 'svelte';
 	import { m } from '$lib/i18n-paraglide';
+	import { LoaderCircle } from '@lucide/svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 
 	let {
 		option = $bindable(),
 		width = '100%',
 		height = '300px',
+		loading = false,
 		onclick,
 		ondblclick
 	}: {
 		option: EChartsOption;
 		width?: string;
 		height?: string;
+		// When true, the chart shows a spinner overlay on top of the canvas.
+		// Parent components toggle this during refetches so the chart doesn't
+		// visually freeze on stale data while waiting for the next payload.
+		loading?: boolean;
 		// onclick fires for ECharts series clicks (node/edge). The payload is the
 		// raw ECharts event object; inspect dataType ('node'|'edge') + data.value.
 		onclick?: (params: Record<string, unknown>) => void;
@@ -68,6 +74,16 @@
 		const handleResize = () => instance?.resize();
 		window.addEventListener('resize', handleResize);
 
+		// Watch the container's size directly. A window 'resize' listener alone
+		// misses cases where the container changes size without the window
+		// resizing — e.g. an accordion expanding, a modal opening, or a sidebar
+		// collapsing — which left the chart squeezed into its old (often 0-width)
+		// box. ResizeObserver fires on those layout transitions.
+		const resizeObserver = new ResizeObserver(() => {
+			instance?.resize();
+		});
+		if (container) resizeObserver.observe(container);
+
 		// Watch for theme changes (data-theme attribute on <html>)
 		const observer = new MutationObserver(() => {
 			initChart();
@@ -79,6 +95,7 @@
 
 		return () => {
 			window.removeEventListener('resize', handleResize);
+			resizeObserver.disconnect();
 			observer.disconnect();
 			instance?.dispose();
 			instance = undefined;
@@ -90,6 +107,11 @@
 			instance.setOption(option);
 		}
 	});
+
+	// Loading overlay: parent sets `loading` while refetching. We render a CSS
+	// overlay rather than ECharts' built-in showLoading() to avoid pulling in the
+	// (unregistered here) LoadingComponent and to keep the spinner consistent
+	// with the rest of the app's LoaderCircle icon.
 
 	// Bind the click handler whenever it or the instance changes. ECharts
 	// 'click' events carry the series payload (node/edge data) — distinct from
@@ -127,5 +149,13 @@
 		<EmptyState title={m['common.No Data']()} />
 	</div>
 {:else}
-	<div bind:this={container} class="echarts-container" style="width: {width}; height: {height};"></div>
+	<div class="relative" style="width: {width}; height: {height};">
+		<div bind:this={container} class="echarts-container" style="width: 100%; height: 100%;"></div>
+		{#if loading}
+			<div class="absolute inset-0 flex items-center justify-center bg-surface/60 backdrop-blur-sm rounded-lg">
+				<LoaderCircle class="w-6 h-6 animate-spin text-primary" aria-hidden="true" />
+				<span class="sr-only">{m['common.Loading']()}</span>
+			</div>
+		{/if}
+	</div>
 {/if}

--- a/web/src/lib/components/ConfirmDialog.svelte
+++ b/web/src/lib/components/ConfirmDialog.svelte
@@ -49,6 +49,14 @@
 	let busy = $state(false);
 	const pending = $derived(busy || loading);
 
+	// Per-instance ids so two concurrent ConfirmDialogs (or a ConfirmDialog
+	// alongside a Modal) don't collide on aria-labelledby/describedby targets.
+	const idBase = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+		? crypto.randomUUID()
+		: Math.random().toString(36).slice(2);
+	const confirmTitleId = `confirm-title-${idBase}`;
+	const confirmMessageId = `confirm-message-${idBase}`;
+
 	async function handleConfirm() {
 		if (pending) return;
 		busy = true;
@@ -81,11 +89,11 @@
 			class="confirm-content"
 			role="alertdialog"
 			aria-modal="true"
-			aria-labelledby="confirm-title"
-			aria-describedby="confirm-message"
+			aria-labelledby={confirmTitleId}
+			aria-describedby={confirmMessageId}
 		>
-			<h3 id="confirm-title" class="sr-only">{title}</h3>
-			<p id="confirm-message" class="confirm-message">{message}</p>
+			<h3 id={confirmTitleId} class="sr-only">{title}</h3>
+			<p id={confirmMessageId} class="confirm-message">{message}</p>
 			<div class="confirm-actions">
 				<button
 					class="cd-btn cd-cancel"

--- a/web/src/lib/components/DataTable.svelte
+++ b/web/src/lib/components/DataTable.svelte
@@ -174,6 +174,7 @@
 					oninput={() => onSearchChange?.(searchQuery)}
 					placeholder={searchPlaceholder}
 					data-search-shortcut
+					aria-label={searchPlaceholder}
 					class="input pl-10 pr-10"
 				/>
 				{#if searchQuery}
@@ -196,7 +197,16 @@
 				<thead>
 					<tr class="border-b border-border text-left text-xs text-muted bg-surface">
 						{#each columns as col}
-							<th scope="col" class="px-4 py-3 {col.sortable ? 'cursor-pointer select-none hover:text-text' : ''}" class:whitespace-nowrap={true}>
+							<th
+								scope="col"
+								class="px-4 py-3 {col.sortable ? 'cursor-pointer select-none hover:text-text' : ''}"
+								class:whitespace-nowrap={true}
+								aria-sort={col.sortable
+									? (displaySortKey === col.key
+										? (displaySortDir === 'asc' ? 'ascending' : displaySortDir === 'desc' ? 'descending' : 'none')
+										: 'none')
+									: undefined}
+							>
 								{#if col.sortable}
 									<button
 										class="inline-flex items-center gap-1.5"

--- a/web/src/lib/components/Modal.svelte
+++ b/web/src/lib/components/Modal.svelte
@@ -52,6 +52,13 @@
 	let previouslyFocused: HTMLElement | undefined = $state();
 	let showConfirm = $state(false);
 
+	// Unique id for this instance's title element so aria-labelledby resolves
+	// correctly even when multiple Modals (or a Modal + ConfirmDialog) are open
+	// at once. Hardcoded "modal-title" collided across concurrent instances.
+	const titleId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+		? `modal-title-${crypto.randomUUID()}`
+		: `modal-title-${Math.random().toString(36).slice(2)}`;
+
 	const FOCUSABLE =
 		'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
@@ -128,19 +135,26 @@
 			previouslyFocused = document.activeElement as HTMLElement;
 			document.body.style.overflow = 'hidden';
 
-			// Focus first focusable element after render
-			const timeout = setTimeout(() => {
-				if (!dialogRef) return;
-				const focusable = getFocusable();
-				if (focusable.length > 0) {
-					focusable[0].focus();
-				} else {
-					dialogRef!.focus();
-				}
-			}, 50);
+			// Focus first focusable element after the dialog's scale transition
+			// paints. requestAnimationFrame (chained once to land on the post-paint
+			// frame) is more reliable than a fixed setTimeout(50), which raced the
+			// transition and occasionally focused before the dialog was interactive.
+			let raf2 = 0;
+			const raf1 = requestAnimationFrame(() => {
+				raf2 = requestAnimationFrame(() => {
+					if (!dialogRef) return;
+					const focusable = getFocusable();
+					if (focusable.length > 0) {
+						focusable[0].focus();
+					} else {
+						dialogRef!.focus();
+					}
+				});
+			});
 
 			return () => {
-				clearTimeout(timeout);
+				cancelAnimationFrame(raf1);
+				cancelAnimationFrame(raf2);
 			};
 		} else {
 			document.body.style.overflow = '';
@@ -166,11 +180,11 @@
 			transition:scale={{ duration: 200, start: 0.95 }}
 			role="dialog"
 			aria-modal="true"
-			aria-labelledby="modal-title"
+			aria-labelledby={titleId}
 			tabindex="-1"
 		>
 			<header class="modal-header">
-				<h2 id="modal-title" class="modal-title">{title}</h2>
+				<h2 id={titleId} class="modal-title">{title}</h2>
 				<button
 					class="modal-close"
 					onclick={close}

--- a/web/src/lib/components/NotificationBell.svelte
+++ b/web/src/lib/components/NotificationBell.svelte
@@ -92,7 +92,14 @@
 	}
 
 	function formatTime(iso: string): string {
-		return new Date(iso).toLocaleString();
+		if (!iso) return '-';
+		try {
+			return new Date(iso).toLocaleString();
+		} catch {
+			// A malformed sent_at would otherwise throw inside the {#each} and
+			// crash the whole dropdown. Fall back to the raw value.
+			return iso;
+		}
 	}
 
 	onMount(() => {

--- a/web/src/lib/components/Pagination.svelte
+++ b/web/src/lib/components/Pagination.svelte
@@ -76,7 +76,6 @@
 			</span>
 			{#if onPageSizeChange}
 				<div class="flex items-center gap-1.5">
-					<span class="text-xs text-muted">{''}</span>
 					<select
 						value={limit}
 						onchange={handlePageSizeChange}

--- a/web/src/lib/components/scanner/LabelEditor.svelte
+++ b/web/src/lib/components/scanner/LabelEditor.svelte
@@ -145,6 +145,7 @@
 							<input
 								type="text"
 								placeholder="key"
+								aria-label="Label key"
 								value={entry.key}
 								oninput={(e) => updateKey(entry.id, (e.target as HTMLInputElement).value)}
 								class="label-input"
@@ -153,6 +154,7 @@
 							<input
 								type="text"
 								placeholder="value"
+								aria-label="Label value"
 								value={entry.value}
 								oninput={(e) => updateValue(entry.id, (e.target as HTMLInputElement).value)}
 								class="label-input"

--- a/web/src/lib/components/scanner/PipelineConfigEditor.svelte
+++ b/web/src/lib/components/scanner/PipelineConfigEditor.svelte
@@ -120,24 +120,18 @@
 	);
 
 	// --- SVG icons per stage ---
-	function stageIcon(icon: string): string {
-		switch (icon) {
-			case 'icmp':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />';
-			case 'snmp':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />';
-			case 'port':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />';
-			case 'service':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />';
-			case 'prometheus':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />';
-			case 'node':
-				return '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />';
-			default:
-				return '';
-		}
-	}
+	// Stage icon path data, keyed by stage.icon. Inlined directly into the <svg>
+	// below via an {#if} chain rather than rendered through {@html} — the paths
+	// are static literals (no injection surface), but avoiding {@html} keeps the
+	// markup auditable and lets the Svelte compiler type-check the attribute set.
+	const STAGE_ICON_PATHS: Record<string, string> = {
+		icmp: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+		snmp: 'M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+		port: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9',
+		service: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+		prometheus: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+		node: 'M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01'
+	};
 </script>
 
 <div class="pipeline-editor">
@@ -188,7 +182,9 @@
 					<!-- Icon -->
 					<div class="stage-icon {enabled ? 'stage-icon-active' : ''}">
 						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							{@html stageIcon(stage.icon)}
+							{#if STAGE_ICON_PATHS[stage.icon]}
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={STAGE_ICON_PATHS[stage.icon]} />
+							{/if}
 						</svg>
 					</div>
 


### PR DESCRIPTION
Resolves the still-open sub-items of #74 (the component a11y/cleanup list). Item #7 (ThemeToggle i18n) was already fixed by a prior PR — skipped.

## Changes (9 sub-items)

| # | Item | Fix |
|---|------|-----|
| 1 | CertificateModal `copyPEM` silent empty catch | Now toasts on failure (insecure HTTP context) |
| 2 | Modal/ConfirmDialog hardcoded aria ids collide | Per-instance ids via `crypto.randomUUID()` |
| 3 | Modal `setTimeout(50)` focus race | `requestAnimationFrame` (chained, post-paint) |
| 4 | NotificationBell `formatTime` unguarded | try/catch + empty check (mirrors HeartbeatExpandableRow) |
| 5 | DataTable no `aria-sort`, search no label | `aria-sort` on sortable th; `aria-label` on search |
| 6 | Pagination leftover empty `{''}` span | Removed |
| 8 | LabelEditor inputs no label | `aria-label` on key/value inputs |
| 9 | PipelineConfigEditor `{@html}` stageIcon | Typed map + `{#if}`, no more `{@html}` |
| 10 | Chart window-resize only, no `loading` prop | `ResizeObserver` on container + `loading` overlay prop |
| 11 | echarts.ts unregistered components undocumented | Documented (intentionally not registered to keep bundle lean) |

## Notes
- **#11 trade-off**: the 7 named components (Dataset/DataZoom/MarkLine/MarkArea/Polar/Geo/Calendar + Radar) are *not* bulk-registered — that would grow the bundle for components no chart currently uses. Instead a comment documents them so a future chart addition knows to register what it needs.
- **#8 aria-labels**: LabelEditor key/value use literal English aria-labels ("Label key"/"Label value"); full i18n of these placeholders is tracked under #62, this PR is a11y-scoped.

## Verification
- `npm test`: 181/181 pass (7 files)
- `svelte-check`: 45 errors / 103 warnings — **identical to main baseline** (zero new errors). An intermediate `{id}={...}` syntax mistake broke Modal/ConfirmDialog compilation and cascaded 27 errors; corrected to `id={...}` and the count returned to baseline.

🤖 Generated with [ZCode](https://zcode.dev)