### PR TITLE
fix(web): api client hardening — GET retry, env base, unified 401 (#73)

### DIFF
--- a/web/src/__tests__/client.test.ts
+++ b/web/src/__tests__/client.test.ts
@@ -1,0 +1,108 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+ *
+ * This file is part of MiBee Steward, distributed under the GNU Affero General
+ * Public License v3.0 or later. A commercial license is available for use cases
+ * the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.mock factories are hoisted above all imports, so the spies they close
+// over must be created with vi.hoisted (also hoisted) — plain top-level const
+// would be in the temporal dead zone when the factory runs.
+const { logoutSpy, gotoSpy } = vi.hoisted(() => ({
+	logoutSpy: vi.fn(),
+	gotoSpy: vi.fn()
+}));
+vi.mock('$lib/stores/auth', () => ({ auth: { logout: logoutSpy } }));
+vi.mock('$app/navigation', () => ({ goto: gotoSpy }));
+
+import { api, ApiError, SessionExpiredError } from '$lib/api/client';
+
+// Build a fetch Response without coupling to the full Response API.
+function jsonResponse(body: unknown, init: { status: number }): Response {
+	return new Response(JSON.stringify(body), {
+		status: init.status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
+// We use REAL timers (not fake) on purpose: the retry loop interleaves fetch
+// microtasks with setTimeout-driven backoff sleeps, and driving that correctly
+// under fake timers requires pumping the queue in a loop. The total backoff is
+// small (RETRY_BASE_DELAY_MS=150 → 150ms + 300ms = 450ms for the full 2-retry
+// exhaustion path), so letting real time elapse keeps the test honest and far
+// simpler. Each retry-capable case is awaited to settlement.
+describe('api client retry / 401 handling', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		logoutSpy.mockClear();
+		gotoSpy.mockClear();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('retries GET on HTTP 500 and succeeds once the server recovers', async () => {
+		fetchMock
+			.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, { status: 500 }))
+			.mockResolvedValueOnce(jsonResponse({ ok: true }, { status: 200 }));
+
+		const result = await api.get<{ ok: boolean }>('/anything');
+
+		expect(result).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('exhausts retries on persistent GET 500 and throws ApiError(500)', async () => {
+		// MAX_RETRIES = 2 → 3 attempts total (initial + 2 retries).
+		fetchMock.mockResolvedValue(jsonResponse({ error: 'down' }, { status: 500 }));
+
+		// Catch once and assert against the captured error.
+		const err = await api.get('/down').catch((e) => e);
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(500);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it('does NOT retry POST on 500 (non-idempotent)', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ error: 'down' }, { status: 500 }));
+
+		await expect(api.post('/write', { x: 1 })).rejects.toBeInstanceOf(ApiError);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('does NOT retry 4xx (client errors are not transient)', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ error: 'bad' }, { status: 422 }));
+
+		await expect(api.get('/bad')).rejects.toBeInstanceOf(ApiError);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('401 logs out, redirects, and throws SessionExpiredError without retrying', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ error: 'no' }, { status: 401 }));
+
+		await expect(api.get('/secret')).rejects.toBeInstanceOf(SessionExpiredError);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(logoutSpy).toHaveBeenCalledTimes(1);
+		expect(gotoSpy).toHaveBeenCalledWith('/login');
+	});
+
+	it('retries GET on a network-level failure (fetch rejects)', async () => {
+		fetchMock
+			.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+			.mockResolvedValueOnce(jsonResponse({ ok: true }, { status: 200 }));
+
+		const result = await api.get<{ ok: boolean }>('/flaky');
+
+		expect(result).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -19,7 +19,11 @@ import { auth } from '$lib/stores/auth';
 import { getErrorMessage } from '$lib/utils/error';
 import { m } from '$lib/i18n-paraglide';
 
-const API_BASE = '/api/v1';
+// API base path. Defaults to the same-origin /api/v1 prefix (the SPA is served
+// by the Go binary, so same-origin is the norm). Override with
+// VITE_API_BASE when the frontend talks to a different origin (e.g. local dev
+// against a remote backend). Opt-in: unset → /api/v1, preserving existing behavior.
+const API_BASE = import.meta.env.VITE_API_BASE ?? '/api/v1';
 
 /**
  * Thrown by all three request paths (request / download / upload) on HTTP 401,
@@ -55,37 +59,98 @@ export class ApiError extends Error {
 	}
 }
 
+/**
+ * Shared 401 handling: logs the user out, redirects to /login, and returns a
+ * SessionExpiredError for the caller to throw (request/download) or reject
+ * with (upload's XHR callback can't throw across the async boundary).
+ *
+ * This was previously copy-pasted in request(), download(), and upload() —
+ * three identical logout+goto+throw/reject triplets. Centralizing it keeps the
+ * session-expiry contract (logout BEFORE redirect, typed error after) in one
+ * place.
+ */
+function handleUnauthorized(): SessionExpiredError {
+	auth.logout();
+	goto('/login');
+	return new SessionExpiredError();
+}
+
+// Retry config for transient failures. Only idempotent GET requests retry —
+// POST/PUT/PATCH/DELETE are never retried (a retried write could double-apply).
+// A retry happens on: HTTP 5xx (server-side, likely transient) or a network-
+// level failure (fetch rejected — DNS/connection drop). 4xx, 401, and
+// AbortError (explicit cancel / timeout) are NOT retried.
+const MAX_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 150;
+
+function isRetryableMethod(method?: string): boolean {
+	// GET (and HEAD/OPTIONS) are safe/idempotent. Default (no method) is GET.
+	return !method || method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 	const csrfToken = getCSRFToken();
 	if (csrfToken && options?.method && options.method !== 'GET') {
 		headers['X-CSRF-Token'] = csrfToken;
 	}
-	try {
-		const res = await fetch(`${API_BASE}${path}`, {
-			...options,
-			signal: AbortSignal.timeout(30000),
-			credentials: 'include',
-			headers: { ...headers, ...(options?.headers as Record<string, string>) }
-		});
-		if (res.status === 401) {
-			auth.logout();
-			goto('/login');
-			throw new SessionExpiredError();
+
+	const method = options?.method;
+	const canRetry = isRetryableMethod(method);
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		try {
+			const res = await fetch(`${API_BASE}${path}`, {
+				...options,
+				signal: AbortSignal.timeout(30000),
+				credentials: 'include',
+				headers: { ...headers, ...(options?.headers as Record<string, string>) }
+			});
+			if (res.status === 401) {
+				throw handleUnauthorized();
+			}
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: m['api.Request Failed']() }));
+				const apiErr = new ApiError(res.status, err.error || m['api.HTTP Error']({ status: String(res.status) }));
+				// 5xx on a GET is worth one more shot; anything else (4xx) is final.
+				if (canRetry && res.status >= 500 && attempt < MAX_RETRIES) {
+					lastError = apiErr;
+					await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
+					continue;
+				}
+				throw apiErr;
+			}
+			if (res.status === 204) return undefined as T;
+			return res.json();
+		} catch (err: unknown) {
+			// Typed errors we created (SessionExpiredError / ApiError) propagate
+			// as-is. A retryable ApiError (5xx GET) was already handled above
+			// via `continue`; if it reaches here the retry budget is exhausted.
+			if (err instanceof SessionExpiredError) throw err;
+			if (err instanceof ApiError) throw err;
+			// Anything else is a network/abort/parse failure. Distinguish:
+			//  - AbortError (timeout/explicit cancel): never retry, surface now.
+			//  - network TypeError on a GET: retry, then surface if exhausted.
+			const isAbort = err instanceof DOMException && err.name === 'AbortError';
+			if (canRetry && !isAbort && attempt < MAX_RETRIES) {
+				lastError = err;
+				await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
+				continue;
+			}
+			// Wrap the genuine network/abort/parse error (no HTTP status) into a
+			// plain Error. Callers distinguish it from ApiError via instanceof.
+			throw new Error(getErrorMessage(err));
 		}
-		if (!res.ok) {
-			const err = await res.json().catch(() => ({ error: m['api.Request Failed']() }));
-			throw new ApiError(res.status, err.error || m['api.HTTP Error']({ status: String(res.status) }));
-		}
-		if (res.status === 204) return undefined as T;
-		return res.json();
-	} catch (err: unknown) {
-		// Preserve typed errors (SessionExpiredError / ApiError) so callers can
-		// branch on `instanceof` / `.status`. Only wrap genuine network/abort/
-		// parse errors (which have no HTTP status) into a plain Error.
-		if (err instanceof SessionExpiredError || err instanceof ApiError) throw err;
-		throw new Error(getErrorMessage(err));
 	}
+	// Retry budget exhausted — surface the last error.
+	throw lastError instanceof Error
+		? lastError
+		: new Error(getErrorMessage(lastError));
 }
 
 export const api = {
@@ -113,9 +178,7 @@ export const api = {
 			signal: AbortSignal.timeout(60000)
 		});
 		if (res.status === 401) {
-			auth.logout();
-			goto('/login');
-			throw new SessionExpiredError();
+			throw handleUnauthorized();
 		}
 		if (!res.ok) {
 			const err = await res.json().catch(() => ({ error: m['api.Download Failed']() }));
@@ -140,9 +203,7 @@ export const api = {
 			xhr.timeout = 30000;
 			xhr.onload = () => {
 				if (xhr.status === 401) {
-					auth.logout();
-					goto('/login');
-					reject(new SessionExpiredError());
+					reject(handleUnauthorized());
 					return;
 				}
 				if (xhr.status >= 400) {


### PR DESCRIPTION
Resolves the 3 still-open sub-items of #73. Item #3 (typed ApiError) was already done by a prior PR — skipped.

## Changes

### 1. GET retry with exponential backoff
Idempotent **GET** (and HEAD/OPTIONS) now retries up to **2x** on:
- HTTP **5xx** (server-side, likely transient)
- **network-level** failure (fetch rejected — DNS/connection drop)

Not retried:
- **POST/PUT/PATCH/DELETE** (non-idempotent — a retried write could double-apply)
- **4xx** (client errors are not transient)
- **401** (session expired — handled separately)
- **AbortError** (explicit cancel / timeout)

Backoff: `RETRY_BASE_DELAY_MS (150) × 2^attempt` → 150ms, 300ms. On budget exhaustion the last error surfaces.

### 2. Env-driven API base
`API_BASE = import.meta.env.VITE_API_BASE ?? '/api/v1'`. Opt-in — unset preserves the same-origin default (existing embedded deployments unaffected); enables pointing the SPA at a remote backend for local dev.

### 3. Unified `handleUnauthorized()`
The `auth.logout() + goto('/login') + SessionExpiredError` triplet was copy-pasted across `request`/`download`/`upload`. Now centralized in one helper that returns the error instance — `request`/`download` throw it, `upload` rejects with it (XHR callback can't throw across the async boundary).

## Tests
New `client.test.ts` (6 cases) covering the retry matrix:
- GET 500 → retry → success (2 fetches)
- GET 500 persistent → exhausts → ApiError(500) (3 fetches)
- POST 500 → no retry (1 fetch)
- 4xx → no retry (1 fetch)
- 401 → no retry + logout + redirect
- network failure (fetch rejects) → retry → success

## Verification
- `npm test`: **187/187 pass** (181 existing + 6 new)
- `svelte-check`: 45 errors / 103 warnings — **identical to main baseline** (zero new errors)

🤖 Generated with [ZCode](https://zcode.dev)