### PR TITLE
fix(web): paginate scanner alive-hosts table for large (/22+) ranges (#100)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -466,6 +466,7 @@
 		"Search IP": "Search IP address...",
 		"Show All Unreachable": "Show all {count} unreachable hosts",
 		"Show Less Unreachable": "Show less",
+		"Large Range Hint": "Large range — results are paginated. For ranges this wide, consider a scan task (async) instead of a quick scan.",
 		"Unreachable Hosts": "Unreachable Hosts ({count})",
 		"Confirm Add Title": "Confirm Bulk Add",
 		"Confirm Add Message": "You are about to add {count} devices. Continue?",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -466,6 +466,7 @@
 		"Search IP": "搜索 IP 地址...",
 		"Show All Unreachable": "显示全部 {count} 台不可达主机",
 		"Show Less Unreachable": "收起",
+		"Large Range Hint": "扫描范围较大——结果已分页。如此大的范围建议改用扫描任务（异步）而非快速扫描。",
 		"Unreachable Hosts": "不可达主机（{count}）",
 		"Confirm Add Title": "确认批量添加",
 		"Confirm Add Message": "即将添加 {count} 台设备，是否继续？",

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -16,6 +16,7 @@
 	import { validateScanTarget } from '$lib/utils/validation';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
+	import Pagination from '$lib/components/Pagination.svelte';
 	import { LoaderCircle, Radar } from '@lucide/svelte';
 
 	// All 9 device types matching internal/domain/device.go
@@ -64,6 +65,13 @@
 	let adding = $state(false);
 	// Expand/collapse unreachable hosts
 	let showAllUnreachable = $state(false);
+	// Client-side pagination of the alive-hosts table. The alive table renders
+	// a heavy row (4 bound inputs + a 9-option select + 4 conditional badges),
+	// so an unbounded /22+ (1k+ hosts) thrashes the DOM. Form state is kept in
+	// Record<ip, value> maps keyed by IP, so slicing the rendered rows loses no
+	// edits when paging — the maps survive independent of which slice is shown.
+	let aliveOffset = $state(0);
+	let aliveLimit = $state(50);
 	// Confirm dialog for bulk add
 	let confirmAddOpen = $state(false);
 
@@ -120,6 +128,7 @@
 		deviceLocations = {};
 		autoDetectedFields = {};
 		showAllUnreachable = false;
+		aliveOffset = 0;
 
 		try {
 			const res = await api.post<ScanResponse>('/scanner/scan', {
@@ -389,7 +398,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each getAliveHosts() as host (host.ip)}
+						{#each getAliveHosts().slice(aliveOffset, aliveOffset + aliveLimit) as host (host.ip)}
 							{@const autoFields = autoDetectedFields[host.ip] || new Set<string>()}
 							<tr class="border-b border-border hover:bg-bg/50 transition-colors">
 								<td class="px-3 py-2">
@@ -529,8 +538,20 @@
 								</tr>
 							{/if}
 					</tbody>
-				</table>
-			</div>
+					</table>
+				</div>
+
+				{#if getAliveHosts().length > aliveLimit}
+					<p class="text-xs text-muted italic mt-1 mb-1">{m['scanner.Large Range Hint']()}</p>
+				{/if}
+
+				<Pagination
+					total={getAliveHosts().length}
+					limit={aliveLimit}
+					offset={aliveOffset}
+					onPageChange={(o) => (aliveOffset = o)}
+					onPageSizeChange={(n) => { aliveLimit = n; aliveOffset = 0; }}
+				/>
 		{:else}
 			<div class="bg-surface border border-border rounded-lg">
 				<EmptyState


### PR DESCRIPTION
Resolves #100 (split out of #70). The other 9 sub-items of #70 were resolved by parallel PRs; this performance item is the last one.

## Problem
The alive-hosts table rendered every alive host in one pass. Each row is heavy — 4 bound inputs + a 9-option device-type `<select>` + 4 conditional auto-detected badges — so a `/22+` scan (1k+ hosts × that row weight) thrashed the DOM and stalled the page.

## Fix: client-side pagination
Per the discussion in #100, virtualization was ruled out (it conflicts with the per-row `bind:value` form controls — off-screen rows unmount and lose focus/state mid-edit). Instead, client-side pagination:

- `{#each getAliveHosts().slice(offset, offset+limit)}` — default 50/page
- `<Pagination>` component below the table (the same one used on all other list pages), **auto-hides when `total <= limit`** so a `/24` with ≤50 alive hosts behaves exactly as before
- form state lives in `Record<ip, value>` maps keyed by IP → paging loses **no edits** (the maps are independent of which slice is rendered)
- a large-range hint points users to the async scan-task API when results exceed one page (quick scan was never meant for `/22+`; that's what tasks are for)
- `startScan` resets `aliveOffset` to 0

## Acceptance (from #100)
- [x] `/22` scan no longer stalls (paginated)
- [x] `/24` behavior unchanged (pagination bar hidden when ≤50 alive hosts)

## Verification
- `npm test`: 181/181 pass
- `svelte-check`: 45 errors / 103 warnings — **identical to main baseline** (zero new errors)
- New i18n key `scanner.Large Range Hint` (en + zh)

🤖 Generated with [ZCode](https://zcode.dev)