### PR TITLE
chore(deploy): OpenWrt deploy polish — ARMv7 build target, init dedup (#37)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-s -w -X mibee-steward/internal/version.Version=$(VERSION)
 BUILD_DIR=bin
 
-.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan clean test dev migrate-up sync-fingerprints sync-device-types fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
+.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan build-linux-amd64 build-linux-arm64 build-linux-arm clean test dev migrate-up sync-fingerprints sync-device-types fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
 
 all: build
 
@@ -24,12 +24,19 @@ build-all: build-frontend sync-device-types
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/server/
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/server/
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm ./cmd/server/
 
 build-linux-amd64: sync-device-types
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/server/
 
 build-linux-arm64: sync-device-types
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/server/
+
+# ARM 32-bit (ARMv7) — targets older ARM routers/boards (GL.iNet AR300, etc.).
+# GOARM=7 is the modern soft-float baseline; the README's cross-compile section
+# documents this arch for OpenWrt form B/C. MIPS is NOT supported (modernc/libc).
+build-linux-arm: sync-device-types
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm ./cmd/server/
 
 # Build with the eBPF passive observer enabled. Requires clang/llvm/bpftool
 # and kernel BTF on the build host; produces a binary that, at runtime, needs

--- a/deploy/openwrt/README.md
+++ b/deploy/openwrt/README.md
@@ -35,6 +35,17 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
 
 `GOARCH=arm` (32-bit, GOARM=7) also works for older ARM boards. `GOARCH=mips*` does **not** (see above).
 
+The repo's Makefile has cross-compile targets for all three supported archs —
+prefer these over the raw `go build` above (they run the device-type sync the
+embed step needs):
+
+```bash
+make build-linux-amd64   # x86_64 (generic Linux host)
+make build-linux-arm64   # ARMv8 (GL.iNet MT3000, ipq807x, mt798x)
+make build-linux-arm     # ARMv7 32-bit (older ARM boards)
+make build-all           # all three at once (server binary each)
+```
+
 ## Install (form B — agent → remote center)
 
 ```bash

--- a/deploy/openwrt/mibee-agent.init
+++ b/deploy/openwrt/mibee-agent.init
@@ -33,7 +33,6 @@
 USE_PROCD=1
 
 START=95  # after network + dnsmasq
-USE_PROCD=1
 
 BINARY=/usr/bin/mibee-agent
 CONFIG=/etc/mibee/agent.yaml

--- a/deploy/openwrt/mibee-steward.init
+++ b/deploy/openwrt/mibee-steward.init
@@ -44,7 +44,6 @@
 USE_PROCD=1
 
 START=95  # after network + dnsmasq (START=60) so the center sees a populated ARP table at boot
-USE_PROCD=1
 
 BINARY=/usr/bin/mibee-steward
 CONFIG=/etc/mibee/config.yaml


### PR DESCRIPTION
Closes the **non-hardware** follow-ups on #37 (OpenWrt router deployment, form B/C). The packaging + docs landed in PR #31; the issue's remaining open item is **real-ARM-router validation**, which needs physical hardware I don't have. This PR handles the code/config edges that *don't* need hardware.

## Changes

- **Makefile**: add `build-linux-arm` (`GOOS=linux GOARCH=arm GOARM=7`) and fold it into `build-all`. The README and init scripts already documented ARMv7 32-bit as supported, but there was no `make` target — operators had to hand-roll the `go build`. **Verified**: produces a stripped static ELF 32-bit ARM EABI5 binary.
- **`deploy/openwrt/mibee-steward.init` / `mibee-agent.init`**: drop the duplicated `USE_PROCD=1` line (appeared twice in both procd scripts — harmless but redundant). `sh -n` passes on both.
- **`deploy/openwrt/README.md`**: document the `make build-linux-*` cross-compile targets so users reach for `make` instead of raw `go build` (the make targets also run the device-type sync the embed step needs).

## What this does NOT do
- **Real ARM-router validation** — still needs physical hardware (GL.iNet MT3000 / ipq807x / mt798x). #37 stays open for that.
- **Official .ipk packaging** (OpenWrt buildroot `golang-package` macros) — explicitly a separate follow-up, not tracked on #37.
- **MIPS support** — structural (`modernc/libc`); would require swapping the SQLite backend.

## Verification
- `make build-linux-arm` → `file` confirms `ELF 32-bit LSB executable, ARM, EABI5, statically linked, stripped`
- `sh -n` on both init scripts passes

🤖 Generated with [ZCode](https://zcode.dev)