### PR TITLE
fix(web): hide scanner pagination bar when results fit one page (#100)

### DIFF
--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -543,15 +543,14 @@
 
 				{#if getAliveHosts().length > aliveLimit}
 					<p class="text-xs text-muted italic mt-1 mb-1">{m['scanner.Large Range Hint']()}</p>
+					<Pagination
+						total={getAliveHosts().length}
+						limit={aliveLimit}
+						offset={aliveOffset}
+						onPageChange={(o) => (aliveOffset = o)}
+						onPageSizeChange={(n) => { aliveLimit = n; aliveOffset = 0; }}
+					/>
 				{/if}
-
-				<Pagination
-					total={getAliveHosts().length}
-					limit={aliveLimit}
-					offset={aliveOffset}
-					onPageChange={(o) => (aliveOffset = o)}
-					onPageSizeChange={(n) => { aliveLimit = n; aliveOffset = 0; }}
-				/>
 		{:else}
 			<div class="bg-surface border border-border rounded-lg">
 				<EmptyState


### PR DESCRIPTION
Follow-up to #110, caught by browser testing.

## Bug
The pagination bar (rows-per-page selector + disabled prev/next) was rendering even for small result sets (e.g. 2 alive hosts). Root cause: `<Pagination>`'s `showBar = total > limit || onPageSizeChange` renders whenever `onPageSizeChange` is passed, regardless of `total <= limit`. Since #110 passed `onPageSizeChange`, the bar showed on a 2-row table — regressing the #100 acceptance criterion "existing /24 behavior unchanged".

## Fix
Gate the entire `<Pagination>` + large-range hint behind the same `{#if getAliveHosts().length > aliveLimit}` so both only render when results actually overflow one page. Small result sets show the table alone, as before.

## Verification
- `npm test`: 187/187 pass
- `svelte-check`: 45/103 — identical to baseline
- **Browser**: verified on the test env — before this fix a 2-host /29 scan showed the pagination bar; this is the regression being fixed

🤖 Generated with [ZCode](https://zcode.dev)