### PR TITLE
feat(identity): key satellite tables + heartbeat target by device_uuid

### DIFF
--- a/db/queries/devices.sql
+++ b/db/queries/devices.sql
@@ -9,19 +9,19 @@
 
 -- name: CreateDevice :one
 INSERT INTO devices (
-    name, type, brand, model, location, purpose, description,
+    device_uuid, name, type, brand, model, location, purpose, description,
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
 
 -- name: GetDevice :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE id = ?;
 
 -- name: ListDevices :many
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -46,7 +46,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
 
 -- name: UpdateUserAttributes :exec
 UPDATE devices SET user_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?;
@@ -97,7 +97,7 @@ SET scan_source = ?, prometheus_labels = ?, last_scanned_at = ?, last_scan_task_
 WHERE id = ?;
 
 -- name: GetDeviceByIP :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1;
@@ -107,7 +107,7 @@ LIMIT 1;
 -- both fresh installs (which have the scan_mac generated column) and upgraded
 -- DBs (which have an expression index on json_extract instead). The expression
 -- index idx_devices_scan_mac_expr covers this WHERE clause on either shape.
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1;

--- a/db/queries/host_tls_certs.sql
+++ b/db/queries/host_tls_certs.sql
@@ -13,12 +13,16 @@ WHERE ip = ?
 ORDER BY port ASC, cert_index ASC;
 
 -- name: ListTLSCertsByDeviceID :many
--- Join through devices (composite-unique on (ip_address, network_id) means a
--- device's IP is its cert lookup key). Includes certs from every port on the
--- device, ordered for stable UI display (port, then chain order).
+-- Join through devices on device_uuid so certs follow the device across a DHCP
+-- roam (a device's IP is NOT stable, so the old ip-based join stranded the cert
+-- rows on the pre-roam IP). Transition rows with empty device_uuid fall back to
+-- the IP join. Ordered for stable UI display (port, then chain order).
 SELECT c.*
 FROM host_tls_certs AS c
-JOIN devices AS d ON d.ip_address = c.ip
+JOIN devices AS d ON (
+    (d.device_uuid != '' AND c.device_uuid = d.device_uuid)
+    OR (c.device_uuid = '' AND c.ip = d.ip_address)
+)
 WHERE d.id = ?
 ORDER BY c.port ASC, c.cert_index ASC;
 

--- a/db/queries/scan_snapshots.sql
+++ b/db/queries/scan_snapshots.sql
@@ -10,6 +10,16 @@
 -- name: UpsertScanSnapshot :exec
 -- Mark an IP as seen in this scan: insert or reset miss_count to 0 + refresh
 -- last_seen_at. Called for every alive host in a scan.
+--
+-- NOTE: this query is intentionally a sqlc query ONLY in its simplest form.
+-- The version that also writes device_uuid + CASE WHEN clauses in the ON
+-- CONFLICT DO UPDATE is implemented as raw SQL in
+-- internal/service/scannerv2/runner/detect_lost.go (Runner.upsertScanSnapshot),
+-- because sqlc's SQLite parser truncates the trailing bytes of the ON CONFLICT
+-- clause when it contains a CASE WHEN on excluded.device_uuid (the same
+-- documented parser bug that forced ListStaleAgentSnapshots to raw SQL). The
+-- raw-SQL path is what Runner.RecordAliveSnapshots calls; this sqlc query is
+-- retained for any other caller but the device_uuid write is NOT done here.
 INSERT INTO scan_snapshots (network_id, task_id, ip, mac, miss_count, last_seen_at)
 VALUES (?, ?, ?, ?, 0, ?)
 ON CONFLICT(network_id, ip) DO UPDATE SET

--- a/internal/api/routes/scanner_integration_test.go
+++ b/internal/api/routes/scanner_integration_test.go
@@ -37,6 +37,7 @@ func newTestDB(t *testing.T) *sql.DB {
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			ip_address TEXT,
 			type TEXT DEFAULT 'unknown',

--- a/internal/db/devices.sql.go
+++ b/internal/db/devices.sql.go
@@ -189,14 +189,15 @@ func (q *Queries) CountDevicesByTypeForNetwork(ctx context.Context, arg CountDev
 const createDevice = `-- name: CreateDevice :one
 
 INSERT INTO devices (
-    name, type, brand, model, location, purpose, description,
+    device_uuid, name, type, brand, model, location, purpose, description,
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 `
 
 type CreateDeviceParams struct {
+	DeviceUuid     string `json:"device_uuid"`
 	Name           string `json:"name"`
 	Type           string `json:"type"`
 	Brand          string `json:"brand"`
@@ -224,6 +225,7 @@ type CreateDeviceParams struct {
 // for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Device, error) {
 	row := q.db.QueryRowContext(ctx, createDevice,
+		arg.DeviceUuid,
 		arg.Name,
 		arg.Type,
 		arg.Brand,
@@ -243,6 +245,7 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 	var i Device
 	err := row.Scan(
 		&i.ID,
+		&i.DeviceUuid,
 		&i.Name,
 		&i.Type,
 		&i.Brand,
@@ -295,7 +298,7 @@ func (q *Queries) DeleteDevice(ctx context.Context, id int64) (int64, error) {
 }
 
 const getDevice = `-- name: GetDevice :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE id = ?
 `
@@ -305,6 +308,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 	var i Device
 	err := row.Scan(
 		&i.ID,
+		&i.DeviceUuid,
 		&i.Name,
 		&i.Type,
 		&i.Brand,
@@ -344,7 +348,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 }
 
 const getDeviceByIP = `-- name: GetDeviceByIP :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1
@@ -355,6 +359,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 	var i Device
 	err := row.Scan(
 		&i.ID,
+		&i.DeviceUuid,
 		&i.Name,
 		&i.Type,
 		&i.Brand,
@@ -394,7 +399,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 }
 
 const getDeviceByMAC = `-- name: GetDeviceByMAC :one
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1
@@ -409,6 +414,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 	var i Device
 	err := row.Scan(
 		&i.ID,
+		&i.DeviceUuid,
 		&i.Name,
 		&i.Type,
 		&i.Brand,
@@ -448,7 +454,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 }
 
 const listDevices = `-- name: ListDevices :many
-SELECT id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -483,6 +489,7 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 		var i Device
 		if err := rows.Scan(
 			&i.ID,
+			&i.DeviceUuid,
 			&i.Name,
 			&i.Type,
 			&i.Brand,
@@ -601,7 +608,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
 `
 
 type UpdateDeviceParams struct {
@@ -646,6 +653,7 @@ func (q *Queries) UpdateDevice(ctx context.Context, arg UpdateDeviceParams) (Dev
 	var i Device
 	err := row.Scan(
 		&i.ID,
+		&i.DeviceUuid,
 		&i.Name,
 		&i.Type,
 		&i.Brand,

--- a/internal/db/host_tls_certs.sql.go
+++ b/internal/db/host_tls_certs.sql.go
@@ -35,7 +35,7 @@ func (q *Queries) DeleteHostTLSCertsStaleBatched(ctx context.Context, arg Delete
 }
 
 const listTLSCertsByDeviceID = `-- name: ListTLSCertsByDeviceID :many
-SELECT c.id, c.ip, c.port, c.cert_index, c.subject_cn, c.subject_org, c.subject, c.issuer_cn, c.issuer_org, c.issuer, c.san_dns, c.san_ip, c.san_email, c.serial, c.not_before, c.not_after, c.sig_algorithm, c.key_algorithm, c.key_bits, c.is_ca, c.self_signed, c.fingerprint_sha256, c.pem, c.tls_version, c.cipher_suite, c.trusted, c.error, c.updated_at
+SELECT c.id, c.ip, c.device_uuid, c.port, c.cert_index, c.subject_cn, c.subject_org, c.subject, c.issuer_cn, c.issuer_org, c.issuer, c.san_dns, c.san_ip, c.san_email, c.serial, c.not_before, c.not_after, c.sig_algorithm, c.key_algorithm, c.key_bits, c.is_ca, c.self_signed, c.fingerprint_sha256, c.pem, c.tls_version, c.cipher_suite, c.trusted, c.error, c.updated_at
 FROM host_tls_certs AS c
 JOIN devices AS d ON d.ip_address = c.ip
 WHERE d.id = ?
@@ -57,6 +57,7 @@ func (q *Queries) ListTLSCertsByDeviceID(ctx context.Context, id int64) ([]HostT
 		if err := rows.Scan(
 			&i.ID,
 			&i.Ip,
+			&i.DeviceUuid,
 			&i.Port,
 			&i.CertIndex,
 			&i.SubjectCn,
@@ -99,7 +100,7 @@ func (q *Queries) ListTLSCertsByDeviceID(ctx context.Context, id int64) ([]HostT
 
 const listTLSCertsByIP = `-- name: ListTLSCertsByIP :many
 
-SELECT id, ip, port, cert_index, subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer, san_dns, san_ip, san_email, serial, not_before, not_after, sig_algorithm, key_algorithm, key_bits, is_ca, self_signed, fingerprint_sha256, pem, tls_version, cipher_suite, trusted, error, updated_at FROM host_tls_certs
+SELECT id, ip, device_uuid, port, cert_index, subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer, san_dns, san_ip, san_email, serial, not_before, not_after, sig_algorithm, key_algorithm, key_bits, is_ca, self_signed, fingerprint_sha256, pem, tls_version, cipher_suite, trusted, error, updated_at FROM host_tls_certs
 WHERE ip = ?
 ORDER BY port ASC, cert_index ASC
 `
@@ -124,6 +125,7 @@ func (q *Queries) ListTLSCertsByIP(ctx context.Context, ip string) ([]HostTlsCer
 		if err := rows.Scan(
 			&i.ID,
 			&i.Ip,
+			&i.DeviceUuid,
 			&i.Port,
 			&i.CertIndex,
 			&i.SubjectCn,

--- a/internal/db/host_tls_certs.sql.go
+++ b/internal/db/host_tls_certs.sql.go
@@ -37,14 +37,18 @@ func (q *Queries) DeleteHostTLSCertsStaleBatched(ctx context.Context, arg Delete
 const listTLSCertsByDeviceID = `-- name: ListTLSCertsByDeviceID :many
 SELECT c.id, c.ip, c.device_uuid, c.port, c.cert_index, c.subject_cn, c.subject_org, c.subject, c.issuer_cn, c.issuer_org, c.issuer, c.san_dns, c.san_ip, c.san_email, c.serial, c.not_before, c.not_after, c.sig_algorithm, c.key_algorithm, c.key_bits, c.is_ca, c.self_signed, c.fingerprint_sha256, c.pem, c.tls_version, c.cipher_suite, c.trusted, c.error, c.updated_at
 FROM host_tls_certs AS c
-JOIN devices AS d ON d.ip_address = c.ip
+JOIN devices AS d ON (
+    (d.device_uuid != '' AND c.device_uuid = d.device_uuid)
+    OR (c.device_uuid = '' AND c.ip = d.ip_address)
+)
 WHERE d.id = ?
 ORDER BY c.port ASC, c.cert_index ASC
 `
 
-// Join through devices (composite-unique on (ip_address, network_id) means a
-// device's IP is its cert lookup key). Includes certs from every port on the
-// device, ordered for stable UI display (port, then chain order).
+// Join through devices on device_uuid so certs follow the device across a DHCP
+// roam (a device's IP is NOT stable, so the old ip-based join stranded the cert
+// rows on the pre-roam IP). Transition rows with empty device_uuid fall back to
+// the IP join. Ordered for stable UI display (port, then chain order).
 func (q *Queries) ListTLSCertsByDeviceID(ctx context.Context, id int64) ([]HostTlsCert, error) {
 	rows, err := q.db.QueryContext(ctx, listTLSCertsByDeviceID, id)
 	if err != nil {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -68,6 +68,7 @@ type DashboardConfig struct {
 
 type Device struct {
 	ID               int64      `json:"id"`
+	DeviceUuid       string     `json:"device_uuid"`
 	Name             string     `json:"name"`
 	Type             string     `json:"type"`
 	Brand            string     `json:"brand"`
@@ -185,6 +186,7 @@ type HeartbeatResult struct {
 type HostService struct {
 	ID         int64     `json:"id"`
 	Ip         string    `json:"ip"`
+	DeviceUuid string    `json:"device_uuid"`
 	Service    string    `json:"service"`
 	Port       int64     `json:"port"`
 	Protocol   string    `json:"protocol"`
@@ -196,6 +198,7 @@ type HostService struct {
 type HostTlsCert struct {
 	ID                int64     `json:"id"`
 	Ip                string    `json:"ip"`
+	DeviceUuid        string    `json:"device_uuid"`
 	Port              int64     `json:"port"`
 	CertIndex         int64     `json:"cert_index"`
 	SubjectCn         string    `json:"subject_cn"`
@@ -280,13 +283,16 @@ type ScanResult struct {
 }
 
 type ScanSnapshot struct {
-	ID         int64     `json:"id"`
-	NetworkID  int64     `json:"network_id"`
-	TaskID     *int64    `json:"task_id"`
-	Ip         string    `json:"ip"`
-	Mac        string    `json:"mac"`
-	MissCount  int64     `json:"miss_count"`
-	LastSeenAt time.Time `json:"last_seen_at"`
+	ID         int64      `json:"id"`
+	NetworkID  int64      `json:"network_id"`
+	TaskID     *int64     `json:"task_id"`
+	Ip         string     `json:"ip"`
+	Mac        string     `json:"mac"`
+	DeviceUuid string     `json:"device_uuid"`
+	MissCount  int64      `json:"miss_count"`
+	LastSeenAt time.Time  `json:"last_seen_at"`
+	FlapCount  int64      `json:"flap_count"`
+	LastFlapAt *time.Time `json:"last_flap_at"`
 }
 
 type ScanTask struct {
@@ -324,6 +330,7 @@ type ScanTaskRun struct {
 type ServiceEvidence struct {
 	ID         int64     `json:"id"`
 	Ip         string    `json:"ip"`
+	DeviceUuid string    `json:"device_uuid"`
 	Source     string    `json:"source"`
 	Kind       string    `json:"kind"`
 	Port       int64     `json:"port"`

--- a/internal/db/scan_snapshots.sql.go
+++ b/internal/db/scan_snapshots.sql.go
@@ -183,6 +183,16 @@ type UpsertScanSnapshotParams struct {
 // for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 // Mark an IP as seen in this scan: insert or reset miss_count to 0 + refresh
 // last_seen_at. Called for every alive host in a scan.
+//
+// NOTE: this query is intentionally a sqlc query ONLY in its simplest form.
+// The version that also writes device_uuid + CASE WHEN clauses in the ON
+// CONFLICT DO UPDATE is implemented as raw SQL in
+// internal/service/scannerv2/runner/detect_lost.go (Runner.upsertScanSnapshot),
+// because sqlc's SQLite parser truncates the trailing bytes of the ON CONFLICT
+// clause when it contains a CASE WHEN on excluded.device_uuid (the same
+// documented parser bug that forced ListStaleAgentSnapshots to raw SQL). The
+// raw-SQL path is what Runner.RecordAliveSnapshots calls; this sqlc query is
+// retained for any other caller but the device_uuid write is NOT done here.
 func (q *Queries) UpsertScanSnapshot(ctx context.Context, arg UpsertScanSnapshotParams) error {
 	_, err := q.db.ExecContext(ctx, upsertScanSnapshot,
 		arg.NetworkID,

--- a/internal/db/scan_snapshots.sql.go
+++ b/internal/db/scan_snapshots.sql.go
@@ -110,18 +110,28 @@ FROM scan_snapshots
 WHERE network_id = ?
 `
 
+type ListSnapshotsForNetworkRow struct {
+	ID         int64     `json:"id"`
+	NetworkID  int64     `json:"network_id"`
+	TaskID     *int64    `json:"task_id"`
+	Ip         string    `json:"ip"`
+	Mac        string    `json:"mac"`
+	MissCount  int64     `json:"miss_count"`
+	LastSeenAt time.Time `json:"last_seen_at"`
+}
+
 // All snapshots for a network (the known alive set). Used to compute the set
 // difference: which of these did NOT appear in the current scan, then
 // increment their miss_count (done in Go since the IN-list is dynamic).
-func (q *Queries) ListSnapshotsForNetwork(ctx context.Context, networkID int64) ([]ScanSnapshot, error) {
+func (q *Queries) ListSnapshotsForNetwork(ctx context.Context, networkID int64) ([]ListSnapshotsForNetworkRow, error) {
 	rows, err := q.db.QueryContext(ctx, listSnapshotsForNetwork, networkID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ScanSnapshot{}
+	items := []ListSnapshotsForNetworkRow{}
 	for rows.Next() {
-		var i ScanSnapshot
+		var i ListSnapshotsForNetworkRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.NetworkID,

--- a/internal/repository/device.go
+++ b/internal/repository/device.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
 )
@@ -48,6 +50,7 @@ func (r *DeviceRepository) Create(ctx context.Context, req domain.CreateDeviceRe
 	}
 
 	device, err := r.queries.CreateDevice(ctx, db.CreateDeviceParams{
+		DeviceUuid:     uuid.NewString(),
 		Name:           req.Name,
 		Type:           deviceType,
 		Brand:          req.Brand,

--- a/internal/repository/device_attributes_test.go
+++ b/internal/repository/device_attributes_test.go
@@ -23,6 +23,7 @@ func setupAttributesTestDB(t *testing.T) (*DeviceRepository, *sql.DB, int64) {
 	_, err = conn.Exec(`
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other',
 			brand TEXT NOT NULL DEFAULT '',
@@ -147,6 +148,7 @@ func TestCreateDeviceRejectsInvalidUserAttributes(t *testing.T) {
 	_, err = conn.Exec(`
 		CREATE TABLE devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other',
 			status TEXT NOT NULL DEFAULT 'unknown',

--- a/internal/repository/device_system_test.go
+++ b/internal/repository/device_system_test.go
@@ -25,6 +25,7 @@ func setupDeviceSystemTestDB(t *testing.T) (*DeviceSystemRepository, *sql.DB, in
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other' CHECK(type IN ('pc', 'embedded', 'iot', 'other', 'server', 'switch', 'router', 'firewall', 'nas')),
 			brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/batch_test.go
+++ b/internal/service/batch_test.go
@@ -28,6 +28,7 @@ func setupBatchTestDB(t *testing.T) *sql.DB {
 const batchSchemaSQL = `
 CREATE TABLE IF NOT EXISTS devices (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_uuid TEXT NOT NULL DEFAULT '',
     name TEXT NOT NULL DEFAULT '',
     type TEXT NOT NULL DEFAULT 'other',
     brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/device_system_test.go
+++ b/internal/service/device_system_test.go
@@ -24,6 +24,7 @@ func setupDeviceSystemService(t *testing.T) (*DeviceSystemService, *sql.DB, int6
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other' CHECK(type IN ('pc', 'embedded', 'iot', 'other', 'server', 'switch', 'router', 'firewall', 'nas')),
 			brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -30,6 +30,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *sql.DB) {
 		);
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other' CHECK(type IN ('pc', 'embedded', 'iot', 'other', 'server', 'switch', 'router', 'firewall', 'nas')),
 			brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -28,6 +28,7 @@ func setupExportTest(t *testing.T) (*ExportService, *sql.DB) {
 	_, err = dbConn.Exec(`
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL DEFAULT '',
 			type TEXT NOT NULL DEFAULT '',
 			brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -14,6 +14,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -250,33 +252,52 @@ func GetProber(method, community, oid string) probe.Prober {
 // Defined as raw SQL (not sqlc) because sqlc's SQLite parser truncates queries
 // whose WHERE clause contains an empty-string literal (”) — see the NOTE in
 // db/queries/heartbeat_configs.sql.
+//
+// d.ip_address is selected so the prober can dereference the device's CURRENT IP
+// at probe time (see probeAndRecord): the config's target string embeds the IP
+// frozen at config-creation time, so without this a device that DHCP-roamed to a
+// new IP would be probed at its dead old address forever. The prober substitutes
+// the device's live ip_address into the target, so a roam is picked up on the
+// very next tick with no config rewrite needed.
 const listLocalProbeConfigsSQL = `SELECT hc.id, hc.device_id, hc.method, hc.target,
        hc.interval_seconds, hc.timeout_seconds, hc.snmp_community, hc.snmp_oid,
-       hc.enabled, hc.created_at, hc.updated_at
+       hc.enabled, hc.created_at, hc.updated_at,
+       d.ip_address AS device_ip
 FROM heartbeat_configs hc
 JOIN devices d ON d.id = hc.device_id
 LEFT JOIN networks n ON n.id = d.network_id
 WHERE hc.enabled = 1
   AND (n.agent_id IS NULL OR n.agent_id = '')`
 
+// probeConfig wraps a heartbeat config row with the device's CURRENT ip_address
+// (resolved fresh every tick from the devices table), so the prober targets the
+// live address instead of the IP frozen in hc.target at config-creation time.
+type probeConfig struct {
+	db.HeartbeatConfig
+	DeviceIP string
+}
+
 // listLocalProbeConfigs returns the enabled heartbeat configs the center should
 // probe locally this tick (excludes agent-managed-network devices).
-func (s *HeartbeatService) listLocalProbeConfigs(ctx context.Context) ([]db.HeartbeatConfig, error) {
+func (s *HeartbeatService) listLocalProbeConfigs(ctx context.Context) ([]probeConfig, error) {
 	rows, err := s.mainDB.QueryContext(ctx, listLocalProbeConfigsSQL)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var out []db.HeartbeatConfig
+	var out []probeConfig
 	for rows.Next() {
-		var c db.HeartbeatConfig
+		var c probeConfig
+		var deviceIP sql.NullString
 		if err := rows.Scan(
 			&c.ID, &c.DeviceID, &c.Method, &c.Target,
 			&c.IntervalSeconds, &c.TimeoutSeconds, &c.SnmpCommunity, &c.SnmpOid,
 			&c.Enabled, &c.CreatedAt, &c.UpdatedAt,
+			&deviceIP,
 		); err != nil {
 			return nil, err
 		}
+		c.DeviceIP = deviceIP.String
 		out = append(out, c)
 	}
 	return out, rows.Err()
@@ -300,15 +321,15 @@ func (s *HeartbeatService) runChecks(ctx context.Context) {
 	// so per-config isDue would sometimes include only the failing config in a
 	// tick, making OR-aggregation see an all-fail that's really just one stale
 	// config. Device-level due + probe-all-configs keeps the OR verdict honest.
-	allByDevice := make(map[int64][]db.HeartbeatConfig)
+	allByDevice := make(map[int64][]probeConfig)
 	deviceDue := make(map[int64]bool)
 	for _, cfg := range configs {
 		allByDevice[cfg.DeviceID] = append(allByDevice[cfg.DeviceID], cfg)
-		if !deviceDue[cfg.DeviceID] && s.isDue(ctx, cfg) {
+		if !deviceDue[cfg.DeviceID] && s.isDue(ctx, cfg.HeartbeatConfig) {
 			deviceDue[cfg.DeviceID] = true
 		}
 	}
-	byDevice := make(map[int64][]db.HeartbeatConfig)
+	byDevice := make(map[int64][]probeConfig)
 	// Offline-device backoff: a device already marked offline in the in-memory
 	// statusCache is probed only every offlineBackoff ticks (not every tick).
 	// This stops known-dead hosts from generating a steady stream of timeout
@@ -354,7 +375,7 @@ func (s *HeartbeatService) runChecks(ctx context.Context) {
 	var wg sync.WaitGroup
 	for deviceID, cfgs := range byDevice {
 		wg.Add(1)
-		go func(deviceID int64, cfgs []db.HeartbeatConfig) {
+		go func(deviceID int64, cfgs []probeConfig) {
 			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
@@ -377,7 +398,7 @@ func (s *HeartbeatService) runChecks(ctx context.Context) {
 // — the root cause of the persistent fleet-wide online/offline flapping.
 // Devices still run concurrently (maxConcurrency), so a fleet of 84 finishes in
 // ~2 batches; serializing 1-3 quick probes per device adds negligible latency.
-func (s *HeartbeatService) checkDevice(ctx context.Context, deviceID int64, cfgs []db.HeartbeatConfig) {
+func (s *HeartbeatService) checkDevice(ctx context.Context, deviceID int64, cfgs []probeConfig) {
 	anySuccess := false
 	for _, cfg := range cfgs {
 		if s.probeAndRecord(ctx, cfg) {
@@ -389,7 +410,13 @@ func (s *HeartbeatService) checkDevice(ctx context.Context, deviceID int64, cfgs
 
 // probeAndRecord runs a single config (with retry), writes the result row, and
 // reports whether the probe succeeded.
-func (s *HeartbeatService) probeAndRecord(ctx context.Context, cfg db.HeartbeatConfig) bool {
+//
+// DHCP-roam handling: the config's target was frozen at config-creation time
+// (it embeds the device's then-current IP). resolveLiveTarget substitutes the
+// device's CURRENT ip_address (cfg.DeviceIP, read fresh this tick) into the
+// target, so a device that roamed is probed at its live address on the very next
+// tick — no config rewrite, no roam hook.
+func (s *HeartbeatService) probeAndRecord(ctx context.Context, cfg probeConfig) bool {
 	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 5 * time.Second
@@ -406,7 +433,8 @@ func (s *HeartbeatService) probeAndRecord(ctx context.Context, cfg db.HeartbeatC
 	s.lastProbeMu.Lock()
 	s.lastProbe[cfg.ID] = time.Now()
 	s.lastProbeMu.Unlock()
-	result, err := prober.Probe(ctx, cfg.Target, timeout)
+	liveTarget := resolveLiveTarget(cfg.Target, cfg.DeviceIP)
+	result, err := prober.Probe(ctx, liveTarget, timeout)
 	if err != nil {
 		slog.Error("heartbeat probe error", "config_id", cfg.ID, "error", err)
 		// A transport-level error counts as a failure for aggregation.
@@ -792,4 +820,54 @@ func toHeartbeatResultResponse(r db.HeartbeatResult) domain.HeartbeatResultRespo
 		ErrorMessage: r.ErrorMessage,
 		CheckedAt:    r.CheckedAt,
 	}
+}
+
+// resolveLiveTarget substitutes the device's CURRENT ip_address into a frozen
+// heartbeat target string. The target was captured at config-creation time and
+// embeds the device's then-current IP; when the device DHCP-roams, the frozen IP
+// goes dead and the heartbeat would forever probe the wrong address. This makes
+// every tick use the device's live IP instead, with no config rewrite needed.
+//
+// Recognized target shapes (all produced by the scanner's heartbeat handlers):
+//   - bare host      : "192.168.1.10"              (icmp, snmp)
+//   - host:port      : "192.168.1.10:80"           (tcp)
+//   - scheme://h:p/..: "http://192.168.1.10:80/"   (http, onvif, cascade)
+//
+// When deviceIP is empty (the device somehow lost its IP — shouldn't happen for
+// an online device), the original frozen target is returned unchanged so the
+// probe at least attempts the old address rather than an empty string.
+//
+// The substitution preserves everything except the host: the port, scheme, path,
+// and query stay intact. For bare-host targets the whole string is replaced.
+func resolveLiveTarget(frozenTarget, deviceIP string) string {
+	if deviceIP == "" || frozenTarget == "" {
+		return frozenTarget
+	}
+	// scheme://host[:port]/...  → parse, swap Host, re-render.
+	if strings.Contains(frozenTarget, "://") {
+		u, err := url.Parse(frozenTarget)
+		if err != nil || u.Host == "" {
+			return frozenTarget
+		}
+		// Preserve the port if the original host had one.
+		port := u.Port()
+		if port == "" {
+			u.Host = deviceIP
+		} else {
+			u.Host = deviceIP + ":" + port
+		}
+		return u.String()
+	}
+	// host:port (tcp targets). Split on the LAST colon so IPv6 bare hosts (rare
+	// on a LAN tool) aren't mis-split; if neither side parses as host/port the
+	// original is returned.
+	if strings.Count(frozenTarget, ":") == 1 {
+		idx := strings.IndexByte(frozenTarget, ':')
+		port := frozenTarget[idx+1:]
+		if port != "" {
+			return deviceIP + ":" + port
+		}
+	}
+	// Bare host (icmp/snmp): replace wholesale.
+	return deviceIP
 }

--- a/internal/service/heartbeat_target_test.go
+++ b/internal/service/heartbeat_target_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveLiveTarget covers the DHCP-roam fix: a heartbeat config's frozen
+// target must be rewritten to the device's CURRENT ip_address so a roamed
+// device is probed at its live address on the next tick. Each method's target
+// shape (bare host / host:port / scheme URL) is exercised.
+func TestResolveLiveTarget(t *testing.T) {
+	const frozen = "192.168.63.187"
+	const live = "192.168.63.60"
+
+	tests := []struct {
+		name   string
+		frozen string
+		live   string
+		want   string
+	}{
+		{"icmp bare host", frozen, live, live},
+		{"snmp bare host", frozen, live, live},
+		{"tcp host:port", "192.168.63.187:80", live, "192.168.63.60:80"},
+		{"http scheme url", "http://192.168.63.187:80/health", live, "http://192.168.63.60:80/health"},
+		{"https scheme url default port", "https://192.168.63.187/", live, "https://192.168.63.60/"},
+		{"onvif scheme url", "http://192.168.63.187:8080/onvif/device_service", live, "http://192.168.63.60:8080/onvif/device_service"},
+		{"no change when live empty (frozen kept)", frozen, "", frozen},
+		{"no change when both empty", "", "", ""},
+		{"url path + query preserved", "http://192.168.63.187:8080/path?q=1", live, "http://192.168.63.60:8080/path?q=1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveLiveTarget(tt.frozen, tt.live)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/service/heartbeat_test.go
+++ b/internal/service/heartbeat_test.go
@@ -37,6 +37,7 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 		);
 		CREATE TABLE IF NOT EXISTS devices (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
 			name TEXT NOT NULL,
 			type TEXT NOT NULL DEFAULT 'other' CHECK(type IN ('pc', 'embedded', 'iot', 'other', 'server', 'switch', 'router', 'firewall', 'nas')),
 			brand TEXT NOT NULL DEFAULT '',

--- a/internal/service/scannerv2/runner/detect_lost.go
+++ b/internal/service/scannerv2/runner/detect_lost.go
@@ -143,13 +143,13 @@ func (rn *Runner) RecordAliveSnapshots(ctx context.Context, networkID sql.NullIn
 			t := taskID
 			taskIDPtr = &t
 		}
-		if err := rn.queries.UpsertScanSnapshot(ctx, db.UpsertScanSnapshotParams{
-			NetworkID:  networkID.Int64,
-			TaskID:     taskIDPtr,
-			Ip:         rep.IP,
-			Mac:        mac,
-			LastSeenAt: now,
-		}); err != nil {
+		// Resolve the device's stable uuid so the snapshot row follows the device,
+		// not the IP. DetectLost runs AFTER applyDeviceBridge persisted the device
+		// (Run step 3 → step 3c), so the device row exists on the local-scan path;
+		// on the agent→center lease path a prior report already created it. An empty
+		// uuid (device somehow still absent) is healed on the next scan.
+		devUUID := rn.resolveDeviceUUIDForIP(ctx, rep.IP, networkID)
+		if err := rn.upsertScanSnapshot(ctx, networkID.Int64, taskIDPtr, rep.IP, mac, devUUID, now); err != nil {
 			rn.logger.Warn("record-alive-snapshots: upsert failed", "ip", rep.IP, "error", err)
 		}
 	}
@@ -203,4 +203,63 @@ func (rn *Runner) recordDeviceRecovered(ctx context.Context, deviceID int64, net
 		Before:     before,
 		After:      after,
 	})
+}
+
+// resolveDeviceUUIDForIP returns the stable device_uuid for an IP, scoped to
+// networkID when valid (mirrors the store's resolveDeviceUUID identity rule).
+// Returns "" on miss (the snapshot row gets device_uuid=” and is healed next
+// scan). Used by RecordAliveSnapshots so a scan_snapshots lease row keys on the
+// device's stable identity rather than its roaming-prone IP.
+func (rn *Runner) resolveDeviceUUIDForIP(ctx context.Context, ip string, networkID sql.NullInt64) string {
+	if rn.dbConn == nil {
+		return ""
+	}
+	var u string
+	var err error
+	if networkID.Valid {
+		err = rn.dbConn.QueryRowContext(ctx,
+			`SELECT device_uuid FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`,
+			ip, networkID.Int64).Scan(&u)
+		if err != nil {
+			// Fall back to any device with this IP (NULL-network / cross-network).
+			err = rn.dbConn.QueryRowContext(ctx,
+				`SELECT device_uuid FROM devices WHERE ip_address = ? LIMIT 1`, ip).Scan(&u)
+		}
+	} else {
+		err = rn.dbConn.QueryRowContext(ctx,
+			`SELECT device_uuid FROM devices WHERE ip_address = ? LIMIT 1`, ip).Scan(&u)
+	}
+	if err != nil {
+		return ""
+	}
+	return u
+}
+
+// upsertScanSnapshotRawSQL is the device_uuid-writing scan-snapshot upsert,
+// implemented as raw SQL because sqlc's SQLite parser truncates the trailing
+// bytes of the ON CONFLICT DO UPDATE clause when it contains a CASE WHEN on
+// excluded.device_uuid (the same documented parser bug that forced
+// ListStaleAgentSnapshots to raw SQL in lease_sweeper.go). The query is
+// otherwise identical to the sqlc UpsertScanSnapshot, plus the device_uuid
+// write + the CASE that preserves an existing uuid when the caller passes ”.
+//
+// CONFLICT target stays (network_id, ip): a DHCP roam (same network, new IP)
+// inserts a fresh row with miss_count 0, and lost detection + the lease sweeper
+// join through devices to follow the device by uuid, so the IP-keyed conflict
+// target is the correct choice here.
+func (rn *Runner) upsertScanSnapshot(ctx context.Context, networkID int64, taskID *int64, ip, mac, devUUID string, lastSeen time.Time) error {
+	if rn.dbConn == nil {
+		return nil
+	}
+	_, err := rn.dbConn.ExecContext(ctx, `
+		INSERT INTO scan_snapshots (network_id, task_id, ip, mac, device_uuid, miss_count, last_seen_at)
+		VALUES (?, ?, ?, ?, ?, 0, ?)
+		ON CONFLICT(network_id, ip) DO UPDATE SET
+			task_id = excluded.task_id,
+			mac = CASE WHEN excluded.mac != '' THEN excluded.mac ELSE scan_snapshots.mac END,
+			device_uuid = CASE WHEN excluded.device_uuid != '' THEN excluded.device_uuid ELSE scan_snapshots.device_uuid END,
+			miss_count = 0,
+			last_seen_at = excluded.last_seen_at`,
+		networkID, taskID, ip, mac, devUUID, lastSeen)
+	return err
 }

--- a/internal/service/scannerv2/runner/device_bridge.go
+++ b/internal/service/scannerv2/runner/device_bridge.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service/scannerv2"
@@ -656,17 +658,17 @@ func (rn *Runner) createDevice(ctx context.Context, devType, brand, descr, locat
 	scanAttrs := marshalScanAttributes(buildScanAttributes(rep))
 	now := time.Now().UTC()
 	res, err := rn.dbConn.ExecContext(ctx, `
-		INSERT INTO devices (name, type, brand, ip_address, mac_address,
+		INSERT INTO devices (device_uuid, name, type, brand, ip_address, mac_address,
 		                     status, scan_source, description, location,
 		                     open_ports, detected_services, prometheus_url, node_exporter_url,
 		                     scan_attributes, network_id, first_seen, last_seen,
 		                     tags, last_scan_rtt_ms, last_scanned_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?,
+		VALUES (?, ?, ?, ?, ?, ?,
 		        'online', 'scanner_v2', ?, ?,
 		        ?, ?, ?, ?,
 		        ?, ?, ?, ?,
 		        ?, ?, ?, ?, ?)`,
-		name, devType, brand, rep.IP, mac,
+		uuid.NewString(), name, devType, brand, rep.IP, mac,
 		descr, location,
 		ports, services, promURL, neURL,
 		scanAttrs, networkID, now, now,

--- a/internal/service/scannerv2/runner/lease_sweeper.go
+++ b/internal/service/scannerv2/runner/lease_sweeper.go
@@ -40,11 +40,21 @@ type staleAgentSnapshot struct {
 // path + the heartbeat service. The device JOIN + status='online' filter
 // mirrors ListLostSnapshots so an already-lost device is not re-emitted.
 //
+// The device JOIN is device_uuid-aware: when the snapshot row carries a uuid we
+// match the device by (device_uuid, network_id), which means a device that
+// DHCP-roamed to a new IP is STILL found from its stale pre-roam snapshot row
+// (the device's uuid is unchanged across the roam) — so a roam can't strand a
+// device's lease on the old IP. Transition rows with empty device_uuid fall back
+// to the IP join.
+//
 // Defined as raw SQL (not sqlc) because sqlc's SQLite parser truncates this
 // query's trailing bytes — see the NOTE in db/queries/scan_snapshots.sql.
 const staleAgentSnapshotsSQL = `SELECT s.id, s.network_id, s.ip, s.mac, s.last_seen_at, d.id, s.flap_count, s.last_flap_at
 FROM scan_snapshots s
-JOIN devices d ON d.ip_address = s.ip AND (d.network_id = s.network_id OR d.network_id IS NULL)
+JOIN devices d ON (
+	(s.device_uuid != '' AND d.device_uuid = s.device_uuid AND d.network_id = s.network_id)
+	OR (s.device_uuid = '' AND d.ip_address = s.ip AND (d.network_id = s.network_id OR d.network_id IS NULL))
+)
 JOIN networks n ON n.id = s.network_id
 WHERE n.agent_id IS NOT NULL AND n.agent_id != ''
   AND s.last_seen_at < ?
@@ -60,10 +70,14 @@ WHERE n.agent_id IS NOT NULL AND n.agent_id != ''
 // though the agent is actively reporting it alive again. This query finds those
 // stuck rows so sweepOnce can flip them back to online — closing the recovery
 // gap the stable-hash optimization opened. Same agent-only scope; the center's
-// own network recovers online via its own applyDeviceBridge scan path.
+// own network recovers online via its own applyDeviceBridge scan path. The
+// device_uuid-aware JOIN matches staleAgentSnapshotsSQL.
 const recoverableAgentSnapshotsSQL = `SELECT s.id, s.network_id, s.ip, s.mac, s.last_seen_at, d.id, s.flap_count, s.last_flap_at
 FROM scan_snapshots s
-JOIN devices d ON d.ip_address = s.ip AND (d.network_id = s.network_id OR d.network_id IS NULL)
+JOIN devices d ON (
+	(s.device_uuid != '' AND d.device_uuid = s.device_uuid AND d.network_id = s.network_id)
+	OR (s.device_uuid = '' AND d.ip_address = s.ip AND (d.network_id = s.network_id OR d.network_id IS NULL))
+)
 JOIN networks n ON n.id = s.network_id
 WHERE n.agent_id IS NOT NULL AND n.agent_id != ''
   AND s.last_seen_at >= ?

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -101,10 +101,22 @@ var _ scannerv2.Repository = (*SQLiteRepository)(nil)
 
 // RecordEvidence inserts raw evidence rows. Sampling: when persistRawEvidence
 // is false, the method is a no-op. Batches inserts in a single tx.
+//
+// device_uuid is resolved best-effort (the engine runs this BEFORE the runner
+// persists the device row, so on first discovery the device may not exist yet —
+// the row lands with device_uuid=” and is healed on the next scan / by the
+// backfill migration). Steady-state scans (the common case) find the device.
 func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.Evidence) error {
 	if !r.persistRawEvidence || len(evs) == 0 {
 		return nil
 	}
+	// Resolve once per call: all rows in a batch share the same IP, so a single
+	// lookup is enough. '' when unresolved (see method doc).
+	var uuid string
+	if len(evs) > 0 {
+		uuid, _ = r.resolveDeviceUUID(ctx, evs[0].IP)
+	}
+
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -112,8 +124,8 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 	defer tx.Rollback() //nolint:errcheck
 
 	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO service_evidence (ip, source, kind, port, protocol, raw_data, confidence, observed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+		INSERT INTO service_evidence (ip, device_uuid, source, kind, port, protocol, raw_data, confidence, observed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -128,7 +140,7 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 		if ts.IsZero() {
 			ts = time.Now()
 		}
-		if _, err := stmt.ExecContext(ctx, e.IP, e.Source, e.Kind, e.Port, e.Protocol, string(raw), e.Confidence, ts.UTC()); err != nil {
+		if _, err := stmt.ExecContext(ctx, e.IP, uuid, e.Source, e.Kind, e.Port, e.Protocol, string(raw), e.Confidence, ts.UTC()); err != nil {
 			r.logger.Debug("insert evidence row failed", "error", err)
 		}
 	}
@@ -136,23 +148,41 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 }
 
 // RecordServices replaces the host's service-identity set atomically.
+//
+// Keyed by device_uuid (resolved from IP) so the service list follows a device
+// across a DHCP roam instead of stranding on the old IP. On first discovery the
+// device row may not exist yet (the engine runs before the runner persists the
+// device); the rows land with device_uuid=” and are healed on the next scan.
+// The DELETE keeps an IP guard as a belt-and-suspenders so a not-yet-uuid'd row
+// set is still replaced rather than accumulated while the uuid is unresolved.
 func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, services []scannerv2.ServiceIdentity) error {
+	uuid, _ := r.resolveDeviceUUID(ctx, ip)
+
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ?`, ip); err != nil {
-		return err
+	// Replace the host's prior service set. When we have a uuid, scope the delete
+	// to it (the stable identity); otherwise fall back to IP so unresolved hosts
+	// still get a clean replace instead of unbounded row growth.
+	if uuid != "" {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE device_uuid = ?`, uuid); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ? AND device_uuid = ?`, ip, ""); err != nil {
+			return err
+		}
 	}
 	if len(services) == 0 {
 		return tx.Commit()
 	}
 
 	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO host_services (ip, service, port, protocol, confidence, metadata, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+		INSERT INTO host_services (ip, device_uuid, service, port, protocol, confidence, metadata, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -194,7 +224,7 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 		if err != nil {
 			meta = []byte("{}")
 		}
-		if _, err := stmt.ExecContext(ctx, ip, s.Service, s.Port, s.Protocol, s.Confidence, string(meta), now); err != nil {
+		if _, err := stmt.ExecContext(ctx, ip, uuid, s.Service, s.Port, s.Protocol, s.Confidence, string(meta), now); err != nil {
 			r.logger.Warn("insert host_service row failed", "ip", ip, "service", s.Service, "error", err)
 		}
 	}
@@ -214,6 +244,8 @@ func (r *SQLiteRepository) RecordTLSCerts(ctx context.Context, ip string, certs 
 	if len(certs) == 0 {
 		return nil
 	}
+	uuid, _ := r.resolveDeviceUUID(ctx, ip)
+
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -221,26 +253,34 @@ func (r *SQLiteRepository) RecordTLSCerts(ctx context.Context, ip string, certs 
 	defer tx.Rollback() //nolint:errcheck
 
 	// Collect the distinct ports in this batch; delete prior rows for each.
+	// Keyed by device_uuid when resolved (follows the device across a roam),
+	// else falls back to IP (unresolved first-discovery host).
 	ports := make(map[int]struct{}, len(certs))
 	for _, c := range certs {
 		ports[c.Port] = struct{}{}
 	}
 	for port := range ports {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE ip = ? AND port = ?`, ip, port); err != nil {
-			return err
+		if uuid != "" {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE device_uuid = ? AND port = ?`, uuid, port); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE ip = ? AND device_uuid = ? AND port = ?`, ip, "", port); err != nil {
+				return err
+			}
 		}
 	}
 
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO host_tls_certs (
-			ip, port, cert_index,
+			ip, device_uuid, port, cert_index,
 			subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer,
 			san_dns, san_ip, san_email, serial,
 			not_before, not_after,
 			sig_algorithm, key_algorithm, key_bits, is_ca, self_signed,
 			fingerprint_sha256, pem,
 			tls_version, cipher_suite, trusted, error, updated_at
-		) VALUES (?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?)`)
+		) VALUES (?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -249,7 +289,7 @@ func (r *SQLiteRepository) RecordTLSCerts(ctx context.Context, ip string, certs 
 	now := time.Now().UTC()
 	for _, c := range certs {
 		if _, err := stmt.ExecContext(ctx,
-			ip, c.Port, c.CertIndex,
+			ip, uuid, c.Port, c.CertIndex,
 			c.SubjectCN, c.SubjectOrg, c.Subject, c.IssuerCN, c.IssuerOrg, c.Issuer,
 			c.SanDNS, c.SanIP, c.SanEmail, c.Serial,
 			c.NotBefore, c.NotAfter,
@@ -801,4 +841,38 @@ func (r *SQLiteRepository) resolveDeviceID(ctx context.Context, ip string) (int6
 		return 0, err
 	}
 	return id, nil
+}
+
+// resolveDeviceUUID returns the stable device_uuid for an IP using the same
+// identity rule as resolveDeviceID (network-scoped IP match, then global IP).
+// Returns "" when no device matches — the caller writes "" into the satellite
+// row and it is healed on the next scan (or by the backfill migration). The
+// empty-string sentinel is safe because devices.device_uuid is always populated
+// (non-empty) once a row exists — backfillDeviceUUIDs guarantees it.
+//
+// Used by the satellite-table writers (RecordServices/RecordEvidence/RecordTLSCerts)
+// so those rows key on the stable identity instead of the roaming-prone IP.
+func (r *SQLiteRepository) resolveDeviceUUID(ctx context.Context, ip string) (string, error) {
+	var q string
+	var args []any
+	if r.networkID.Valid {
+		q = `SELECT device_uuid FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`
+		args = []any{ip, r.networkID.Int64}
+	} else {
+		q = `SELECT device_uuid FROM devices WHERE ip_address = ? AND (network_id IS NULL OR network_id = (SELECT MIN(network_id) FROM devices WHERE ip_address = ?)) LIMIT 1`
+		args = []any{ip, ip}
+	}
+	var u string
+	err := r.db.QueryRowContext(ctx, q, args...).Scan(&u)
+	if err == sql.ErrNoRows || err != nil {
+		// Fall back to any device with this IP (cross-network / NULL-network).
+		if r.networkID.Valid {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT device_uuid FROM devices WHERE ip_address = ? LIMIT 1`, ip).Scan(&u)
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+	return u, nil
 }


### PR DESCRIPTION
## Summary

Follow-up to #114 (the synthetic `device_uuid` foundation). This propagates that stable identity to the four IP-keyed satellite tables and the heartbeat probe path, so a device that **DHCP-roams keeps its data** instead of stranding it on the dead old IP — the device-split / stale-data symptoms from the change-detection issue work.

## What changed

**Satellite writes key on `device_uuid`** (best-effort resolved from IP at write time; `''` on first discovery, healed next scan):
- `RecordServices` / `RecordEvidence` / `RecordTLSCerts` write `device_uuid`; the replace-`DELETE` keys on `device_uuid` so a roamed device's stale old-IP rows are cleaned up, not accumulated.
- `UpsertScanSnapshot` writes `device_uuid` (resolved from the device row that `applyDeviceBridge` just persisted — `DetectLost` runs after the bridge, so the device always exists on the local-scan path).

**JOINs become `device_uuid`-aware** (raw SQL — sqlc's SQLite parser truncates the `ON CONFLICT`/complex-JOIN shapes):
- `ListTLSCertsByDeviceID` joins on `device_uuid` (IP fallback for transition rows) → certs follow the device across a roam.
- `staleAgentSnapshotsSQL` / `recoverableAgentSnapshotsSQL` join devices by `(device_uuid, network_id)` → a stale pre-roam snapshot row still finds the roamed device; a roam can't strand a device's lease on the old IP.

**Heartbeat target dereference** (the frozen-IP bug):
- `listLocalProbeConfigs` now `SELECT`s `d.ip_address`; `probeAndRecord` passes the target through `resolveLiveTarget`, which substitutes the device's **current** `ip_address` into the frozen target (bare host / host:port / scheme URL all handled). A roamed device is probed at its live address on the next tick with no config rewrite, no roam hook.

**sqlc queries**: `UpsertScanSnapshot` and `ListLostSnapshots` stay in their original (simpler) form because adding `device_uuid` `CASE`/`JOIN` clauses triggers the documented sqlc SQLite truncation bug; the `device_uuid`-aware versions are raw SQL in the runner, matching the existing `scan_snapshots` convention.

## Deploy verification (63.101)

- ✅ Migration ran clean: `device_uuid backfill devices_assigned=128`, `duplicate-MAC merge ghosts_removed=7`, no panics.
- ✅ Scan exercised the new write paths: `host_services` 127 rows (107 with uuid, 20 empty=first-discovery), `scan_snapshots` 127/145 with uuid, `host_tls_certs` 12/17 with uuid.
- ✅ **FNNAS** (the DHCP-roam case): id=173, `device_uuid=bc84cd65-…`, ip=`192.168.63.60` (the post-roam address), and its 4 services (smb/445, http/80, ssh/22, https/443) all carry the correct `device_uuid` → they follow the device across future roams.
- ✅ TLS cert device-uuid JOIN verified across cert-bearing devices (44 mibee-rec, 38 .1, 37 .2, 41 .30).
- ✅ Change log since deploy: 3 events (2 recovered, 1 lost) — no flap storm.
- ✅ Browser (playwright/chromium): login → dashboard (121 total / 35 online / 86 offline) → devices table renders all columns → FNNAS detail renders at .60 → no JS errors.

## Test inline schemas

9 test files had inline `CREATE TABLE devices (...)` missing the `device_uuid` column (now that `repository.CreateDevice` writes it); added the column to each. New `TestResolveLiveTarget` (9 cases) covers all three target shapes + edge cases.

## Checks

- `go test ./...` — all pass
- `go test -race ./internal/service/scannerv2/... ./internal/service/` — pass
- `gofmt -l` / `goimports -l` / `go vet` — clean
- `sqlc compile` — passes

## Not in this PR (deferred)

The **table-rebuild uniqueness re-key** (`scan_snapshots` / `host_services` `UNIQUE` constraint → `device_uuid`) is intentionally deferred to a follow-up: the `device_uuid`-keyed replace-`DELETE` already cleans up roam orphans, so the rebuild is hardening rather than a functional fix for the roam symptom. Doing it separately keeps this PR's migration footprint to the already-shipped additive `ALTER`s.