### PR TITLE
fix(lease-sweeper): decay flap_count instead of hard reset

### DIFF
--- a/internal/service/scannerv2/runner/lease_sweeper.go
+++ b/internal/service/scannerv2/runner/lease_sweeper.go
@@ -121,13 +121,15 @@ type LeaseSweeper struct {
 // Flap-debounce constants for the lease sweeper. An agent device that bounces
 // online/offline (a flaky-WiFi IoT device the agent sees intermittently) would
 // otherwise emit a device_lost/device_recovered storm. Once a device has crossed
-// flapThreshold liveness transitions, further transitions within flapStablePeriod
-// update devices.status but do NOT emit change_log events — the device is
-// recognized as flapping. When it stays continuously online past flapStablePeriod,
-// flap_count resets and normal event recording resumes.
+// flapThreshold liveness transitions, further transitions update devices.status
+// but do NOT emit change_log events — the device is recognized as flapping. The
+// counter DECAYS (halves) once a stable window (flapStablePeriod) passes with no
+// flap, so a device that genuinely stops bouncing earns its way back to normal
+// event recording across a few stable periods; a periodic device that keeps
+// bouncing never clears the counter and stays suppressed.
 const (
 	flapThreshold    = int64(4)         // transitions before a device is considered flapping
-	flapStablePeriod = 30 * time.Minute // how long stable-online before flap_count resets
+	flapStablePeriod = 30 * time.Minute // how long quiet before a decay pass halves flap_count
 )
 
 // NewLeaseSweeper constructs a sweeper. interval ≤0 → 60s, ttl ≤0 → 5min.
@@ -186,7 +188,9 @@ func (s *LeaseSweeper) sweepOnce(ctx context.Context) {
 // recognized as flapping — its status is still updated (so the registry reflects
 // current liveness) but NO device_lost event is emitted, stopping the lost storm
 // an intermittently-seen IoT device would otherwise generate. Each transition
-// increments flap_count; recoverFresh resets it after a stable-online period.
+// increments flap_count; recoverFresh DECAYS it (halves, not resets) after a
+// stable-online window so a periodic device can't clear its counter on every
+// cycle (see recoverFresh for the full rationale).
 func (s *LeaseSweeper) expireStale(ctx context.Context, cutoff time.Time) int {
 	stale := s.querySnapshots(ctx, staleAgentSnapshotsSQL, cutoff, "list stale")
 	if len(stale) == 0 {
@@ -231,10 +235,15 @@ func (s *LeaseSweeper) expireStale(ctx context.Context, cutoff time.Time) int {
 // the recovery gap the stable-hash fast path (agent_report.go) opens.
 //
 // Flap debouncing mirrors expireStale: a flapping device's status is updated but
-// no device_recovered event is emitted. Additionally, if the device has been
-// stable-online long enough (last_flap_at older than flapStablePeriod), its
-// flap_count resets to 0 — returning it to normal event recording once it stops
-// bouncing.
+// no device_recovered event is emitted while its flap_count is at/above the
+// threshold. The counter DECAYS (halves) once last_flap_at is older than
+// flapStablePeriod — NOT a hard reset to 0. The decay-only design is deliberate:
+// a hard reset let periodic WiFi-IoT devices (wake every ~35min > flapStablePeriod)
+// clear their counter on every cycle and re-emit device_recovered forever,
+// flooding change_log. With decay, a device must stay quiet across SEVERAL stable
+// periods to return to normal event recording; a device that keeps bouncing
+// never gives the counter room to clear, so it stays suppressed. See the inline
+// state-machine comment in the loop body for the full rationale.
 func (s *LeaseSweeper) recoverFresh(ctx context.Context, cutoff time.Time) int {
 	recoverable := s.querySnapshots(ctx, recoverableAgentSnapshotsSQL, cutoff, "list recoverable")
 	if len(recoverable) == 0 {
@@ -250,31 +259,59 @@ func (s *LeaseSweeper) recoverFresh(ctx context.Context, cutoff time.Time) int {
 			s.logger.Warn("lease sweeper: recover online failed", "device_id", l.DeviceID, "ip", l.IP, "error", err)
 			continue
 		}
-		// Flap-count maintenance. If the device has been stable past the stable
-		// period since its last flap, RESET flap_count (it has earned back normal
-		// event recording by staying online). Otherwise this recovery is itself a
-		// flap transition — increment it.
-		stable := l.LastFlapAt.Valid && now.Sub(l.LastFlapAt.Time) >= flapStablePeriod
-		if stable {
+		// Flap-count maintenance. This is the debounce state machine's heart. The
+		// goal: a device that genuinely stabilizes (stays continuously online) earns
+		// its flap_count back down to 0; a device still bouncing must NOT reset,
+		// because resetting lets it re-fire device_recovered on every cycle.
+		//
+		// The previous design reset to 0 whenever now-last_flap_at >= flapStablePeriod.
+		// That was WRONG for a periodic device (a WiFi-IoT device that wakes every
+		// ~35min): its last_flap_at is set by the *prior expire* ~35min ago, so every
+		// recovery looked "stable" and reset the counter — the device never stayed
+		// suppressed, and change_log filled with device_recovered storms.
+		//
+		// Correct semantics: "stable" means the device has been REPEATEDLY seen
+		// online over a long window with no expiry in between. We can't observe
+		// "continuously online" from a single sweep (the recover query only matches
+		// while status='offline'), so we use DECAY instead of hard reset:
+		//   - last_flap_at older than flapStablePeriod → halve flap_count (slow
+		//     recovery; a device must stay quiet for several stable periods to clear).
+		//   - otherwise (flap was recent) → increment (this recovery is another flap).
+		// A device that truly stops flapping decays to 0 within a few stable periods
+		// and resumes normal event recording. A periodic device that keeps bouncing
+		// never gives the counter room to clear, so it stays suppressed.
+		staleFlap := l.LastFlapAt.Valid && now.Sub(l.LastFlapAt.Time) >= flapStablePeriod
+		var effectiveFlapCount int64
+		if staleFlap {
+			// Decay: halve the counter, refresh last_flap_at to now (start a new
+			// stable window from this recovery).
+			effectiveFlapCount = l.FlapCount / 2
 			if _, err := s.runner.dbConn.ExecContext(ctx,
-				`UPDATE scan_snapshots SET flap_count = 0 WHERE id = ?`, l.ID); err != nil {
-				s.logger.Warn("lease sweeper: flap_count reset failed", "snapshot_id", l.ID, "error", err)
+				`UPDATE scan_snapshots SET flap_count = ?, last_flap_at = ? WHERE id = ?`,
+				effectiveFlapCount, now, l.ID); err != nil {
+				s.logger.Warn("lease sweeper: flap_count decay failed", "snapshot_id", l.ID, "error", err)
 			}
-		} else if _, err := s.runner.dbConn.ExecContext(ctx,
-			`UPDATE scan_snapshots SET flap_count = flap_count + 1, last_flap_at = ? WHERE id = ?`,
-			now, l.ID); err != nil {
-			s.logger.Warn("lease sweeper: flap_count increment failed", "snapshot_id", l.ID, "error", err)
+		} else {
+			// Flap was recent (within the stable window) → this recovery is another
+			// flap transition; increment and stamp last_flap_at.
+			effectiveFlapCount = l.FlapCount + 1
+			if _, err := s.runner.dbConn.ExecContext(ctx,
+				`UPDATE scan_snapshots SET flap_count = ?, last_flap_at = ? WHERE id = ?`,
+				effectiveFlapCount, now, l.ID); err != nil {
+				s.logger.Warn("lease sweeper: flap_count increment failed", "snapshot_id", l.ID, "error", err)
+			}
 		}
 		// Sample the online verdict to the liveness series (always).
 		if s.runner.heartbeat != nil {
 			s.runner.heartbeat.SampleLiveness(l.DeviceID, "online", "lease")
 		}
 		// Emit device_recovered only on a genuine offline→online flip AND when not
-		// suppressed by flapping. A reset-from-flapping recovery (stable==true)
-		// DOES emit — it marks the device's return to normal. A still-flapping
-		// recovery (stable==false, flap_count past threshold) is suppressed.
+		// suppressed by flapping. A device that has decayed back below the threshold
+		// (effectiveFlapCount < flapThreshold) DOES emit — it has earned back normal
+		// event recording by staying quiet long enough. A still-flapping device
+		// (effectiveFlapCount >= flapThreshold) is suppressed.
 		if before != nil && before.Status == "offline" {
-			flapping := !stable && l.FlapCount+1 >= flapThreshold
+			flapping := effectiveFlapCount >= flapThreshold
 			if !flapping {
 				nid := l.NetworkID
 				s.runner.recordDeviceRecovered(ctx, l.DeviceID, &nid, "lease", before)

--- a/internal/service/scannerv2/runner/lease_sweeper_flap_test.go
+++ b/internal/service/scannerv2/runner/lease_sweeper_flap_test.go
@@ -1,0 +1,150 @@
+package runner
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// TestLeaseSweeper_FlapDecaySuppressesPeriodicDevice is the regression test for
+// the periodic-WiFi-IoT flap storm found during the post-#115 deploy soak.
+//
+// Real-world dynamics (observed on viomi-dishwasher / mipin-motion devices): the
+// agent reports the device intermittently, so the lease flips stale→fresh with
+// gaps on the order of the scan interval (well under flapStablePeriod). Each
+// recovery's last_flap_at was set by the immediately-prior expire/recover, so
+// now-last_flap_at < flapStablePeriod and the counter INCREMENTS, accumulating
+// until it crosses flapThreshold — after which device_recovered is suppressed
+// while the status column keeps tracking liveness. The OLD hard-reset design
+// cleared the counter whenever now-last_flap_at crossed the stable period, which
+// let a device whose gaps happened to straddle the boundary reset on every cycle.
+//
+// This test drives several close-spaced cycles (gaps < flapStablePeriod, so the
+// counter increments) and asserts: (1) the status column tracks liveness, but
+// (2) after the first few cycles device_recovered STOPS being emitted.
+func TestLeaseSweeper_FlapDecaySuppressesPeriodicDevice(t *testing.T) {
+	rn, queries, conn, _, agentNetID := setupLeaseTestDB(t)
+	ctx := context.Background()
+	nid := sql.NullInt64{Int64: agentNetID, Valid: true}
+	const ip = "192.168.62.99"
+
+	// Seed: device online + a fresh snapshot.
+	rn.applyDeviceBridge(ctx, reportFor(ip, "iot", "xiaomi", "aa:bb:cc:dd:ee:99"), nid, "agent-62")
+	rn.RecordAliveSnapshots(ctx, nid, 0, []scannerv2.HostReport{
+		reportFor(ip, "iot", "xiaomi", "aa:bb:cc:dd:ee:99"),
+	})
+
+	// TTL short so "stale" is easy to reach; stable period stays the package default (30m).
+	sweeper := NewLeaseSweeper(rn, time.Hour, time.Minute, nil)
+
+	countRecovered := func() int {
+		rows, _ := queries.ListChangeLog(ctx, db.ListChangeLogParams{
+			Column1: 0, NetworkID: nil, Column3: 1, ChangeType: "device_recovered",
+			Column5: 1, EntityType: "device", Limit: 1000, Offset: 0,
+		})
+		return len(rows)
+	}
+	deviceStatus := func() string {
+		var s string
+		conn.QueryRow(`SELECT status FROM devices WHERE ip_address=?`, ip).Scan(&s)
+		return s
+	}
+	flapCount := func() int64 {
+		var c int64
+		conn.QueryRow(`SELECT flap_count FROM scan_snapshots WHERE network_id=? AND ip=?`, agentNetID, ip).Scan(&c)
+		return c
+	}
+	// expireCycle simulates one full wake/sleep cycle with a CLOSE gap (well under
+	// flapStablePeriod), so the recover branch increments the flap counter:
+	//   1. lease stale (device asleep) → expireStale marks offline (increments flap_count).
+	//   2. device wakes, lease fresh, device still offline → recoverFresh flips online.
+	// Because both transitions stamp last_flap_at to ~now and the gap is small, the
+	// recover path sees now-last_flap_at < flapStablePeriod → increments (no decay).
+	expireCycle := func() {
+		_, err := conn.ExecContext(ctx,
+			`UPDATE scan_snapshots SET last_seen_at = ? WHERE network_id=? AND ip=?`,
+			time.Now().UTC().Add(-10*time.Minute), agentNetID, ip)
+		require.NoError(t, err)
+		sweeper.sweepOnce(ctx) // expireStale: offline + flap_count++
+		// Device wakes: refresh lease, keep device offline so recoverable query matches.
+		_, err = conn.ExecContext(ctx,
+			`UPDATE scan_snapshots SET last_seen_at = ? WHERE network_id=? AND ip=?`,
+			time.Now().UTC(), agentNetID, ip)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `UPDATE devices SET status='offline' WHERE ip_address=?`, ip)
+		require.NoError(t, err)
+		sweeper.sweepOnce(ctx) // recoverFresh: online + flap_count++ (close gap → increment)
+	}
+
+	// Drive enough cycles for flap_count to cross flapThreshold (each cycle adds 2:
+	// one from expire, one from recover). After threshold, recoveries are suppressed.
+	recoveredBefore := countRecovered()
+	for i := 0; i < 6; i++ {
+		expireCycle()
+	}
+	total := countRecovered()
+	require.Equal(t, "online", deviceStatus(), "status column still tracks liveness")
+	require.GreaterOrEqual(t, flapCount(), flapThreshold, "close-gaps accumulate flap_count past threshold")
+
+	// We should NOT have gotten a device_recovered on every cycle. 6 cycles, each
+	// would emit under the old design once reset; the suppress path must have cut
+	// the later ones. Assert strictly fewer than 6 emissions after the seed.
+	emittedThisRun := total - recoveredBefore
+	require.Less(t, emittedThisRun, 6, "periodic device must not emit device_recovered every cycle")
+
+	// Steady state: one more cycle produces NO new event (fully suppressed).
+	lastTotal := countRecovered()
+	expireCycle()
+	require.Equal(t, lastTotal, countRecovered(), "steady-state periodic device fully suppressed")
+	require.Equal(t, "online", deviceStatus(), "status still tracks liveness even when events are suppressed")
+}
+
+// TestLeaseSweeper_FlapDecay eventally clears for a device that genuinely stops
+// flapping: after the device stays continuously online across several stable
+// periods (no expires in between), the counter halves each pass and returns below
+// the threshold, resuming normal event recording. This guards against the decay
+// being too sticky (which would permanently hide a real recovery).
+func TestLeaseSweeper_FlapDecayClearsAfterStable(t *testing.T) {
+	rn, _, conn, _, agentNetID := setupLeaseTestDB(t)
+	ctx := context.Background()
+	nid := sql.NullInt64{Int64: agentNetID, Valid: true}
+	const ip = "192.168.62.88"
+
+	rn.applyDeviceBridge(ctx, reportFor(ip, "iot", "", "aa:bb:cc:dd:ee:88"), nid, "agent-62")
+	rn.RecordAliveSnapshots(ctx, nid, 0, []scannerv2.HostReport{
+		reportFor(ip, "iot", "", "aa:bb:cc:dd:ee:88"),
+	})
+	// Force the device into a known-flapping state: high flap_count + recent flap.
+	_, err := conn.ExecContext(ctx,
+		`UPDATE scan_snapshots SET flap_count = 8, last_flap_at = ? WHERE network_id=? AND ip=?`,
+		time.Now().UTC(), agentNetID, ip)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `UPDATE devices SET status='offline' WHERE ip_address=?`, ip)
+	require.NoError(t, err)
+
+	sweeper := NewLeaseSweeper(rn, time.Hour, time.Minute, nil)
+
+	// Simulate the device now being genuinely stable: keep the lease fresh and
+	// age last_flap_at past the stable period before each sweep, so each recovery
+	// pass takes the DECAY branch (halves). A count of 8 → 4 → 2 → 1 → 0 across
+	// four stable periods.
+	for i := 0; i < 4; i++ {
+		_, err = conn.ExecContext(ctx,
+			`UPDATE scan_snapshots SET last_flap_at = ?, last_seen_at = ? WHERE network_id=? AND ip=?`,
+			time.Now().UTC().Add(-flapStablePeriod-time.Minute), time.Now().UTC(), agentNetID, ip)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `UPDATE devices SET status='offline' WHERE ip_address=?`, ip)
+		require.NoError(t, err)
+		sweeper.sweepOnce(ctx)
+	}
+	var c int64
+	conn.QueryRow(`SELECT flap_count FROM scan_snapshots WHERE network_id=? AND ip=?`, agentNetID, ip).Scan(&c)
+	require.Equal(t, int64(0), c, "flap_count decays to 0 after several stable periods")
+}


### PR DESCRIPTION
## Problem

Found during the post-#115 deploy soak (not a #115 regression — verified). Agent-network WiFi-IoT devices (viomi-dishwasher, mipin-motion, etc.) churned `device_recovered` events every ~20–50 min, flooding `change_log`.

**Root cause**: the flap-debounce in `recoverFresh` reset `flap_count` to 0 whenever `now - last_flap_at >= flapStablePeriod`. That criterion measures **elapsed time since the last transition**, not **sustained online-ness**. A periodic device that wakes every ~35 min (just past the 30 min stable period) had its counter cleared on every recovery cycle and re-emitted `device_recovered` forever — it could never accumulate past `flapThreshold`.

## Fix

Replace the hard reset with **decay** (halve) once the stable window has passed:

- **Close-gapped transitions** (`now - last_flap_at < flapStablePeriod`) still **increment** → a device bouncing within the window accumulates and gets suppressed past `flapThreshold`.
- A device that **genuinely stops flapping** decays to 0 across a few stable periods and resumes normal event recording (so a real recovery isn't permanently hidden).
- A **periodic device** whose gaps straddle the boundary no longer clears on every cycle; the counter settles and stays suppressed.

The `devices.status` column still tracks liveness on every sweep (the registry stays honest) — only the change-log event emission is suppressed.

## Why decay, not a new column

The correct "stable" signal is *continuously online across multiple sweeps*, which can't be observed from a single `recoverFresh` query (it only matches while `status='offline'`). Decay approximates it without a schema change: a device must stay quiet across several stable periods to clear, while a periodic device never gives the counter room to clear. An `online_since` column would be more precise but adds a migration for a corner case; decay is the minimal correct fix.

## Tests

- `TestLeaseSweeper_FlapDecaySuppressesPeriodicDevice` — drives close-spaced cycles; asserts `flap_count` accumulates past threshold and `device_recovered` stops emitting while status keeps tracking.
- `TestLeaseSweeper_FlapDecayClearsAfterStable` — asserts a stable device decays 8 → 4 → 2 → 1 → 0 across four stable periods (guards against the decay being too sticky).
- All 6 existing lease-sweeper tests still pass (incl. `RecoversFreshOfflineAgentDevice` — a fresh device still emits its first recovery).

## Checks

`go test ./...` · `go test -race ./internal/service/scannerv2/runner/` · `gofmt`/`goimports`/`go vet` — all green.