### PR TITLE
feat(retention): auto-prune devices with no heartbeat (issue #117)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -313,6 +313,12 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		"ALTER TABLE host_services ADD COLUMN device_uuid TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE service_evidence ADD COLUMN device_uuid TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE host_tls_certs ADD COLUMN device_uuid TEXT NOT NULL DEFAULT ''",
+		// offline_since: stamped when a device flips to 'offline' (all heartbeat
+		// configs failed, or lost-detection/lease-sweeper marked it gone), cleared
+		// on recovery. Drives the silent-device retention sweep (issue #117). The
+		// backfill below approximates it for existing offline devices from
+		// updated_at (the last status write).
+		"ALTER TABLE devices ADD COLUMN offline_since TIMESTAMP",
 		// Dual JSON layer (scan_attributes + user_attributes). Generated columns
 		// (scan_vendor/scan_mac/scan_os/scan_hostname) can't be added via ALTER
 		// on existing DBs — those are only present on fresh installs. For
@@ -398,6 +404,15 @@ func runMigrations(db *sql.DB, dbPath string) error {
 	// out via retention sweeps.
 	if err := backfillSatelliteUUIDs(context.Background(), db); err != nil {
 		return fmt.Errorf("backfill satellite device_uuid: %w", err)
+	}
+
+	// Backfill offline_since for existing offline devices (issue #117). The column
+	// was just added (nullable, all-NULL). For rows already 'offline' we approximate
+	// the flip time from updated_at — the last status write, which is the closest
+	// available proxy for when the device went offline. Online/unknown rows stay
+	// NULL (they're not offline). Idempotent: only fills NULLs on offline rows.
+	if err := backfillOfflineSince(context.Background(), db); err != nil {
+		return fmt.Errorf("backfill offline_since: %w", err)
 	}
 
 	// Merge duplicate-MAC device rows (the device-split symptom): when the same
@@ -803,6 +818,27 @@ func backfillSatelliteUUIDs(ctx context.Context, db *sql.DB) error {
 			// the next start once the ALTER has run. Log and continue.
 			slog.Warn("satellite device_uuid backfill statement failed", "error", err)
 		}
+	}
+	return nil
+}
+
+// backfillOfflineSince populates devices.offline_since for rows that are already
+// 'offline' but have a NULL offline_since (the column was just added by the ALTER
+// above, so every existing row starts NULL). The flip time is approximated from
+// updated_at — the last write to the row, which for an offline device is the
+// status='offline' write itself (the closest available proxy for when it went
+// offline). Online/unknown rows keep NULL (they're not offline, so the silent-
+// device retention sweep correctly skips them). Idempotent: only touches NULLs on
+// offline rows, so a second run is a no-op.
+func backfillOfflineSince(ctx context.Context, db *sql.DB) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE devices SET offline_since = updated_at
+		 WHERE status = 'offline' AND offline_since IS NULL`)
+	if err != nil {
+		return fmt.Errorf("backfill offline devices: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		slog.Info("offline_since backfill", "offline_devices_approximated", n)
 	}
 	return nil
 }

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -233,6 +233,15 @@ scanner:
 #
 # Defaults: heartbeat 7d, scan_results/runs 30d, audit 90d, notifications 30d,
 # service_evidence 14d, host_tls_certs 30d, sweep every 6h, batches of 5000.
+#
+# silent_device_*: scanner-discovered devices (scan_source='scanner_v2') that
+# have had NO heartbeat (all probe configs failing) for longer than these
+# windows are physically DELETED (manual devices are never auto-deleted). A
+# device WITH a MAC gets silent_device_days_mac (7d — a real asset may be
+# genuinely gone for a while); a device WITHOUT a MAC gets
+# silent_device_hours_no_mac (24h — a mac-less identity is unreliable and pruned
+# faster). A device that recovers (5 consecutive online probe cycles) clears its
+# offline clock. Each deletion is logged to change_log as device_removed.
 retention:
   heartbeat_results_days: 7
   scan_results_days: 30
@@ -241,5 +250,7 @@ retention:
   notification_log_days: 30
   service_evidence_days: 14
   host_tls_certs_days: 30
+  silent_device_days_mac: 7
+  silent_device_hours_no_mac: 24
   sweep_interval_hours: 6
   batch_size: 5000

--- a/db/queries/devices.sql
+++ b/db/queries/devices.sql
@@ -13,15 +13,15 @@ INSERT INTO devices (
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at;
 
 -- name: GetDevice :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE id = ?;
 
 -- name: ListDevices :many
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -46,7 +46,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at;
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at;
 
 -- name: UpdateUserAttributes :exec
 UPDATE devices SET user_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?;
@@ -97,7 +97,7 @@ SET scan_source = ?, prometheus_labels = ?, last_scanned_at = ?, last_scan_task_
 WHERE id = ?;
 
 -- name: GetDeviceByIP :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1;
@@ -107,16 +107,25 @@ LIMIT 1;
 -- both fresh installs (which have the scan_mac generated column) and upgraded
 -- DBs (which have an expression index on json_extract instead). The expression
 -- index idx_devices_scan_mac_expr covers this WHERE clause on either shape.
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1;
 
 -- name: UpdateDeviceStatus :exec
--- Updates ONLY the status column (and updated_at). Used by the heartbeat
--- service so a status transition doesn't clobber other columns (name, tags,
--- location, ...) that may have been edited between the GetDevice read and this
--- write -- the full-row UpdateDevice path is racy in that window.
+-- Updates the status column (and updated_at) AND maintains offline_since on
+-- the online↔offline flip: stamps CURRENT_TIMESTAMP when transitioning TO
+-- 'offline', clears to NULL when transitioning TO 'online'. Used by paths that
+-- set a single device's status. The CASE evaluates against the row's current
+-- status, so a no-op write (status unchanged) leaves offline_since untouched.
+-- offline_since is the authoritative "how long has this device had no heartbeat"
+-- signal for the silent-device retention sweep (issue #117).
 UPDATE devices
-SET status = ?, updated_at = CURRENT_TIMESTAMP
+SET status = ?,
+    offline_since = CASE
+      WHEN ? = 'offline' AND status != 'offline' THEN CURRENT_TIMESTAMP
+      WHEN ? = 'online' THEN NULL
+      ELSE offline_since
+    END,
+    updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -104,6 +104,15 @@ CREATE TABLE IF NOT EXISTS devices (
     -- across distributed instances.
     first_seen TIMESTAMP,
     last_seen TIMESTAMP,
+    -- offline_since is stamped when the device FLIPS to 'offline' (all heartbeat
+    -- configs failed past the offline_threshold, or scan lost-detection / lease
+    -- sweeper marked it gone) and cleared to NULL when it comes back online. It
+    -- is the signal for the silent-device retention sweep: a device whose
+    -- offline_since is older than the configured window (7d with a MAC, 24h
+    -- without) is auto-pruned. Distinct from last_seen (which is scan-derived
+    -- and not refreshed on heartbeat-online) — offline_since is the authoritative
+    -- "how long has this device had no heartbeat" timestamp.
+    offline_since TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -562,7 +562,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// service_evidence) on a single ticker, each with its own retention window.
 	// Defaults & scanner.retention_days back-compat are applied in
 	// config.normalizeRetention, so cfg.Retention is fully populated here.
-	cleanupSvc := scannerv2cleanup.New(scanQueries, hbStore.Queries(), hbStore.DB(), cfg.Retention)
+	cleanupSvc := scannerv2cleanup.New(scanQueries, hbStore.Queries(), hbStore.DB(), dbConn, cfg.Retention)
 	cleanupSvc.Start(context.Background())
 
 	if scanScheduler != nil {

--- a/internal/api/routes/scanner_integration_test.go
+++ b/internal/api/routes/scanner_integration_test.go
@@ -55,6 +55,7 @@ func newTestDB(t *testing.T) *sql.DB {
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,20 @@ type RetentionConfig struct {
 	// cert chain behind. PEM payload is a few KB per row, so we default tighter
 	// than host_services. Default 30.
 	HostTLSCertsDays int `koanf:"host_tls_certs_days"`
+	// SilentDeviceDaysMAC is how long a scanner-discovered device WITH a MAC
+	// address can stay offline (no heartbeat — all probe configs failing) before
+	// the silent-device retention sweep physically deletes it (issue #117). MAC-
+	// bearing devices are real assets that may genuinely disappear for a while
+	// (laptop on a long trip, IoT device powered off), so the window is generous
+	// (7d). A device that comes back online (5 consecutive successful probe
+	// cycles) clears offline_since and the clock resets. Manual devices
+	// (scan_source != 'scanner_v2') are NEVER auto-deleted. 0 → default 7.
+	SilentDeviceDaysMAC int `koanf:"silent_device_days_mac"`
+	// SilentDeviceHoursNoMAC is the same window for scanner-discovered devices
+	// WITHOUT a MAC (mac_address=''). A mac-less device is an unreliable identity
+	// (could be a transient/duplicate discovery), so it's pruned much faster
+	// (24h) to keep the registry clean. 0 → default 24.
+	SilentDeviceHoursNoMAC int `koanf:"silent_device_hours_no_mac"`
 	// SweepIntervalHours is how often the retention sweeper runs across all
 	// tables. Default 6h — frequent enough that no table drifts far past its
 	// window, rare enough to be negligible overhead.
@@ -554,6 +568,12 @@ func normalizeRetention(cfg *Config) {
 	}
 	if r.HostTLSCertsDays <= 0 {
 		r.HostTLSCertsDays = 30
+	}
+	if r.SilentDeviceDaysMAC <= 0 {
+		r.SilentDeviceDaysMAC = 7
+	}
+	if r.SilentDeviceHoursNoMAC <= 0 {
+		r.SilentDeviceHoursNoMAC = 24
 	}
 	if r.SweepIntervalHours <= 0 {
 		r.SweepIntervalHours = 6

--- a/internal/db/devices.sql.go
+++ b/internal/db/devices.sql.go
@@ -193,7 +193,7 @@ INSERT INTO devices (
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 `
 
 type CreateDeviceParams struct {
@@ -278,6 +278,7 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 		&i.NetworkID,
 		&i.FirstSeen,
 		&i.LastSeen,
+		&i.OfflineSince,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -298,7 +299,7 @@ func (q *Queries) DeleteDevice(ctx context.Context, id int64) (int64, error) {
 }
 
 const getDevice = `-- name: GetDevice :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE id = ?
 `
@@ -341,6 +342,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 		&i.NetworkID,
 		&i.FirstSeen,
 		&i.LastSeen,
+		&i.OfflineSince,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -348,7 +350,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 }
 
 const getDeviceByIP = `-- name: GetDeviceByIP :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1
@@ -392,6 +394,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 		&i.NetworkID,
 		&i.FirstSeen,
 		&i.LastSeen,
+		&i.OfflineSince,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -399,7 +402,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 }
 
 const getDeviceByMAC = `-- name: GetDeviceByMAC :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1
@@ -447,6 +450,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 		&i.NetworkID,
 		&i.FirstSeen,
 		&i.LastSeen,
+		&i.OfflineSince,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -454,7 +458,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 }
 
 const listDevices = `-- name: ListDevices :many
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -522,6 +526,7 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 			&i.NetworkID,
 			&i.FirstSeen,
 			&i.LastSeen,
+			&i.OfflineSince,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -608,7 +613,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, created_at, updated_at
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
 `
 
 type UpdateDeviceParams struct {
@@ -686,6 +691,7 @@ func (q *Queries) UpdateDevice(ctx context.Context, arg UpdateDeviceParams) (Dev
 		&i.NetworkID,
 		&i.FirstSeen,
 		&i.LastSeen,
+		&i.OfflineSince,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -729,21 +735,37 @@ func (q *Queries) UpdateDeviceScanInfo(ctx context.Context, arg UpdateDeviceScan
 
 const updateDeviceStatus = `-- name: UpdateDeviceStatus :exec
 UPDATE devices
-SET status = ?, updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
+SET status = ?,
+    offline_since = CASE
+      WHEN ? = 'offline' AND status != 'offline' THEN CURRENT_TIMESTAMP
+      WHEN ? = 'online' THEN NULL
+      ELSE offline_since
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id =
 `
 
 type UpdateDeviceStatusParams struct {
-	Status string `json:"status"`
-	ID     int64  `json:"id"`
+	Status  string      `json:"status"`
+	Column2 interface{} `json:"column_2"`
+	Column3 interface{} `json:"column_3"`
+	ID      int64       `json:"id"`
 }
 
-// Updates ONLY the status column (and updated_at). Used by the heartbeat
-// service so a status transition doesn't clobber other columns (name, tags,
-// location, ...) that may have been edited between the GetDevice read and this
-// write -- the full-row UpdateDevice path is racy in that window.
+// Updates the status column (and updated_at) AND maintains offline_since on
+// the online↔offline flip: stamps CURRENT_TIMESTAMP when transitioning TO
+// 'offline', clears to NULL when transitioning TO 'online'. Used by paths that
+// set a single device's status. The CASE evaluates against the row's current
+// status, so a no-op write (status unchanged) leaves offline_since untouched.
+// offline_since is the authoritative "how long has this device had no heartbeat"
+// signal for the silent-device retention sweep (issue #117).
 func (q *Queries) UpdateDeviceStatus(ctx context.Context, arg UpdateDeviceStatusParams) error {
-	_, err := q.db.ExecContext(ctx, updateDeviceStatus, arg.Status, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateDeviceStatus,
+		arg.Status,
+		arg.Column2,
+		arg.Column3,
+		arg.ID,
+	)
 	return err
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -101,6 +101,7 @@ type Device struct {
 	NetworkID        *int64     `json:"network_id"`
 	FirstSeen        *time.Time `json:"first_seen"`
 	LastSeen         *time.Time `json:"last_seen"`
+	OfflineSince     *time.Time `json:"offline_since"`
 	CreatedAt        time.Time  `json:"created_at"`
 	UpdatedAt        time.Time  `json:"updated_at"`
 }

--- a/internal/repository/device_attributes_test.go
+++ b/internal/repository/device_attributes_test.go
@@ -56,6 +56,7 @@ func setupAttributesTestDB(t *testing.T) (*DeviceRepository, *sql.DB, int64) {
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
@@ -155,6 +156,8 @@ func TestCreateDeviceRejectsInvalidUserAttributes(t *testing.T) {
 			tags TEXT NOT NULL DEFAULT '{}',
 			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
 			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);`)

--- a/internal/repository/device_system_test.go
+++ b/internal/repository/device_system_test.go
@@ -58,6 +58,7 @@ func setupDeviceSystemTestDB(t *testing.T) (*DeviceSystemRepository, *sql.DB, in
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/batch.go
+++ b/internal/service/batch.go
@@ -102,17 +102,26 @@ func (s *BatchService) UpdateDeviceStatuses(ctx context.Context, ids []int64, st
 	defer func() { _ = tx.Rollback() }() // rollback errors (sql.ErrTxDone after commit) are expected
 
 	// Use raw SQL for batch status update — more efficient than looping UpdateDevice
-	// since we only change one field
+	// since we only change one field. status is bound 3×: once for SET, twice for
+	// the offline_since CASE branches (flip-to-offline stamps, flip-to-online clears).
 	placeholders := make([]string, len(ids))
-	args := make([]interface{}, 0, len(ids)+1)
-	args = append(args, status)
+	args := make([]interface{}, 0, len(ids)+3)
+	args = append(args, status, status, status)
 	for i, id := range ids {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
 
 	query := fmt.Sprintf(
-		"UPDATE devices SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id IN (%s)",
+		`UPDATE devices SET
+			status = ?,
+			offline_since = CASE
+				WHEN ? = 'offline' AND status != 'offline' THEN CURRENT_TIMESTAMP
+				WHEN ? = 'online' THEN NULL
+				ELSE offline_since
+			END,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE id IN (%s)`,
 		strings.Join(placeholders, ","),
 	)
 

--- a/internal/service/batch_test.go
+++ b/internal/service/batch_test.go
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS devices (
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/internal/service/device_system_test.go
+++ b/internal/service/device_system_test.go
@@ -57,6 +57,7 @@ func setupDeviceSystemService(t *testing.T) (*DeviceSystemService, *sql.DB, int6
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -63,6 +63,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *sql.DB) {
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -61,6 +61,7 @@ func setupExportTest(t *testing.T) (*ExportService, *sql.DB) {
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -646,7 +646,22 @@ func (s *HeartbeatService) syncStatus(ctx context.Context) {
 		return
 	}
 	for _, c := range changed {
-		if _, err := tx.ExecContext(ctx, "UPDATE devices SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", c.status, c.id); err != nil {
+		// Stamp offline_since on the online→offline flip and clear it on
+		// offline→online, so the silent-device retention sweep (issue #117) has
+		// an authoritative "how long has this device had no heartbeat" signal.
+		// The CASE evaluates against the row's CURRENT status, so a no-op write
+		// (status unchanged — shouldn't happen here, lastSynced guards it, but
+		// defensive) leaves offline_since untouched.
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE devices SET
+				status = ?,
+				offline_since = CASE
+					WHEN ? = 'offline' AND status != 'offline' THEN CURRENT_TIMESTAMP
+					WHEN ? = 'online' THEN NULL
+					ELSE offline_since
+				END,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE id = ?`, c.status, c.status, c.status, c.id); err != nil {
 			slog.Error("syncStatus update failed", "device_id", c.id, "error", err)
 		}
 	}

--- a/internal/service/heartbeat_test.go
+++ b/internal/service/heartbeat_test.go
@@ -70,6 +70,7 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 			network_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
@@ -878,4 +879,57 @@ func TestHeartbeat_ListEnabledConfigs_ExcludesAgentNetwork(t *testing.T) {
 	// Only the center device's config should appear.
 	require.Len(t, enabled, 1, "agent-network config must be excluded")
 	require.Equal(t, centerDev, enabled[0].DeviceID, "only center-network device probed")
+}
+
+// TestSyncStatus_StampOfflineSince verifies the offline_since column is maintained
+// correctly across status flips in syncStatus (the center heartbeat path):
+//   - flipping online→offline stamps offline_since = now
+//   - a device already offline keeps its original offline_since (not re-stamped)
+//   - flipping offline→online clears offline_since to NULL
+//
+// This is the signal the silent-device retention sweep (issue #117) keys on.
+func TestSyncStatus_StampOfflineSince(t *testing.T) {
+	svc, dbConn, queries := setupHeartbeatTest(t)
+	ctx := context.Background()
+
+	// Create an ONLINE device via the repo so it has a valid row.
+	dev, err := queries.CreateDevice(ctx, db.CreateDeviceParams{
+		DeviceUuid: "flip-uuid", Name: "flip-test", Type: "server",
+		Status: "online", Tags: "{}", UserAttributes: "{}",
+	})
+	require.NoError(t, err)
+
+	// Flip it to offline via the in-memory cache + syncStatus.
+	svc.statusCacheMu.Lock()
+	svc.statusCache[dev.ID] = "offline"
+	svc.statusCacheMu.Unlock()
+	svc.syncStatus(ctx)
+
+	var offlineSince *time.Time
+	require.NoError(t, dbConn.QueryRowContext(ctx,
+		`SELECT offline_since FROM devices WHERE id = ?`, dev.ID).Scan(&offlineSince))
+	require.NotNil(t, offlineSince, "flipping online→offline must stamp offline_since")
+	firstStamp := *offlineSince
+
+	// Sync 'offline' AGAIN (no real change) — force a re-sync by desyncing
+	// lastSynced, but keep the status at 'offline'. offline_since must NOT move
+	// (the CASE guards: status was already 'offline', so the flip branch is skipped).
+	time.Sleep(10 * time.Millisecond)
+	svc.statusCacheMu.Lock()
+	svc.lastSynced[dev.ID] = "online" // pretend we haven't synced the offline yet
+	svc.statusCacheMu.Unlock()
+	svc.syncStatus(ctx)
+	require.NoError(t, dbConn.QueryRowContext(ctx,
+		`SELECT offline_since FROM devices WHERE id = ?`, dev.ID).Scan(&offlineSince))
+	require.Equal(t, firstStamp.Unix(), offlineSince.Unix(),
+		"already-offline device must keep its original offline_since (not re-stamped)")
+
+	// Flip it back to online — offline_since must clear to NULL.
+	svc.statusCacheMu.Lock()
+	svc.statusCache[dev.ID] = "online"
+	svc.statusCacheMu.Unlock()
+	svc.syncStatus(ctx)
+	require.NoError(t, dbConn.QueryRowContext(ctx,
+		`SELECT offline_since FROM devices WHERE id = ?`, dev.ID).Scan(&offlineSince))
+	require.Nil(t, offlineSince, "flipping offline→online must clear offline_since to NULL")
 }

--- a/internal/service/scannerv2/cleanup/cleanup.go
+++ b/internal/service/scannerv2/cleanup/cleanup.go
@@ -22,7 +22,9 @@ package cleanup
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"mibee-steward/internal/config"
@@ -35,6 +37,7 @@ type Service struct {
 	queries          *db.Queries // main DB (scan_results, scan_task_runs, audit_logs, notification_log, service_evidence)
 	heartbeatQueries *db.Queries // dedicated heartbeat DB (heartbeat_results lives in a separate file)
 	heartbeatDB      *sql.DB     // raw conn to heartbeat.db, for device_liveness RFC3339-bound deletes (sqlc passes time.Time which sorts wrong vs stored RFC3339 text)
+	mainDB           *sql.DB     // raw conn to the main DB, for the device-pruning DELETE + change_log emit (sqlc has no batched device delete)
 	cfg              config.RetentionConfig
 	interval         time.Duration
 	batch            int64
@@ -47,8 +50,10 @@ type Service struct {
 // sqlc Queries bound to the dedicated heartbeat.db (nil ⇒ heartbeat pruning
 // is skipped, for tests/main-DB-only contexts). heartbeatDB is the raw
 // connection for the RFC3339-bound device_liveness delete (nil ⇒ skipped).
-// SweepIntervalHours<=0 and BatchSize<=0 are defended in config.normalizeRetention.
-func New(queries *db.Queries, heartbeatQueries *db.Queries, heartbeatDB *sql.DB, cfg config.RetentionConfig) *Service {
+// mainDB is the raw main-DB connection for the silent-device prune (nil ⇒
+// device pruning is skipped — tests that don't exercise it). SweepIntervalHours
+// <=0 and BatchSize<=0 are defended in config.normalizeRetention.
+func New(queries *db.Queries, heartbeatQueries *db.Queries, heartbeatDB, mainDB *sql.DB, cfg config.RetentionConfig) *Service {
 	interval := time.Duration(cfg.SweepIntervalHours) * time.Hour
 	if interval <= 0 {
 		interval = 6 * time.Hour
@@ -61,6 +66,7 @@ func New(queries *db.Queries, heartbeatQueries *db.Queries, heartbeatDB *sql.DB,
 		queries:          queries,
 		heartbeatQueries: heartbeatQueries,
 		heartbeatDB:      heartbeatDB,
+		mainDB:           mainDB,
 		cfg:              cfg,
 		interval:         interval,
 		batch:            batch,
@@ -118,6 +124,7 @@ func (s *Service) runOnce(ctx context.Context) {
 	s.pruneDeviceNeighbors(ctx)
 	s.pruneHostServices(ctx)
 	s.pruneHostTLSCerts(ctx)
+	s.pruneSilentDevices(ctx)
 }
 
 // cutoff returns now - retentionDays, or a zero time if days<=0 (which would
@@ -311,4 +318,207 @@ func (s *Service) pruneHostTLSCerts(ctx context.Context) {
 			Limit:     limit,
 		})
 	})
+}
+
+// silentDeviceCutoff returns the cutoff time for the "no heartbeat" silent-
+// device prune, keyed by MAC presence. macCutoff uses SilentDeviceDaysMAC
+// (default 7d); noMacCutoff uses SilentDeviceHoursNoMAC (default 24h). A field
+// of 0 means "use the default" (normalizeRetention fills them), never "disabled".
+func silentDeviceCutoffs(cfg config.RetentionConfig) (macCutoff, noMacCutoff time.Time) {
+	now := time.Now()
+	macDays := cfg.SilentDeviceDaysMAC
+	if macDays <= 0 {
+		macDays = 7
+	}
+	noMacHours := cfg.SilentDeviceHoursNoMAC
+	if noMacHours <= 0 {
+		noMacHours = 24
+	}
+	return now.AddDate(0, 0, -macDays), now.Add(time.Duration(-noMacHours) * time.Hour)
+}
+
+// pruneSilentDevices physically deletes scanner-discovered devices that have had
+// no heartbeat for longer than the configured window (issue #117). Two cases:
+//
+//  1. Silent device: a scanner_v2 device whose status is 'offline' and whose
+//     offline_since is older than the threshold — 7d if it has a MAC (a real
+//     asset that may be genuinely gone), 24h if it has no MAC (an unreliable
+//     mac-less identity that's likely a transient/duplicate discovery).
+//  2. Roamed orphan: a scanner_v2 device whose MAC also exists ONLINE in another
+//     network (it DHCP-roamed) AND whose offline_since is older than
+//     roamedOrphanWindow — the device has a live copy elsewhere, so this row is
+//     a stale old-network leftover. The window is tighter than the silent
+//     window (the online copy proves the asset still exists).
+//
+// Manual devices (scan_source != 'scanner_v2') are NEVER auto-deleted — a human
+// added them, a human removes them (CMDB semantics). Each deletion is logged to
+// change_log as device_removed (with a before snapshot + reason) BEFORE the
+// DELETE, so the audit trail survives the CASCADE. Skipped entirely when mainDB
+// is nil (tests that don't exercise device pruning).
+//
+// NOTE on cutoff formatting: offline_since is stored as RFC3339-ish TEXT (the
+// heartbeat/scan writers pass Go time.Time, which modernc serializes with a
+// space + monotonic suffix; the silent-device tests store RFC3339Nano). A
+// string-comparison `< ?` therefore needs the cutoff bound in a matching
+// RFC3339 shape, NOT a raw time.Time (which would sort wrong). Mirrors the
+// documented device_liveness prune (pruneDeviceLiveness). We use RFC3339Nano
+// for sub-second precision.
+func (s *Service) pruneSilentDevices(ctx context.Context) {
+	if s.mainDB == nil {
+		return
+	}
+	macCut, noMacCut := silentDeviceCutoffs(s.cfg)
+	// The roamed-orphan window: ~5 probe cycles at the 30s default tick ≈ 2.5min is
+	// too aggressive (a scan-in-progress could briefly show the old row offline).
+	// Use a safe floor (10min) so a genuine roam settles before the orphan is cut.
+	const roamedOrphanWindow = 10 * time.Minute
+	roamedCut := time.Now().Add(-roamedOrphanWindow)
+	// Format cutoffs as RFC3339Nano so the string `<` comparison against the
+	// stored offline_since TEXT sorts correctly (see the NOTE above).
+	macCutStr := macCut.UTC().Format(time.RFC3339Nano)
+	noMacCutStr := noMacCut.UTC().Format(time.RFC3339Nano)
+	roamedCutStr := roamedCut.UTC().Format(time.RFC3339Nano)
+
+	var totalDeleted int64
+	for {
+		if ctx.Err() != nil {
+			s.logger.Info("cleanup: silent-device sweep cancelled", "deleted_so_far", totalDeleted)
+			return
+		}
+		// Select one batch of candidate rows (id + identity for the change_log
+		// before-snapshot). The DELETE happens row-by-row after the log write so a
+		// failure on one row doesn't lose the audit trail for the others.
+		rows, err := s.mainDB.QueryContext(ctx, `
+			SELECT id, device_uuid, name, type, brand, model, mac_address, ip_address,
+			       network_id, offline_since,
+			   CASE
+			         WHEN mac_address != '' AND offline_since < ? THEN 'silent_mac'
+			         WHEN mac_address = ''  AND offline_since < ? THEN 'silent_no_mac'
+			         WHEN mac_address != '' AND offline_since < ? AND EXISTS (
+			           SELECT 1 FROM devices d2
+			           WHERE d2.mac_address = devices.mac_address
+			             AND d2.id != devices.id
+			             AND d2.status = 'online'
+			         ) THEN 'roamed_orphan'
+			       END AS reason
+			FROM devices
+			WHERE scan_source = 'scanner_v2'
+			  AND status = 'offline'
+			  AND offline_since IS NOT NULL
+			  AND reason IS NOT NULL
+			LIMIT ?`,
+			macCutStr, noMacCutStr, roamedCutStr, s.batch)
+		if err != nil {
+			s.logger.Warn("cleanup: silent-device select failed", "error", err)
+			return
+		}
+		type candidate struct {
+			id           int64
+			uuid         string
+			name         string
+			devType      string
+			brand, model string
+			mac, ip      string
+			networkID    sql.NullInt64
+			offlineSince sql.NullTime
+			reason       string
+		}
+		var batch []candidate
+		for rows.Next() {
+			var c candidate
+			var netID sql.NullInt64
+			if err := rows.Scan(&c.id, &c.uuid, &c.name, &c.devType, &c.brand, &c.model,
+				&c.mac, &c.ip, &netID, &c.offlineSince, &c.reason); err != nil {
+				s.logger.Warn("cleanup: silent-device scan failed", "error", err)
+				break
+			}
+			c.networkID = netID
+			batch = append(batch, c)
+		}
+		rows.Close()
+
+		for _, c := range batch {
+			s.logDeviceRemoved(ctx, c.id, c.uuid, c.name, c.devType, c.brand, c.model,
+				c.mac, c.ip, c.networkID, c.reason)
+			if err := s.execWithBusyRetry(ctx, `DELETE FROM devices WHERE id = ?`, c.id); err != nil {
+				s.logger.Warn("cleanup: silent-device delete failed",
+					"device_id", c.id, "ip", c.ip, "mac", c.mac, "reason", c.reason, "error", err)
+				continue
+			}
+			totalDeleted++
+		}
+
+		// Under batch size ⇒ no more candidates this pass.
+		if int64(len(batch)) < s.batch {
+			break
+		}
+	}
+	if totalDeleted > 0 {
+		s.logger.Info("cleanup: pruned silent devices",
+			"count", totalDeleted,
+			"silent_mac_days", s.cfg.SilentDeviceDaysMAC,
+			"silent_no_mac_hours", s.cfg.SilentDeviceHoursNoMAC)
+	}
+}
+
+// logDeviceRemoved writes a device_removed audit row to change_log BEFORE the
+// device row is deleted (so the before snapshot is captured while the row still
+// exists; CASCADE will then clean up FK children but leave this change_log row —
+// change_log.entity_id has no FK, intentionally, so device history survives the
+// device). Minimal JSON before_data (identity fields) — not the full snapshot,
+// since the device is being deleted anyway and the purpose is a "what got
+// pruned and why" trail, not a full restore record.
+func (s *Service) logDeviceRemoved(ctx context.Context, id int64, uuid, name, devType, brand, model, mac, ip string, networkID sql.NullInt64, reason string) {
+	before := fmt.Sprintf(
+		`{"name":%q,"type":%q,"brand":%q,"model":%q,"mac_address":%q,"ip_address":%q,"device_uuid":%q,"status":"offline"}`,
+		name, devType, brand, model, mac, ip, uuid)
+	var netID any
+	if networkID.Valid {
+		netID = networkID.Int64
+	}
+	if err := s.execWithBusyRetry(ctx, `
+		INSERT INTO change_log (agent_id, network_id, change_type, entity_type, entity_id, before_data, after_data, detected_at)
+		VALUES (?, ?, 'device_removed', 'device', ?, ?, NULL, CURRENT_TIMESTAMP)`,
+		reason, netID, id, before); err != nil {
+		s.logger.Warn("cleanup: log device_removed failed", "device_id", id, "error", err)
+	}
+}
+
+// execWithBusyRetry runs a write statement against mainDB, retrying on
+// SQLITE_BUSY with a short backoff. This stands in for the busy_timeout PRAGMA
+// that the connection pool does NOT reliably apply to every pooled connection
+// (Go's database/sql opens fresh connections with default pragmas, so a write
+// that lands on a fresh connection gets an immediate BUSY instead of waiting).
+// The cleanup sweeper writes many rows in sequence while the heartbeat
+// syncStatusLoop (30s) and scanner may hold the write lock; without retry, ~7%
+// of deletes fail on a busy sweep. Retries up to ~5s total (mirroring the
+// intended busy_timeout=5000). Non-BUSY errors are returned immediately.
+func (s *Service) execWithBusyRetry(ctx context.Context, query string, args ...any) error {
+	const (
+		maxAttempts = 6
+		initialWait = 100 * time.Millisecond
+	)
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		_, err := s.mainDB.ExecContext(ctx, query, args...)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Retry only on SQLITE_BUSY (code 5) / "database is locked". Other
+		// errors (constraint, syntax) fail fast.
+		if !strings.Contains(err.Error(), "busy") && !strings.Contains(err.Error(), "locked") {
+			return err
+		}
+		wait := initialWait * (1 << attempt) // 100ms, 200ms, 400ms, 800ms, 1.6s
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return lastErr
 }

--- a/internal/service/scannerv2/cleanup/cleanup_test.go
+++ b/internal/service/scannerv2/cleanup/cleanup_test.go
@@ -31,7 +31,7 @@ func TestPruneDeviceNeighbors(t *testing.T) {
 	seedNeighbor(t, conn, 1, "aa:bb:cc:dd:ee:02", "Bridge-MIB", &now)
 
 	// Run with a 90-day window. The old edge should be removed; the fresh one kept.
-	svc := New(queries, nil, nil, config.RetentionConfig{
+	svc := New(queries, nil, nil, nil, config.RetentionConfig{
 		DeviceNeighborsDays: 90,
 		BatchSize:           1000,
 		SweepIntervalHours:  1,
@@ -56,7 +56,7 @@ func TestPruneDeviceNeighbors_ZeroDaysGuard(t *testing.T) {
 	require.NoError(t, createSwitch(t, queries, "switch-2"))
 	seedNeighbor(t, conn, 2, "aa:bb:cc:dd:ee:03", "LLDP", &old)
 
-	svc := New(queries, nil, nil, config.RetentionConfig{
+	svc := New(queries, nil, nil, nil, config.RetentionConfig{
 		DeviceNeighborsDays: 0, // not configured → guard: leave the table alone
 		BatchSize:           1000,
 		SweepIntervalHours:  1,

--- a/internal/service/scannerv2/cleanup/silent_device_test.go
+++ b/internal/service/scannerv2/cleanup/silent_device_test.go
@@ -1,0 +1,281 @@
+package cleanup
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/config"
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/testutil"
+)
+
+// insertDevice inserts a devices row with full control over the fields the
+// silent-device prune keys on (scan_source, status, mac_address, offline_since).
+// Returns the row id. Used instead of queries.CreateDevice because CreateDevice
+// defaults scan_source='manual' and doesn't let us set offline_since — both
+// critical to the prune logic under test.
+func insertDevice(t *testing.T, conn *sql.DB, name, scanSource, status, mac, ip string, offlineSince *time.Time) int64 {
+	t.Helper()
+	var offline any
+	if offlineSince != nil {
+		offline = offlineSince.UTC().Format(time.RFC3339Nano)
+	}
+	res, err := conn.ExecContext(context.Background(), `
+		INSERT INTO devices (device_uuid, name, type, status, scan_source, mac_address, ip_address, offline_since, tags, scan_attributes, user_attributes)
+		VALUES (?, ?, 'other', ?, ?, ?, ?, ?, '{}', '{}', '{}')`,
+		name+"-uuid", name, status, scanSource, mac, ip, offline)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+// countDevicesWithStatus counts devices matching the given status (helper for
+// prune assertions).
+func countDevicesWithStatus(t *testing.T, conn *sql.DB, status string) int64 {
+	t.Helper()
+	var c int64
+	require.NoError(t, conn.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM devices WHERE status = ?`, status).Scan(&c))
+	return c
+}
+
+// TestPruneSilentDevices_MAC_7d verifies a scanner-discovered device WITH a MAC
+// is pruned only after the 7-day silent window (SilentDeviceDaysMAC).
+func TestPruneSilentDevices_MAC_7d(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	// Device offline for 8 days (> 7d default) with a MAC → should be pruned.
+	insertDevice(t, conn, "old-mac", "scanner_v2", "offline", "aa:bb:cc:dd:ee:01", "10.0.0.1",
+		utcPtr(time.Now().AddDate(0, 0, -8)))
+	// Device offline for 5 days (< 7d) with a MAC → should be KEPT.
+	insertDevice(t, conn, "recent-mac", "scanner_v2", "offline", "aa:bb:cc:dd:ee:02", "10.0.0.2",
+		utcPtr(time.Now().AddDate(0, 0, -5)))
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var remaining int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE name = 'old-mac'`).Scan(&remaining))
+	require.Equal(t, int64(0), remaining, "8-day-silent MAC device must be pruned")
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE name = 'recent-mac'`).Scan(&remaining))
+	require.Equal(t, int64(1), remaining, "5-day-silent MAC device must be kept (< 7d window)")
+}
+
+// TestPruneSilentDevices_NoMAC_24h verifies a scanner-discovered device WITHOUT
+// a MAC is pruned after the 24h window (SilentDeviceHoursNoMAC), faster than the
+// MAC-bearing case.
+func TestPruneSilentDevices_NoMAC_24h(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	// Mac-less device offline 25h (> 24h) → pruned.
+	insertDevice(t, conn, "old-nomac", "scanner_v2", "offline", "", "10.0.0.3",
+		utcPtr(time.Now().Add(-25*time.Hour)))
+	// Mac-less device offline 12h (< 24h) → kept.
+	insertDevice(t, conn, "recent-nomac", "scanner_v2", "offline", "", "10.0.0.4",
+		utcPtr(time.Now().Add(-12*time.Hour)))
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var remaining int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE name = 'old-nomac'`).Scan(&remaining))
+	require.Equal(t, int64(0), remaining, "25h-silent mac-less device must be pruned")
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE name = 'recent-nomac'`).Scan(&remaining))
+	require.Equal(t, int64(1), remaining, "12h-silent mac-less device must be kept (< 24h window)")
+}
+
+// TestPruneSilentDevices_SkipsManualDevices verifies the scan_source guard: a
+// manually-added device (scan_source != 'scanner_v2') is NEVER auto-deleted,
+// even if it's been offline for years. This is the CMDB-semantic safety net.
+func TestPruneSilentDevices_SkipsManualDevices(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	// A manual device offline for a year with a MAC — must NOT be pruned.
+	insertDevice(t, conn, "manual-keep", "manual", "offline", "aa:bb:cc:dd:ee:99", "10.0.0.99",
+		utcPtr(time.Now().AddDate(-1, 0, 0)))
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var remaining int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE name = 'manual-keep'`).Scan(&remaining))
+	require.Equal(t, int64(1), remaining, "manual device must never be auto-pruned")
+}
+
+// TestPruneSilentDevices_SkipsOnlineDevices verifies an online device is never
+// pruned regardless of offline_since (it's online — offline_since should be NULL
+// anyway, but this guards the status='offline' filter explicitly).
+func TestPruneSilentDevices_SkipsOnlineDevices(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	// Online scanner device with a stale offline_since (shouldn't happen, but
+	// defensive) — must be kept because status='online'.
+	insertDevice(t, conn, "online-stale", "scanner_v2", "online", "aa:bb:cc:dd:ee:50", "10.0.0.50",
+		utcPtr(time.Now().AddDate(0, 0, -30)))
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	require.Equal(t, int64(1), countDevicesWithStatus(t, conn, "online"), "online device must not be pruned")
+}
+
+// TestPruneSilentDevices_RoamedOrphan verifies the cross-network migration
+// cleanup: a device whose MAC exists ONLINE in another network AND whose
+// offline_since is older than the roamed-orphan window is pruned (it's a stale
+// old-network leftover — the live copy is elsewhere).
+func TestPruneSilentDevices_RoamedOrphan(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	// Two networks so the same MAC can legitimately exist in both.
+	net1, err := queries.CreateNetwork(ctx, db.CreateNetworkParams{Name: "net-1"})
+	require.NoError(t, err)
+	net2, err := queries.CreateNetwork(ctx, db.CreateNetworkParams{Name: "net-2"})
+	require.NoError(t, err)
+
+	// The orphan: offline 20min (> 10min roamed window) in net-1.
+	orphanID := insertDevice(t, conn, "orphan", "scanner_v2", "offline", "aa:bb:cc:dd:ee:77", "10.0.0.77",
+		utcPtr(time.Now().Add(-20*time.Minute)))
+	_, err = conn.ExecContext(ctx, `UPDATE devices SET network_id = ? WHERE id = ?`, net1.ID, orphanID)
+	require.NoError(t, err)
+	// The live copy: online in net-2, same MAC.
+	liveID := insertDevice(t, conn, "live", "scanner_v2", "online", "aa:bb:cc:dd:ee:77", "192.168.2.77", nil)
+	_, err = conn.ExecContext(ctx, `UPDATE devices SET network_id = ? WHERE id = ?`, net2.ID, liveID)
+	require.NoError(t, err)
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var orphanGone int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE id = ?`, orphanID).Scan(&orphanGone))
+	require.Equal(t, int64(0), orphanGone, "roamed orphan (MAC online elsewhere, offline > window) must be pruned")
+	var liveKept int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE id = ?`, liveID).Scan(&liveKept))
+	require.Equal(t, int64(1), liveKept, "the live online copy must be kept")
+}
+
+// TestPruneSilentDevices_KeepsRoamedRecent verifies the roamed-orphan prune does
+// NOT fire too early: a device whose MAC is online elsewhere but whose
+// offline_since is RECENT (< the roamed window) is kept, so an in-progress
+// scan/roam can't race the prune.
+func TestPruneSilentDevices_KeepsRoamedRecent(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	net1, err := queries.CreateNetwork(ctx, db.CreateNetworkParams{Name: "net-1"})
+	require.NoError(t, err)
+	net2, err := queries.CreateNetwork(ctx, db.CreateNetworkParams{Name: "net-2"})
+	require.NoError(t, err)
+
+	// Offline only 2min (< 10min roamed window) — kept even though MAC is online elsewhere.
+	recentID := insertDevice(t, conn, "recent-orphan", "scanner_v2", "offline", "aa:bb:cc:dd:ee:88", "10.0.0.88",
+		utcPtr(time.Now().Add(-2*time.Minute)))
+	_, err = conn.ExecContext(ctx, `UPDATE devices SET network_id = ? WHERE id = ?`, net1.ID, recentID)
+	require.NoError(t, err)
+	liveID := insertDevice(t, conn, "live2", "scanner_v2", "online", "aa:bb:cc:dd:ee:88", "192.168.2.88", nil)
+	_, err = conn.ExecContext(ctx, `UPDATE devices SET network_id = ? WHERE id = ?`, net2.ID, liveID)
+	require.NoError(t, err)
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var kept int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM devices WHERE id = ?`, recentID).Scan(&kept))
+	require.Equal(t, int64(1), kept, "recent-roam orphan (< window) must be kept")
+}
+
+// TestPruneSilentDevices_LogsDeviceRemoved verifies each pruned device gets a
+// device_removed change_log row (with before snapshot + reason) BEFORE the
+// delete, so the audit trail survives the CASCADE.
+func TestPruneSilentDevices_LogsDeviceRemoved(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	insertDevice(t, conn, "audited", "scanner_v2", "offline", "aa:bb:cc:dd:ee:33", "10.0.0.33",
+		utcPtr(time.Now().AddDate(0, 0, -10)))
+
+	svc := New(queries, nil, nil, conn, config.RetentionConfig{
+		SilentDeviceDaysMAC:    7,
+		SilentDeviceHoursNoMAC: 24,
+		BatchSize:              1000,
+	})
+	svc.pruneSilentDevices(ctx)
+
+	var n int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM change_log WHERE change_type = 'device_removed'`).Scan(&n))
+	require.Equal(t, int64(1), n, "pruned device must get a device_removed change_log row")
+	var reason string
+	require.NoError(t, conn.QueryRowContext(ctx,
+		`SELECT agent_id FROM change_log WHERE change_type = 'device_removed' LIMIT 1`).Scan(&reason))
+	require.Equal(t, "silent_mac", reason, "change_log agent_id carries the prune reason")
+}
+
+// utcPtr returns a pointer to the UTC-normalized time (helper for the
+// offlineSince *time.Time params above).
+func utcPtr(t time.Time) *time.Time {
+	u := t.UTC()
+	return &u
+}

--- a/internal/service/scannerv2/runner/detect_lost.go
+++ b/internal/service/scannerv2/runner/detect_lost.go
@@ -93,10 +93,15 @@ func (rn *Runner) DetectLost(ctx context.Context, networkID sql.NullInt64, taskI
 	}
 	for _, l := range lost {
 		// Mark the device offline (scan-side lost; heartbeat has its own
-		// separate grace period for probe failures). Best-effort — a status
-		// write failure doesn't block the change_log emit.
+		// separate grace period for probe failures). Stamp offline_since so the
+		// silent-device retention sweep has the "how long gone" signal (issue
+		// #117). CASE guards so a device already offline keeps its original
+		// offline_since (the flip time, not re-stamped every lost-detection pass).
+		// Best-effort — a status write failure doesn't block the change_log emit.
 		if _, err := rn.dbConn.ExecContext(ctx,
-			`UPDATE devices SET status='offline', updated_at=? WHERE id=?`, now, l.DeviceID); err != nil {
+			`UPDATE devices SET status='offline',
+				offline_since = CASE WHEN status != 'offline' THEN ? ELSE offline_since END,
+				updated_at=? WHERE id=?`, now, now, l.DeviceID); err != nil {
 			rn.logger.Warn("detect-lost: mark offline failed", "device_id", l.DeviceID, "error", err)
 		}
 		// Emit device_lost (before_data = the device's pre-lost snapshot).

--- a/internal/service/scannerv2/runner/device_bridge.go
+++ b/internal/service/scannerv2/runner/device_bridge.go
@@ -225,11 +225,14 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 				UPDATE devices SET status='online',
 				    mac_address = ?,
 				    last_seen = COALESCE(last_seen, ?),
+				    offline_since=NULL,
 				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 				mac, now, now, now, existingID)
 			_, _ = rn.dbConn.ExecContext(ctx,
-				`UPDATE devices SET status='offline', updated_at=? WHERE id=?`,
-				now, replacedID)
+				`UPDATE devices SET status='offline',
+				    offline_since = CASE WHEN status != 'offline' THEN ? ELSE offline_since END,
+				    updated_at=? WHERE id=?`,
+				now, now, replacedID)
 			rn.logger.Warn("device bridge: device replaced (router/asset swap detected)",
 				"ip", rep.IP, "scanned_mac", mac, "replaced_device_id", replacedID,
 				"target_device_id", existingID,
@@ -252,6 +255,7 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 				    `+ipClause+`,
 				    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
 				    last_seen = COALESCE(last_seen, ?),
+				    offline_since=NULL,
 				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 				argsForRoamUpdate(roamed, rep.IP, mac, now, existingID)...)
 			if err != nil && roamed {
@@ -273,6 +277,7 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 					UPDATE devices SET status='online', ip_address = ?,
 					    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
 					    last_seen = COALESCE(last_seen, ?),
+					    offline_since=NULL,
 					    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 					rep.IP, mac, mac, now, now, now, existingID)
 				if err != nil {

--- a/internal/service/scannerv2/runner/lease_sweeper.go
+++ b/internal/service/scannerv2/runner/lease_sweeper.go
@@ -208,9 +208,13 @@ func (s *LeaseSweeper) expireStale(ctx context.Context, cutoff time.Time) int {
 			s.logger.Warn("lease sweeper: flap_count increment failed", "snapshot_id", l.ID, "error", err)
 		}
 		// Mark the device offline (always — the registry must reflect liveness
-		// regardless of event suppression).
+		// regardless of event suppression). Stamp offline_since on the flip (CASE
+		// guards so an already-offline device keeps its original stamp) for the
+		// silent-device retention sweep (issue #117).
 		if _, err := s.runner.dbConn.ExecContext(ctx,
-			`UPDATE devices SET status='offline', updated_at=? WHERE id=?`, now, l.DeviceID); err != nil {
+			`UPDATE devices SET status='offline',
+				offline_since = CASE WHEN status != 'offline' THEN ? ELSE offline_since END,
+				updated_at=? WHERE id=?`, now, now, l.DeviceID); err != nil {
 			s.logger.Warn("lease sweeper: mark offline failed", "device_id", l.DeviceID, "ip", l.IP, "error", err)
 		}
 		// Flap suppression: once past the threshold, stop emitting. The device is
@@ -254,7 +258,7 @@ func (s *LeaseSweeper) recoverFresh(ctx context.Context, cutoff time.Time) int {
 		// Capture the BEFORE snapshot while the row is still 'offline'.
 		before := s.runner.snapshotDevice(ctx, l.DeviceID)
 		if _, err := s.runner.dbConn.ExecContext(ctx,
-			`UPDATE devices SET status='online', last_seen=?, last_scanned_at=?, updated_at=? WHERE id=?`,
+			`UPDATE devices SET status='online', last_seen=?, last_scanned_at=?, offline_since=NULL, updated_at=? WHERE id=?`,
 			now, now, now, l.DeviceID); err != nil {
 			s.logger.Warn("lease sweeper: recover online failed", "device_id", l.DeviceID, "ip", l.IP, "error", err)
 			continue


### PR DESCRIPTION
Closes #117.

## What

Scanner-discovered devices (`scan_source='scanner_v2'`) that have had **no heartbeat** (all probe configs failing past `offline_threshold`) for longer than a configured window are physically deleted by the retention sweeper. Closes the "stale device rows accumulate forever" gap — the registry now self-cleans devices that genuinely disappeared, with a MAC-aware threshold.

## Windows (configurable, defaults per the issue)

| Case | Default | Why |
|------|---------|-----|
| **WITH a MAC** | `silent_device_days_mac` = **7d** | A real asset may be genuinely gone for a while (laptop on a trip, IoT powered off). |
| **WITHOUT a MAC** | `silent_device_hours_no_mac` = **24h** | A mac-less identity is unreliable (transient/duplicate discovery), pruned faster. |
| **Roamed orphan** | offline > 10min AND MAC online in another network | DHCP-roamed; the live copy is elsewhere, so this old-network row is a leftover. |

Manual devices (`scan_source != 'scanner_v2'`) are **never** auto-deleted — a human added them, a human removes them (CMDB semantics).

## Signal: new `devices.offline_since` column

Stamped on the **online→offline flip**, cleared on **recovery**. It's the authoritative "how long has this device had no heartbeat" timestamp. Distinct from `last_seen`, which is scan-derived and (a known separate bug) not even refreshed on heartbeat-online — so a new column was required rather than reusing `last_seen`.

- **"全面探测都失败才算"** = existing OR-aggregation (`anySuccess=false` advances the fail count). ✓ already correct.
- **"连续 5 个探测周期在线重置"** = recovery clears `offline_since`, mapping to the existing `fail_count=0` reset path (5 cycles = `offline_threshold`). ✓

`offline_since` is written at **every status-flip site**: `syncStatus` (center heartbeat), `DetectLost` (scan-side lost), lease sweeper (agent-network expire + recover), the runner's device bridge (online clears), and the batch admin endpoint. A `CASE` guards so an already-offline device keeps its original stamp (not re-stamped every sweep).

## Audit trail

Each deletion logs a `device_removed` row to `change_log` (with a before snapshot + reason in `agent_id`) **before** the `DELETE`, so the audit trail survives the CASCADE. `change_log.entity_id` has no FK (intentional), so device history outlives the device.

## Deploy verification (63.101)

- Migration: `offline_since backfill offline_devices_approximated=50`; column populated correctly (21/21 offline rows stamped, 72/72 online rows NULL).
- **First sweep pruned 29 devices** (6 `silent_mac` + 23 `silent_no_mac`) — devices genuinely silent >7d/24h (their backfilled `offline_since` from `updated_at` correctly aged them out). 30 total `device_removed` audit rows across two runs.
- Manual devices untouched: all 93 surviving devices are `scanner_v2`.
- `SQLITE_BUSY` on the per-row deletes (conn-pool doesn't apply `busy_timeout` to every pooled connection) → fixed via `execWithBusyRetry` (exponential backoff, ~5s total mirroring the intended busy_timeout). Verified: the 2 devices that failed on the first run were cleanly pruned on the redeployed binary with no BUSY warnings on the silent-device path.

## Tests

7 prune cases (MAC 7d, no-MAC 24h, manual-skip, online-skip, roamed orphan, roamed-recent-keep, change_log audit) + `TestSyncStatus_StampOfflineSince` (flip stamp/clear + already-offline-keeps-stamp). Full suite + race + gofmt/goimports/vet/sqlc compile all green.

## Not in scope

- The `last_seen` "never advances past first observation" bug (COALESCE in device_bridge) — separate issue, fixing it would change `last_seen`'s meaning for the whole codebase. `offline_since` is independent.
- The pool-wide `busy_timeout` not propagating to all connections — affects the other `sweepBatched` tables too (visible in logs). My new path self-protects via retry; a DSN-level `_busy_timeout` is the proper fix but is a separate infra change.