### PR TITLE
feat(liveness): expose last-seen/offline-since/last-online in device detail

### DIFF
--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -172,6 +172,18 @@ type DeviceResponse struct {
 	PrometheusLabels string     `json:"prometheus_labels"`
 	LastScannedAt    *time.Time `json:"last_scanned_at,omitempty"`
 	LastScanTaskID   *int64     `json:"last_scan_task_id,omitempty"`
+	// Liveness visibility (device-detail only). These let an operator judge
+	// whether the silent-device retention is about to prune a device.
+	//   - LastSeen: scan-derived "last observed online by a scan" (refreshed on
+	//     each alive re-scan).
+	//   - LastOnlineAt: the authoritative "last confirmed alive" timestamp from
+	//     the device_liveness verdict series (heartbeat/scan/lease). nil when the
+	//     device was never seen online or the store is unavailable.
+	//   - OfflineSince: when the device flipped to offline — the retention
+	//     clock's start. offline_since + threshold = prune expiry. nil when online.
+	LastSeen         *time.Time `json:"last_seen,omitempty"`
+	LastOnlineAt     *time.Time `json:"last_online_at,omitempty"`
+	OfflineSince     *time.Time `json:"offline_since,omitempty"`
 	OpenPorts        string     `json:"open_ports"`
 	DetectedServices string     `json:"detected_services"`
 	PrometheusURL    string     `json:"prometheus_url"`

--- a/internal/repository/device.go
+++ b/internal/repository/device.go
@@ -401,7 +401,7 @@ func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, col, 
 		d.mac_address, d.serial_number, d.purchase_date, d.warranty_expiry, d.tags, d.scan_source, d.prometheus_labels,
 		d.last_scanned_at, d.last_scan_task_id, d.open_ports, d.detected_services, d.prometheus_url, d.node_exporter_url,
 		d.last_scan_rtt_ms, d.scan_attributes, d.user_attributes, d.scan_vendor, d.scan_mac, d.scan_os, d.scan_hostname,
-		d.network_id, d.first_seen, d.last_seen,
+		d.network_id, d.first_seen, d.last_seen, d.offline_since,
 		d.created_at, d.updated_at,
 		n.name
 	FROM devices d
@@ -442,7 +442,7 @@ func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, col, 
 			&d.MacAddress, &d.SerialNumber, &d.PurchaseDate, &d.WarrantyExpiry, &d.Tags, &d.ScanSource, &d.PrometheusLabels,
 			&d.LastScannedAt, &d.LastScanTaskID, &d.OpenPorts, &d.DetectedServices, &d.PrometheusUrl, &d.NodeExporterUrl,
 			&d.LastScanRttMs, &d.ScanAttributes, &d.UserAttributes, &d.ScanVendor, &d.ScanMac, &d.ScanOs, &d.ScanHostname,
-			&d.NetworkID, &d.FirstSeen, &d.LastSeen,
+			&d.NetworkID, &d.FirstSeen, &d.LastSeen, &d.OfflineSince,
 			&d.CreatedAt, &d.UpdatedAt,
 			&networkName,
 		); err != nil {

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -77,6 +77,18 @@ func (s *DeviceService) Get(ctx context.Context, id int64) (*domain.DeviceRespon
 	}
 
 	resp := toDeviceResponse(device)
+	// Enrich with the authoritative "last confirmed alive" timestamp from the
+	// device_liveness series (cross-DB, heartbeat.db). Only the detail path pays
+	// this cost (one indexed query); the list path does not. Best-effort: a
+	// missing/empty store or query error leaves LastOnlineAt nil (the field is
+	// omitempty), never fails the whole request.
+	if s.heartbeatSvc != nil {
+		if lastOnline, err := s.heartbeatSvc.LastOnlineAt(ctx, id); err == nil {
+			resp.LastOnlineAt = lastOnline
+		} else {
+			slog.Warn("device detail: last_online_at lookup failed", "device_id", id, "error", err)
+		}
+	}
 	return &resp, nil
 }
 
@@ -319,6 +331,8 @@ func toDeviceResponse(d db.Device) domain.DeviceResponse {
 		PrometheusLabels: d.PrometheusLabels,
 		LastScannedAt:    d.LastScannedAt,
 		LastScanTaskID:   d.LastScanTaskID,
+		LastSeen:         d.LastSeen,
+		OfflineSince:     d.OfflineSince,
 		OpenPorts:        d.OpenPorts,
 		DetectedServices: d.DetectedServices,
 		PrometheusURL:    d.PrometheusUrl,

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -547,6 +547,19 @@ func (s *HeartbeatService) SampleLiveness(deviceID int64, status, source string)
 	})
 }
 
+// LastOnlineAt returns the device's most recent 'online' verdict timestamp from
+// the device_liveness series — the authoritative "last confirmed alive" signal.
+// Used by the device-detail API to surface liveness visibility (so an operator
+// can judge whether the silent-device retention is about to prune a device).
+// Returns nil when the store is unset (tests/agent) or the device was never seen
+// online. Proxies to HeartbeatStore.LastOnlineAt (heartbeat.db, cross-DB).
+func (s *HeartbeatService) LastOnlineAt(ctx context.Context, deviceID int64) (*time.Time, error) {
+	if s.store == nil {
+		return nil, nil
+	}
+	return s.store.LastOnlineAt(ctx, deviceID)
+}
+
 // ResetFailures clears the in-memory device-level failure counter for a device.
 // Called by the scanner's device bridge when a scan confirms the host is alive
 // and sets status=online — otherwise a stale counter from a prior flapping

--- a/internal/service/heartbeat_store.go
+++ b/internal/service/heartbeat_store.go
@@ -448,6 +448,32 @@ func (s *HeartbeatStore) OfflineDuration(ctx context.Context, deviceID int64) (t
 	return time.Since(last), true, nil
 }
 
+// LastOnlineAt returns the timestamp of the device's most recent 'online'
+// verdict sample — the authoritative "last confirmed alive" time, drawn from the
+// device_liveness series (written by heartbeat probing, scans, and the lease
+// sweeper). This is the most accurate liveness signal: unlike devices.last_seen
+// (scan-derived) it reflects ANY online verdict, including heartbeat ticks.
+// Returns (nil, nil) when the device has never been seen online (or its samples
+// aged out past retention) — callers then omit the field rather than guessing.
+// Mirrors OfflineDuration's query (same SELECT, returns the timestamp itself).
+func (s *HeartbeatStore) LastOnlineAt(ctx context.Context, deviceID int64) (*time.Time, error) {
+	var lastStr string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT checked_at FROM device_liveness WHERE device_id=? AND status='online' ORDER BY checked_at DESC LIMIT 1`,
+		deviceID).Scan(&lastStr)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // never seen online (or aged out)
+		}
+		return nil, err
+	}
+	last, err := time.Parse(time.RFC3339, lastStr)
+	if err != nil {
+		return nil, err
+	}
+	return &last, nil
+}
+
 // LivenessHistory returns the raw verdict samples for a device in [from, to],
 // newest-first. Used by the device-detail trend chart and for debugging the
 // multi-period judgment. Capped by limit (the caller pages). Bounds are

--- a/internal/service/heartbeat_store_test.go
+++ b/internal/service/heartbeat_store_test.go
@@ -146,3 +146,42 @@ func TestHeartbeatStore_DeviceLiveness_RetentionSweep(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, hist, 2, "recent samples survive the sweep")
 }
+
+// TestHeartbeatStore_LastOnlineAt verifies the "last confirmed alive" lookup:
+// the most recent 'online' verdict timestamp. nil when never online; the
+// timestamp itself (not a duration) when online samples exist.
+func TestHeartbeatStore_LastOnlineAt(t *testing.T) {
+	store, _ := openTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Device never seen online → nil, nil.
+	last, err := store.LastOnlineAt(ctx, 999)
+	require.NoError(t, err)
+	require.Nil(t, last, "never-online device returns nil")
+
+	// Seed: online at -60s, online at -20s (← last online), offline at -10s.
+	now := time.Now().UTC()
+	for i, s := range []struct {
+		status string
+		at     time.Duration
+	}{
+		{"online", -60 * time.Second},
+		{"online", -20 * time.Second},
+		{"offline", -10 * time.Second},
+	} {
+		store.EnqueueLiveness(livenessRow{
+			DeviceID: 42, Status: s.status, Source: "heartbeat", CheckedAt: now.Add(s.at),
+		})
+		_ = i
+	}
+	store.Start(context.Background())
+	waitForFlush(t, store, 3) // 3 samples seeded
+
+	last, err = store.LastOnlineAt(ctx, 42)
+	require.NoError(t, err)
+	require.NotNil(t, last, "device with online samples returns a timestamp")
+	// Must be the -20s sample, NOT the newer -10s offline one.
+	require.WithinDuration(t, now.Add(-20*time.Second), *last, 2*time.Second,
+		"LastOnlineAt is the most recent ONLINE sample, ignoring later offline ones")
+}

--- a/internal/service/scannerv2/runner/device_bridge.go
+++ b/internal/service/scannerv2/runner/device_bridge.go
@@ -224,7 +224,7 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 			_, _ = rn.dbConn.ExecContext(ctx, `
 				UPDATE devices SET status='online',
 				    mac_address = ?,
-				    last_seen = COALESCE(last_seen, ?),
+				    last_seen = ?,
 				    offline_since=NULL,
 				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 				mac, now, now, now, existingID)
@@ -254,7 +254,7 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 				UPDATE devices SET status='online',
 				    `+ipClause+`,
 				    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
-				    last_seen = COALESCE(last_seen, ?),
+				    last_seen = ?,
 				    offline_since=NULL,
 				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 				argsForRoamUpdate(roamed, rep.IP, mac, now, existingID)...)
@@ -276,7 +276,7 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 				_, err = rn.dbConn.ExecContext(ctx, `
 					UPDATE devices SET status='online', ip_address = ?,
 					    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
-					    last_seen = COALESCE(last_seen, ?),
+					    last_seen = ?,
 					    offline_since=NULL,
 					    last_scanned_at = ?, updated_at = ? WHERE id=?`,
 					rep.IP, mac, mac, now, now, now, existingID)

--- a/internal/service/scannerv2/runner/last_seen_test.go
+++ b/internal/service/scannerv2/runner/last_seen_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyDeviceBridge_LastSeenAdvancesOnRescan is the regression test for the
+// last_seen bug: the re-scan UPDATEs used `last_seen = COALESCE(last_seen, ?)`,
+// which only backfills a NULL and never advances an already-set value — so a
+// known device's last_seen froze at first-discovery time forever. The fix
+// (`last_seen = ?`) makes each alive re-scan refresh it to now, restoring the
+// documented "last observed ONLINE by a scan" semantics (which the liveness-
+// visibility feature now exposes in the API).
+func TestApplyDeviceBridge_LastSeenAdvancesOnRescan(t *testing.T) {
+	rn, _, conn := setupChangeDetectDB(t)
+	ctx := context.Background()
+
+	// First scan: device discovered, last_seen stamped ~now.
+	_, _ = rn.applyDeviceBridge(ctx,
+		reportFor("192.168.63.10", "camera", "hikvision", "aa:bb:cc:dd:ee:10"), rn.networkID, "")
+	var devID int64
+	require.NoError(t, conn.QueryRow(
+		`SELECT id FROM devices WHERE mac_address='aa:bb:cc:dd:ee:10'`).Scan(&devID))
+
+	var firstSeen time.Time
+	require.NoError(t, conn.QueryRow(`SELECT last_seen FROM devices WHERE id=?`, devID).Scan(&firstSeen))
+	require.False(t, firstSeen.IsZero(), "first scan stamps last_seen")
+
+	// Backdate last_seen to simulate the old bug state (frozen at an old time),
+	// then re-scan alive. The fix must advance last_seen to ~now, not leave it.
+	old := time.Now().UTC().Add(-24 * time.Hour)
+	_, err := conn.ExecContext(ctx, `UPDATE devices SET last_seen=? WHERE id=?`, old, devID)
+	require.NoError(t, err)
+
+	// Re-scan the same alive device.
+	_, _ = rn.applyDeviceBridge(ctx,
+		reportFor("192.168.63.10", "camera", "hikvision", "aa:bb:cc:dd:ee:10"), rn.networkID, "")
+
+	var after time.Time
+	require.NoError(t, conn.QueryRow(`SELECT last_seen FROM devices WHERE id=?`, devID).Scan(&after))
+	// Must have advanced well past the backdated 24h-ago value (within the last
+	// minute of now). Under the old COALESCE bug it would have stayed at `old`.
+	require.True(t, after.Sub(old) > 23*time.Hour, "last_seen must advance on alive re-scan (was %v, now %v)", old, after)
+	require.WithinDuration(t, time.Now().UTC(), after, 2*time.Minute, "last_seen refreshed to ~now")
+}

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -442,7 +442,7 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 			    prometheus_url = ?,
 			    node_exporter_url = ?,
 			    scan_attributes = ?,
-			    last_seen = COALESCE(last_seen, ?),
+			    last_seen = ?,
 			    last_scanned_at = ?,
 			    updated_at = ?
 			WHERE id = ?`,

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -577,7 +577,15 @@
 		"No Ports": "No open ports detected",
 		"No Services": "No services detected"
 	},
-	"scanfields": {
+	"liveness": {
+		"Title": "Liveness",
+		"Last Alive": "Last Confirmed Alive",
+		"Offline Since": "Offline Since",
+		"Cleanup Expiry": "Cleanup Expiry",
+		"In Window": "prunes in {remaining} (window: {threshold})",
+		"Prune Pending": "overdue — prune pending next sweep"
+	},
+		"scanfields": {
 		"Discovery": "Scan Discovery",
 		"Vendor": "Vendor",
 		"MAC": "MAC Address",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -577,7 +577,15 @@
 		"No Ports": "未检测到开放端口",
 		"No Services": "未检测到服务"
 	},
-	"scanfields": {
+	"liveness": {
+		"Title": "存活状态",
+		"Last Alive": "上次确认存活",
+		"Offline Since": "离线起始",
+		"Cleanup Expiry": "清理到期",
+		"In Window": "{remaining} 后清理（窗口：{threshold}）",
+		"Prune Pending": "已超期 — 下次扫描将清理"
+	},
+		"scanfields": {
 		"Discovery": "扫描发现",
 		"Vendor": "厂商",
 		"MAC": "MAC 地址",

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -177,6 +177,15 @@ export interface Device {
 	prometheus_labels?: string;
 	last_scanned_at?: string | null;
 	last_scan_task_id?: number | null;
+	// Liveness visibility (device-detail only). Lets an operator judge whether
+	// the silent-device retention is about to prune a device.
+	//   - last_seen: scan-derived "last observed online by a scan".
+	//   - last_online_at: authoritative "last confirmed alive" from the verdict
+	//     series (heartbeat/scan/lease). Preferred over last_seen when present.
+	//   - offline_since: when the device flipped offline — retention clock start.
+	last_seen?: string | null;
+	last_online_at?: string | null;
+	offline_since?: string | null;
 	open_ports?: string;
 	detected_services?: string;
 	prometheus_url?: string;

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -179,6 +179,49 @@
 			catch { return iso; }
 	}
 
+	// Silent-device retention thresholds (must mirror retention.silent_device_*
+	// defaults in configs/config.example.yaml: 7d with a MAC, 24h without). Used
+	// only to display a cleanup-expiry hint on the detail page; the authoritative
+	// cutoff is computed server-side from the configured values.
+	const SILENT_DEVICE_DAYS_MAC = 7;
+	const SILENT_DEVICE_HOURS_NO_MAC = 24;
+
+	// formatDurationMs renders a Duration (ms) as a compact "2d 3h" / "4h 12m"
+	// string for the cleanup-countdown display. (Distinct from formatDuration
+	// above, which takes seconds for uptime.)
+	function formatDurationMs(ms: number): string {
+		if (ms <= 0) return '0m';
+		const min = Math.floor(ms / 60000);
+		const h = Math.floor(min / 60);
+		const d = Math.floor(h / 24);
+		if (d > 0) return `${d}d ${h % 24}h`;
+		if (h > 0) return `${h}h ${min % 60}m`;
+		return `${min}m`;
+	}
+
+	// cleanupExpiry returns {expiryMs, remainingMs, overdue} for a scanner_v2
+	// device that is offline: expiryMs = how long until prune from offline_since;
+	// remainingMs = ms left (negative = already overdue); overdue = prune pending.
+	// Returns null for manual devices or devices without offline_since.
+	function cleanupExpiry(dev: typeof device): { expiryLabel: string; remainingLabel: string; overdue: boolean } | null {
+		if (!dev) return null;
+		if (dev.scan_source === 'manual' || !dev.scan_source) return null;
+		if (dev.status !== 'offline' || !dev.offline_since) return null;
+		const since = new Date(dev.offline_since).getTime();
+		if (Number.isNaN(since)) return null;
+		const thresholdMs = dev.mac_address
+			? SILENT_DEVICE_DAYS_MAC * 24 * 3600_000
+			: SILENT_DEVICE_HOURS_NO_MAC * 3600_000;
+		const now = Date.now();
+		const expiryAt = since + thresholdMs;
+		const remaining = expiryAt - now;
+		return {
+			expiryLabel: formatDurationMs(thresholdMs),
+			remainingLabel: remaining > 0 ? formatDurationMs(remaining) : formatDurationMs(0),
+			overdue: remaining <= 0,
+		};
+	}
+
 	function formatBytes(bytes: number | undefined | null): string {
 		if (!bytes || bytes <= 0) return '-';
 		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -1056,6 +1099,45 @@
 					<p class="text-xs text-muted italic">{m['scaninfo.Never Scanned']()}</p>
 				{/if}
 			</div>
+
+			<!-- Liveness Panel: last confirmed alive + silent-retention countdown.
+			     Surfaces offline_since (the prune clock) so an operator can judge
+			     whether the retention sweep is about to prune this device. -->
+			{#if device && (device.last_online_at || device.last_seen || device.offline_since)}
+				{@const expiry = cleanupExpiry(device)}
+				<div class="scan-info-panel">
+					<h3 class="scan-info-title">
+						<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+						{m['liveness.Title']()}
+					</h3>
+					<div class="scan-info-grid">
+						{#if device.last_online_at || device.last_seen}
+							<div class="scan-info-field">
+								<span class="scan-info-label">{m['liveness.Last Alive']()}</span>
+								<span class="scan-info-value">{formatTimestamp(device.last_online_at ?? device.last_seen)}</span>
+							</div>
+						{/if}
+						{#if device.status === 'offline' && device.offline_since}
+							<div class="scan-info-field">
+								<span class="scan-info-label">{m['liveness.Offline Since']()}</span>
+								<span class="scan-info-value">{formatTimestamp(device.offline_since)}</span>
+							</div>
+						{/if}
+						{#if expiry}
+							<div class="scan-info-field">
+								<span class="scan-info-label">{m['liveness.Cleanup Expiry']()}</span>
+								<span class="scan-info-value {expiry.overdue ? 'text-red-500 font-semibold' : ''}">
+									{#if expiry.overdue}
+										{m['liveness.Prune Pending']()}
+									{:else}
+										{m['liveness.In Window']({ threshold: expiry.expiryLabel, remaining: expiry.remainingLabel })}
+									{/if}
+								</span>
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
 
 			<!-- Prometheus Labels Panel -->
 			<div class="scan-info-panel">


### PR DESCRIPTION
Follow-up to #119 (silent-device retention). The retention wrote \`devices.offline_since\` correctly, but it was silently dropped at the \`toDeviceResponse\` mapping layer — operators had no way to see whether the cleanup clock was about to prune a device. This surfaces the liveness timestamps in the device-detail API + UI, and fixes the \`last_seen\` bug uncovered while wiring it.

## What

**3 fields added to \`DeviceResponse\`** (detail path only; list unchanged):
- \`last_seen\` — scan-derived "last observed online by a scan".
- \`last_online_at\` — the authoritative "last confirmed alive" from the \`device_liveness\` verdict series (heartbeat/scan/lease). Cross-DB query (heartbeat.db) on the detail path only; the most accurate liveness signal.
- \`offline_since\` — when the device flipped offline — the retention clock start. \`offline_since + threshold = prune expiry\`.

**Frontend**: device-detail overview gains a **存活状态 / Liveness** panel showing last-confirmed-alive, offline-since, and a cleanup-expiry countdown (mirrors the 7d-with-MAC / 24h-without thresholds from #119). List page unchanged. i18n keys (en/zh) added.

## Bug fix: last_seen never advanced

The re-scan UPDATEs used \`last_seen = COALESCE(last_seen, ?)\`, which only backfills a NULL and never advances an already-set value — so a known device's \`last_seen\` froze at first-discovery time forever (it had degenerated to "first seen"). Found while investigating why \`last_seen\` couldn't serve as the no-heartbeat signal (#119 added \`offline_since\` instead). Fixed to \`last_seen = ?\` at all 4 write sites. Verified no logic depended on the stale value (only the DTO mapper reads it, and it was being dropped).

## Deploy + browser verification (63.101)

- API exposes all 3 fields correctly (offline device: last_seen + offline_since populated, last_online_at null; online device: offline_since null).
- Playwright/chromium detail page renders the Liveness panel:
  - **Offline device (viomi-dishwasher, MAC)**: 上次确认存活 2026/7/9 · 离线起始 2026/7/31 19:32 · **清理到期 6d 23h 后清理（窗口：7d 0h）** ✓
  - **Online device**: shows 上次确认存活 only, no offline-since/expiry (online devices have no cleanup clock) ✓
- Layout aligned with the neighboring Scan Info panel; no JS errors.

## Tests

- \`TestApplyDeviceBridge_LastSeenAdvancesOnRescan\` — regression for the last_seen bug (backdate → re-scan → must advance).
- \`TestHeartbeatStore_LastOnlineAt\` — never-online → nil; most-recent-online sample returned (ignores later offline samples).
- Full Go suite + race + gofmt/goimports/vet/sqlc all green; frontend vitest 187/187 + svelte build clean.

## Scope notes

- \`last_online_at\` is cross-DB (heartbeat.db); only the detail path pays the cost (one indexed query). No N+1 on the list path.
- The cleanup-expiry countdown is computed client-side from the hardcoded 7d/24h thresholds (mirrors the defaults). If an operator changes \`retention.silent_device_*\`, the countdown would drift until a config endpoint is added (deferred).