### PR TITLE
feat(devices): device list sort — IP/network/vendor/hostname + numeric IP ordering

### DIFF
--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -172,15 +172,21 @@ type DeviceResponse struct {
 	PrometheusLabels string     `json:"prometheus_labels"`
 	LastScannedAt    *time.Time `json:"last_scanned_at,omitempty"`
 	LastScanTaskID   *int64     `json:"last_scan_task_id,omitempty"`
-	// Liveness visibility (device-detail only). These let an operator judge
-	// whether the silent-device retention is about to prune a device.
+	// Liveness visibility. These let an operator judge whether the silent-device
+	// retention is about to prune a device.
 	//   - LastSeen: scan-derived "last observed online by a scan" (refreshed on
-	//     each alive re-scan).
+	//     each alive re-scan). Populated on BOTH list and detail rows (it's a
+	//     column on devices).
 	//   - LastOnlineAt: the authoritative "last confirmed alive" timestamp from
 	//     the device_liveness verdict series (heartbeat/scan/lease). nil when the
-	//     device was never seen online or the store is unavailable.
+	//     device was never seen online or the store is unavailable. Detail-only:
+	//     the verdict series lives in a separate SQLite file (heartbeat.db) that
+	//     cannot be JOINed into the list query, so it's filled by the service on
+	//     Get, not List.
 	//   - OfflineSince: when the device flipped to offline — the retention
 	//     clock's start. offline_since + threshold = prune expiry. nil when online.
+	//     Populated on BOTH list and detail rows (column on devices); the list uses
+	//     it for the "offline for Nd/Nh" hover on the status dot.
 	LastSeen         *time.Time `json:"last_seen,omitempty"`
 	LastOnlineAt     *time.Time `json:"last_online_at,omitempty"`
 	OfflineSince     *time.Time `json:"offline_since,omitempty"`

--- a/internal/repository/device.go
+++ b/internal/repository/device.go
@@ -14,6 +14,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -243,6 +244,17 @@ func (r *DeviceRepository) CountByTypeForNetwork(ctx context.Context, networkID 
 // sortWhitelist maps a client-supplied sort token to the real column name. Any
 // token not in this map falls back to "id". This is the SQL-injection guard:
 // only these literals ever reach ORDER BY, never raw user input.
+//
+// The values here are column names (or `table.col`), NOT arbitrary SQL — they
+// are concatenated into `ORDER BY d.<col> <dir>` only after passing through
+// resolveSortExpr, which for ip_address substitutes a numeric-expression that
+// sorts IPs by value (not lexically). Because every value is a code constant
+// here and user input only selects which constant via the map lookup, there is
+// no injection surface. Columns already present in the listFilteredOn SELECT /
+// JOIN: id/name/type/status/ip_address/last_scanned_at/created_at on `d`, plus
+// n.name (from the LEFT JOIN networks) and scan_vendor/scan_hostname (promoted
+// scan columns on `d`). network_id is included for completeness even though the
+// UI sorts by network_name (a human-meaningful order) — agents/tools may use it.
 var sortWhitelist = map[string]string{
 	"id":              "id",
 	"name":            "name",
@@ -251,6 +263,79 @@ var sortWhitelist = map[string]string{
 	"type":            "type",
 	"last_scanned_at": "last_scanned_at",
 	"created_at":      "created_at",
+	"network_id":      "network_id",
+	"network_name":    "n.name",
+	"vendor":          "scan_vendor",
+	"hostname":        "scan_hostname",
+}
+
+// resolveSortExpr returns the ORDER BY expression for a client sort token,
+// already qualified for the listFilteredOn query (FROM devices d LEFT JOIN
+// networks n): plain columns are returned as `d.<col>` / `n.<col>`, and
+// ip_address is special-cased. Storing IPv4 as TEXT means a naive
+// `ORDER BY d.ip_address` sorts lexically, so 192.168.0.10 wrongly precedes
+// 192.168.0.9; we instead ORDER BY the dotted-quad re-emitted with each octet
+// zero-padded to 3 digits (009 < 010), which sorts numerically while staying a
+// pure string compare. The expression is built by ipSortKeyExpr from one
+// trim-call per octet, so it is readable and fully fixed at compile time (no
+// user input is interpolated — the injection guarantee of the plain-column path
+// is preserved). Non-IPv4 values (IPv6, empty) collapse to all-zero octets and
+// group at one end, which is acceptable for a TEXT column. Returns ("", false)
+// when the token is unknown so the caller applies its "id" default.
+func resolveSortExpr(key string) (expr string, ok bool) {
+	col, ok := sortWhitelist[key]
+	if !ok {
+		return "", false
+	}
+	if key == "ip_address" {
+		return ipSortKeyExpr("d.ip_address"), true
+	}
+	// sortWhitelist values are either bare columns (live on `d`) or already
+	// qualified ("n.name"). Qualify the bare ones; leave "n.x"/"d.x" alone.
+	if !strings.Contains(col, ".") {
+		return "d." + col, true
+	}
+	return col, true
+}
+
+// resolveDeviceSortExpr is the convenience wrapper: the sort expression for a
+// device-list token, defaulting to "d.id" when the token is unknown/empty.
+func resolveDeviceSortExpr(key string) string {
+	if expr, ok := resolveSortExpr(key); ok {
+		return expr
+	}
+	return "d.id"
+}
+
+// octetExpr returns a SQL expression that extracts the Nth dot-separated segment
+// of `ipCol` (1-indexed) and casts it to INTEGER. It is built by walking the
+// string N times: after each `instr(ip,'.')` we trim off the consumed prefix via
+// `substr(ip, instr(...)+1)`, so octet 2 = first segment of the once-trimmed
+// string, octet 3 = first segment of the twice-trimmed string, etc. The final
+// octet has no trailing dot, so instr(...)=0 and `substr(rest,1,-1)` would yield
+// ” — the CASE falls back to the whole `rest` when no dot remains. Used only to
+// compose ipSortKeyExpr; kept here so the per-octet noise lives in one place.
+func octetExpr(ipCol string, n int) string {
+	// `rest` starts as the whole column and loses one `.<octet>` prefix per step.
+	rest := ipCol
+	for i := 1; i < n; i++ {
+		// advance past the i-th dot: substr(rest, instr(rest,'.')+1)
+		rest = "substr(" + rest + ", instr(" + rest + ", '.') + 1)"
+	}
+	// dot position in the current `rest` (0 when this is the final octet)
+	dotPos := "instr(" + rest + ", '.')"
+	upTo := "substr(" + rest + ", 1, " + dotPos + " - 1)"
+	segment := "CASE WHEN " + dotPos + " > 0 THEN " + upTo + " ELSE " + rest + " END"
+	return "CAST(" + segment + " AS INTEGER)"
+}
+
+// ipSortKeyExpr composes the zero-padded IPv4 sort key: printf('%03d.%03d.%03d.%03d', o1, o2, o3, o4).
+func ipSortKeyExpr(ipCol string) string {
+	return "printf('%03d.%03d.%03d.%03d', " +
+		octetExpr(ipCol, 1) + ", " +
+		octetExpr(ipCol, 2) + ", " +
+		octetExpr(ipCol, 3) + ", " +
+		octetExpr(ipCol, 4) + ")"
 }
 
 // escapeLike escapes the SQL LIKE wildcards (\, %, _) in a search term so a
@@ -275,17 +360,14 @@ func escapeLike(s string) string {
 // sorting. The sort column is taken from sortWhitelist (never raw input), and
 // the search term is parameterized with ESCAPE, so there is no injection surface.
 func (r *DeviceRepository) ListFiltered(ctx context.Context, f domain.DeviceFilter) ([]DeviceWithNetwork, error) {
-	col := sortWhitelist[f.SortBy]
-	if col == "" {
-		col = "id"
-	}
+	sortExpr := resolveDeviceSortExpr(f.SortBy)
 	dir := "ASC"
 	if f.Order == "desc" {
 		dir = "DESC"
 	}
 	// Runs outside a transaction; for a snapshot-consistent list+count pair use
 	// ListFilteredWithCount instead.
-	return listFilteredOn(ctx, r.dbConn, f, col, dir)
+	return listFilteredOn(ctx, r.dbConn, f, sortExpr, dir)
 }
 
 // CountFiltered mirrors ListFiltered's WHERE so the page total reflects the
@@ -316,11 +398,8 @@ func strPtr(s string) *string { return &s }
 //
 // It returns the device page and the total matching the filter.
 func (r *DeviceRepository) ListFilteredWithCount(ctx context.Context, f domain.DeviceFilter) ([]DeviceWithNetwork, int64, error) {
-	// Resolve sort column once (shared by list + the tx wrapper).
-	col := sortWhitelist[f.SortBy]
-	if col == "" {
-		col = "id"
-	}
+	// Resolve sort expression once (shared by list + the tx wrapper).
+	sortExpr := resolveDeviceSortExpr(f.SortBy)
 	dir := "ASC"
 	if f.Order == "desc" {
 		dir = "DESC"
@@ -332,7 +411,7 @@ func (r *DeviceRepository) ListFilteredWithCount(ctx context.Context, f domain.D
 	}
 	defer func() { _ = tx.Rollback() }() // safe to roll back a committed tx (no-op)
 
-	list, err := listFilteredOn(ctx, tx, f, col, dir)
+	list, err := listFilteredOn(ctx, tx, f, sortExpr, dir)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -368,7 +447,7 @@ type DeviceWithNetwork struct {
 	NetworkName string
 }
 
-func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, col, dir string) ([]DeviceWithNetwork, error) {
+func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, sortExpr, dir string) ([]DeviceWithNetwork, error) {
 	var (
 		args           []any
 		statusVal      = f.Status
@@ -412,7 +491,7 @@ func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, col, 
 	  AND (? = '' OR d.created_at >= ?)
 	  AND (? = '' OR d.created_at <= ?)
 	  AND (? = 0 OR d.network_id = ?)
-	ORDER BY d.` + col + " " + dir + `
+	ORDER BY ` + sortExpr + " " + dir + `
 	LIMIT ? OFFSET ?`
 
 	args = append(args,

--- a/internal/repository/device_list_sort_test.go
+++ b/internal/repository/device_list_sort_test.go
@@ -1,0 +1,214 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"mibee-steward/internal/domain"
+)
+
+// setupSortTestDB creates an in-memory DB with the devices + networks shape that
+// listFilteredOn queries against (devices with the scan_* generated columns, a
+// networks row for the LEFT JOIN). It returns a DeviceRepository ready to call
+// ListFilteredWithCount. Callers seed devices via repo.Create + raw UPDATEs.
+func setupSortTestDB(t *testing.T) (*DeviceRepository, *sql.DB) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = conn.Exec(`
+		CREATE TABLE IF NOT EXISTS devices (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			device_uuid TEXT NOT NULL DEFAULT '',
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'other',
+			brand TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			location TEXT NOT NULL DEFAULT '',
+			purpose TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'unknown',
+			ip_address TEXT NOT NULL DEFAULT '',
+			mac_address TEXT NOT NULL DEFAULT '',
+			serial_number TEXT NOT NULL DEFAULT '',
+			purchase_date TEXT NOT NULL DEFAULT '',
+			warranty_expiry TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT '{}',
+			scan_source TEXT NOT NULL DEFAULT 'manual',
+			prometheus_labels TEXT NOT NULL DEFAULT '{}',
+			last_scanned_at TIMESTAMP,
+			last_scan_task_id INTEGER,
+			open_ports TEXT NOT NULL DEFAULT '[]',
+			detected_services TEXT NOT NULL DEFAULT '[]',
+			prometheus_url TEXT NOT NULL DEFAULT '',
+			node_exporter_url TEXT NOT NULL DEFAULT '',
+			last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+			scan_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(scan_attributes)),
+			user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
+			scan_vendor   TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.vendor')) STORED,
+			scan_mac      TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.mac')) STORED,
+			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
+			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
+			network_id INTEGER,
+			first_seen TIMESTAMP,
+			last_seen TIMESTAMP,
+			offline_since TIMESTAMP,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE IF NOT EXISTS networks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			cidr TEXT NOT NULL DEFAULT '',
+			site TEXT NOT NULL DEFAULT '',
+			agent_id TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`)
+	require.NoError(t, err)
+	return NewDeviceRepository(conn), conn
+}
+
+// seedIPs inserts devices with the given IPv4 strings (created in the listed
+// order, so id order == call order unless the test sorts).
+func seedIPs(t *testing.T, repo *DeviceRepository, ips ...string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, ip := range ips {
+		_, err := repo.Create(ctx, domain.CreateDeviceRequest{
+			Name:      "d-" + ip,
+			Type:      "pc",
+			IPAddress: ip,
+		})
+		require.NoError(t, err)
+	}
+}
+
+func ipsOf(rows []DeviceWithNetwork) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Device.IpAddress
+	}
+	return out
+}
+
+// TestListFiltered_IPSortIsNumericNotLexical is the regression guard for the
+// IPv4-in-TEXT ordering bug: a lexical ORDER BY puts 192.168.0.10 before
+// 192.168.0.9 ("1" < "9" at the 4th octet's first char). The zero-padded key
+// fixes it so .9 precedes .10, and cross-prefix ordering (10.x < 172.x < 192.x)
+// is correct too.
+func TestListFiltered_IPSortIsNumericNotLexical(t *testing.T) {
+	repo, _ := setupSortTestDB(t)
+	seedIPs(t, repo,
+		"192.168.0.10",
+		"192.168.0.9",
+		"10.0.0.1",
+		"192.168.1.1",
+		"172.16.0.2",
+		"10.0.0.10",
+	)
+
+	rows, _, err := repo.ListFilteredWithCount(context.Background(), domain.DeviceFilter{
+		SortBy: "ip_address",
+		Order:  "asc",
+		Limit:  100,
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"10.0.0.1", "10.0.0.10", "172.16.0.2", "192.168.0.9", "192.168.0.10", "192.168.1.1"},
+		ipsOf(rows),
+		"IPv4 sort must be numeric (.9 before .10), not lexical",
+	)
+
+	// Descending reverses the same numeric order.
+	rows, _, err = repo.ListFilteredWithCount(context.Background(), domain.DeviceFilter{
+		SortBy: "ip_address",
+		Order:  "desc",
+		Limit:  100,
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"192.168.1.1", "192.168.0.10", "192.168.0.9", "172.16.0.2", "10.0.0.10", "10.0.0.1"},
+		ipsOf(rows),
+	)
+}
+
+// TestListFiltered_NetworkNameSort covers the joined n.name column that the new
+// whitelist entry exposes. Two networks + devices on each; sorting by network
+// name groups devices by their network's human name.
+func TestListFiltered_NetworkNameSort(t *testing.T) {
+	repo, conn := setupSortTestDB(t)
+	ctx := context.Background()
+
+	// Two networks: "lan-b" (id 1) and "lan-a" (id 2). Seeded out of name order
+	// so only a network_name sort (not id) would put lan-a first.
+	_, err := conn.Exec(`INSERT INTO networks (id, name) VALUES (1, 'lan-b'), (2, 'lan-a')`)
+	require.NoError(t, err)
+
+	d1, err := repo.Create(ctx, domain.CreateDeviceRequest{Name: "on-b", IPAddress: "10.0.0.1"})
+	require.NoError(t, err)
+	d2, err := repo.Create(ctx, domain.CreateDeviceRequest{Name: "on-a", IPAddress: "10.0.0.2"})
+	require.NoError(t, err)
+	_, err = conn.Exec(`UPDATE devices SET network_id = 1 WHERE id = ?`, d1.ID)
+	require.NoError(t, err)
+	_, err = conn.Exec(`UPDATE devices SET network_id = 2 WHERE id = ?`, d2.ID)
+	require.NoError(t, err)
+
+	rows, _, err := repo.ListFilteredWithCount(ctx, domain.DeviceFilter{
+		SortBy: "network_name",
+		Order:  "asc",
+		Limit:  100,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "on-a", rows[0].Device.Name, "lan-a network should sort first")
+	require.Equal(t, "on-b", rows[1].Device.Name)
+}
+
+// TestListFiltered_VendorHostnameSort covers the scan_vendor / scan_hostname
+// generated columns exposed by the new whitelist entries.
+func TestListFiltered_VendorHostnameSort(t *testing.T) {
+	repo, conn := setupSortTestDB(t)
+	ctx := context.Background()
+
+	d1, err := repo.Create(ctx, domain.CreateDeviceRequest{Name: "z", IPAddress: "10.0.0.1"})
+	require.NoError(t, err)
+	d2, err := repo.Create(ctx, domain.CreateDeviceRequest{Name: "a", IPAddress: "10.0.0.2"})
+	require.NoError(t, err)
+	// vendor: "Zebra" on d1, "Alpha" on d2 → asc should put d2 first.
+	_, err = conn.Exec(`UPDATE devices SET scan_attributes = json_set(scan_attributes, '$.vendor', 'Zebra', '$.hostname', 'host-z') WHERE id = ?`, d1.ID)
+	require.NoError(t, err)
+	_, err = conn.Exec(`UPDATE devices SET scan_attributes = json_set(scan_attributes, '$.vendor', 'Alpha', '$.hostname', 'host-a') WHERE id = ?`, d2.ID)
+	require.NoError(t, err)
+
+	rows, _, err := repo.ListFilteredWithCount(ctx, domain.DeviceFilter{
+		SortBy: "vendor", Order: "asc", Limit: 100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a", rows[0].Device.Name, "vendor=Alpha should sort before Zebra")
+
+	rows, _, err = repo.ListFilteredWithCount(ctx, domain.DeviceFilter{
+		SortBy: "hostname", Order: "asc", Limit: 100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a", rows[0].Device.Name, "hostname=host-a should sort before host-z")
+}
+
+// TestListFiltered_DefaultSortByID verifies the fallback (unknown/empty sort key
+// → ORDER BY d.id) still holds after the sort-expr refactor.
+func TestListFiltered_DefaultSortByID(t *testing.T) {
+	repo, _ := setupSortTestDB(t)
+	seedIPs(t, repo, "192.168.0.10", "192.168.0.9", "10.0.0.1")
+
+	rows, _, err := repo.ListFilteredWithCount(context.Background(), domain.DeviceFilter{
+		Limit: 100, // no SortBy → default
+	})
+	require.NoError(t, err)
+	// id order == insertion order; an unknown sort key must NOT reorder.
+	require.Equal(t, []string{"192.168.0.10", "192.168.0.9", "10.0.0.1"}, ipsOf(rows))
+}


### PR DESCRIPTION
## What

Backend half of the device-list UX pass requested in this session ("精简列表项 + IP/网络可排序 + 展开栏重构 + 额外优化").

**Sort whitelist gains 4 keys** (all backed by columns already SELECTed/JOINed in `listFilteredOn` — no SQL structural change):

| `?sort=` | maps to | note |
|---|---|---|
| `network_name` | `n.name` | the LEFT JOIN networks column |
| `network_id` | `network_id` | |
| `vendor` | `scan_vendor` | generated column |
| `hostname` | `scan_hostname` | generated column |

**`ip_address` sort fixed to be numeric, not lexical.** IPv4 lives in a TEXT column, so the old `ORDER BY d.ip_address` put `192.168.0.10` before `192.168.0.9`. The new `resolveSortExpr` emits a zero-padded sort key (`printf('%03d.%03d.%03d.%03d', ...)`) built per-octet — `.9` now sorts before `.10`, and cross-prefix ordering (`10.x < 172.x < 192.x`) is correct. The expression is a compile-time constant (no user input interpolated), so the existing SQL-injection guarantee is preserved.

Sort-column resolution refactored from a bare column lookup into `resolveSortExpr` / `resolveDeviceSortExpr` helpers (qualified for the `devices d` / `networks n` query), shared by `ListFiltered` and `ListFilteredWithCount`.

Also corrects the stale "Liveness visibility (device-detail only)" comment on `DeviceResponse` — `last_seen` and `offline_since` are columns on `devices` and are populated on list rows too (the list uses `offline_since` for the status-dot "offline for Nd/Nh" hover).

## Why this PR is needed urgently (origin/main is currently inconsistent)

⚠️ **The frontend half of this feature already shipped with #121** (`feat(scanner): MAC 随机化检测 + 身份降级 (#118 Phase 1)`). The device-list UI changes — lean default columns, IP/network/last-scanned sortable headers, expand-panel device summary, status-dot offline-duration hover — were bundled into that commit (`web/src/routes/devices/+page.svelte`, `web/messages/{en,zh}.json`) and are live on `main` now.

But the **backend** this UI depends on is **not** on `main`. So `origin/main` is broken: clicking the "网络" column sends `sort=network_name`, but the current `sortWhitelist` rejects that key → silent fallback to `ORDER BY id`. The sort arrow lights up but nothing actually re-sorts. **This PR lands the backend and restores front/back consistency.**

(I verified this locally with a full build where front+back matched; the breakage only shows for anyone pulling `origin/main` as-is.)

## Tests

- `TestListFiltered_IPSortIsNumericNotLexical` — the regression guard. Asserts `192.168.0.9` precedes `192.168.0.10` (asc + desc), plus cross-prefix (`10.0.0.1 < 172.16.0.2 < 192.168.0.9`).
- `TestListFiltered_NetworkNameSort` / `TestListFiltered_VendorHostnameSort` — cover the new whitelist keys via JOIN / generated columns.
- `TestListFiltered_DefaultSortByID` — confirms the `id` fallback survives the sort-expr refactor.

All Go tests pass (`go test ./...`, 26 packages). `gofmt`/`goimports` clean. The IP-sort expression was validated against real SQLite before integration and re-verified end-to-end via the device list UI on the 192.168.63.101 test server (`.40 .103 .110 .114 .122 .135 .136 .138 .140` — fully numeric ordering).

## Out of scope

Frontend changes — already on `main` via #121, not duplicated here. Accepting that history as-is per discussion (no rebase/rewrite of a merged, deployed PR).