### PR TITLE
feat(web): 详情页/展开面板展示 OUI 厂商(NIC) + 修复 extras 泄漏

### DIFF
--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -557,6 +557,8 @@ func buildStoreScanAttributes(d scannerv2.DeviceRef, extra map[string]string, op
 		ScanSource:          "scanner_v2",
 		InferredType:        d.Type,
 		Vendor:              vendor,
+		OUIPrefix:           extra["oui_prefix"],
+		OUIVendor:           extra["oui_vendor"],
 		InferredDescription: extra["inferred_description"],
 		OS:                  extra["os_type"],
 		OSVersion:           extra["os_version"],
@@ -602,6 +604,7 @@ func buildStoreScanAttributes(d scannerv2.DeviceRef, extra map[string]string, op
 		"inferred_type": true, "inferred_brand": true, "inferred_description": true,
 		"os_type": true, "os_version": true, "kernel_version": true, "firmware_version": true,
 		"node_hostname": true, "sys_name": true, "mac": true,
+		"oui_prefix": true, "oui_vendor": true,
 		"memory_total_bytes": true, "cpu_count": true, "uptime_seconds": true,
 		"inferred_location": true,
 	}
@@ -823,7 +826,13 @@ func (r *SQLiteRepository) EnrichDeviceByMAC(ctx context.Context, mac string, fi
 
 	// Remaining unknown keys go into scan_attributes.extras.
 	unknown := make(map[string]string)
-	known := map[string]bool{"vendor": true, "model": true, "type": true, "hostname": true, "sys_name": true}
+	// "known" lists Fields keys that map to typed scan_attributes columns (or are
+	// otherwise handled) and must NOT leak into the free-form Extras panel. Keep
+	// in sync with the ScanAttributes struct + the orchestrator's evidence fold.
+	known := map[string]bool{
+		"vendor": true, "model": true, "type": true, "hostname": true, "sys_name": true,
+		"mac": true, "oui_prefix": true, "oui_vendor": true,
+	}
 	for k, v := range fields {
 		if !known[k] && v != "" {
 			unknown[k] = v

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -88,6 +88,7 @@
 		"IP Address": "IP Address",
 		"MAC Address": "MAC Address",
 		"Vendor": "Vendor",
+		"OUI Vendor": "OUI Vendor (NIC)",
 		"Hostname": "Hostname",
 		"Serial Number": "Serial Number",
 		"Purchase Date": "Purchase Date",
@@ -593,6 +594,7 @@
 		"scanfields": {
 		"Discovery": "Scan Discovery",
 		"Vendor": "Vendor",
+		"OUI Vendor": "OUI Vendor (NIC)",
 		"MAC": "MAC Address",
 		"Locally Administered MAC": "Locally Admin.",
 		"Locally Administered MAC Hint": "Locally-administered MAC (U/L bit set) — assigned locally, not from an IEEE OUI/MA-S/MA-M block. The bit is neutral fact: it cannot distinguish privacy randomization (unstable) from a locally fixed setting (stable, e.g. soft-router/hypervisor). Does not change device identity.",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -88,6 +88,7 @@
 		"IP Address": "IP 地址",
 		"MAC Address": "MAC 地址",
 		"Vendor": "厂商",
+		"OUI Vendor": "OUI 厂商 (网卡)",
 		"Hostname": "主机名",
 		"Serial Number": "序列号",
 		"Purchase Date": "购买日期",
@@ -593,6 +594,7 @@
 		"scanfields": {
 		"Discovery": "扫描发现",
 		"Vendor": "厂商",
+		"OUI Vendor": "OUI 厂商 (网卡)",
 		"MAC": "MAC 地址",
 		"Locally Administered MAC": "本地管理",
 		"Locally Administered MAC Hint": "本地管理 MAC(U/L 位置位)—— 由本地分配,非 IEEE OUI/MA-S/MA-M 注册块。该位是中性事实:无法区分隐私随机化(不稳定)与本地固定设置(稳定,如软路由/虚拟机)。不改变设备身份。",

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -1180,6 +1180,12 @@ interface AddDevicesResponse {
 								<span class="text-text truncate">{sa?.vendor || device.brand}</span>
 							</summary>
 						{/if}
+						{#if sa?.oui_vendor}
+							<summary class="flex flex-col gap-0.5 min-w-0" title={sa?.oui_prefix ? `IEEE block ${sa.oui_prefix}` : ''}>
+								<span class="text-muted">{m['devices.OUI Vendor']()}</span>
+								<span class="font-mono text-text truncate">{sa?.oui_vendor}</span>
+							</summary>
+						{/if}
 						{#if device.model}
 							<summary class="flex flex-col gap-0.5 min-w-0">
 								<span class="text-muted">{m['devices.Model']()}</span>

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -1182,6 +1182,7 @@
 				</h3>
 				<div class="scan-info-grid">
 					{#if sa.vendor}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Vendor']()}</span><span class="scan-info-value">{sa.vendor}</span></div>{/if}
+					{#if sa.oui_vendor}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.OUI Vendor']()}</span><span class="scan-info-value font-mono text-xs" title={sa.oui_prefix ? `IEEE block ${sa.oui_prefix}` : ''}>{sa.oui_vendor}</span></div>{/if}
 					{#if sa.mac}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.MAC']()}</span><span class="scan-info-value font-mono text-xs">{sa.mac}{#if sa.mac_is_locally_administered}<span class="badge badge-warning ml-2 align-middle" title={m['scanfields.Locally Administered MAC Hint']()}>{m['scanfields.Locally Administered MAC']()}</span>{/if}</span></div>{/if}
 					{#if sa.hostname}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.Hostname']()}</span><span class="scan-info-value">{sa.hostname}</span></div>{/if}
 					{#if sa.os || sa.os_version}<div class="scan-info-field"><span class="scan-info-label">{m['scanfields.OS']()}</span><span class="scan-info-value">{[sa.os, sa.os_version].filter(Boolean).join(' ')}</span></div>{/if}


### PR DESCRIPTION
feat(web): show OUI vendor (NIC silicon) in device detail + expand panel

Phase 2 (#124) added oui_prefix + oui_vendor as factual IEEE-registry fields
(the NIC silicon vendor, distinct from the device's self-declared `vendor`).
This surfaces them in the UI so users can see both — they differ in OEM/rebrand/
virtualization cases.

- Detail Discovery panel: a new "OUI Vendor (NIC)" row after Vendor, showing
  oui_vendor with the matched IEEE block (oui_prefix) as a tooltip.
- Expand-row device summary: same field after Vendor.
- i18n (en/zh): "OUI Vendor" = "OUI Vendor (NIC)" / "OUI 厂商 (网卡)".

Also fixes an extras-leak the browser test surfaced: the store's
RecordDevice/buildStoreScanAttributes path let oui_prefix/oui_vendor (and mac)
fall through into scan_attributes.extras (visible in the Extras panel as raw
OUI_PREFIX/OUI_VENDOR keys). Added them to the known-keys maps in both
buildStoreScanAttributes and EnrichDeviceByMAC so they map to the typed fields
and stay out of Extras.

Verified on 192.168.63.101: detail + expand panels show "OUI 厂商 (网卡)
Raspberry Pi Trading"; after a fresh re-scan the Extras panel no longer contains
oui_prefix/oui_vendor (they remain as top-level typed fields).

Refs #118.
