### PR TITLE
docs: 补全 MAC/OUI 文档 (CHANGELOG #125 + api.md + configuration.md + NOTICE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@ sub-assignee).
   curated table is a hand-authored CC-BY-SA subset, not an IEEE reproduction;
   the full IEEE set stays an optional runtime download.
 
+### UI: OUI vendor (NIC silicon) surfaced in device views
+**Follow-up to the OUI vendor inference above** — the new `oui_vendor` /
+`oui_prefix` fields (Phase 2) are now visible in the UI, kept distinct from the
+device's self-declared `vendor` brand.
+
+- **Device detail Discovery panel**: a new "OUI Vendor (NIC)" row after Vendor,
+  showing `oui_vendor` with the matched IEEE block (`oui_prefix`) as a tooltip.
+- **Expand-row device summary**: the same field after Vendor.
+- **Extras-leak fix**: the store's `RecordDevice`/`buildStoreScanAttributes`
+  path was letting `oui_prefix`/`oui_vendor` (and `mac`) fall through into
+  `scan_attributes.extras` (visible as raw `OUI_PREFIX`/`OUI_VENDOR` keys in the
+  Extras panel). They're now mapped to the typed fields and kept out of Extras.
+
 ## [0.4.0] - 2026-07-29
 
 **Router-resident discovery + OpenWrt deployment + device-persistence rewrite.**

--- a/NOTICE
+++ b/NOTICE
@@ -47,9 +47,20 @@ github.com/Mi-Bee-Studio/mibee-fingerprints-go are licensed under
 Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA-4.0).
 See configs/fingerprints/README.md for corpus attribution and provenance.
 
+== Embedded curated OUI vendor table ==
+
+The hand-authored curated MAC→vendor table embedded in the binary
+(internal/service/scannerv2/vendor/oui_curated.txt, source configs/oui-curated.txt)
+is licensed CC-BY-SA-4.0. It is a MiBee-authored subset of well-known vendor
+OUI prefixes, NOT a reproduction of the IEEE registry. The full IEEE registry
+(MA-L/MA-M/MA-S) is an optional runtime download (scripts/fetch-oui.sh) and is
+NOT bundled — it is loaded from scanner.oui_path when configured, overriding the
+embedded subset.
+
 Provenance of imported identification data:
-- Rapid7 Recog fingerprints     — Apache-2.0 (imported via cmd/fpimport)
-- IEEE OUI registry             — factual data, freely redistributable
+- Rapid7 Recog fingerprints       — Apache-2.0 (imported via cmd/fpimport)
+- IEEE OUI/MA-S/MA-M registry     — factual data, "All rights reserved" (IEEE);
+                                    cited, NOT relicensed into the CC-BY-SA corpus
 - IANA Private Enterprise Numbers — factual data, freely redistributable
 
 == Explicitly NOT included ==

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -203,11 +203,24 @@ List devices with filtering and pagination.
       "description": "Primary web hosting server",
       "status": "online",
       "ip_address": "192.168.1.100",
-      "mac_address": "00:1A:2B:3C:4D:5E",
+      "mac_address": "00:1a:2b:3c:4d:5e",
       "serial_number": "DELL123456",
       "purchase_date": "2022-01-15",
       "warranty_expiry": "2025-01-15",
       "tags": "web,primary",
+      "scan_attributes": {
+        "vendor": "Dell Inc.",
+        "oui_prefix": "001A2B",
+        "oui_vendor": "Dell Inc.",
+        "mac": "00:1a:2b:3c:4d:5e",
+        "mac_is_locally_administered": false,
+        "mac_is_multicast": false,
+        "hostname": "server-01",
+        "os": "Linux",
+        "inferred_type": "server",
+        "inferred_type_source": "protocol",
+        "scan_source": "scanner_v2"
+      },
       "created_at": "2023-01-01T00:00:00Z",
       "updated_at": "2023-01-01T00:00:00Z"
     }
@@ -215,6 +228,17 @@ List devices with filtering and pagination.
   "total": 1
 }
 ```
+
+**`scan_attributes` (engine-written discovery aggregation)** — a JSON object on each device carrying what a scan discovered. MAC/OUI-relevant fields:
+
+| Field | Description |
+|-------|-------------|
+| `vendor` | Device's SELF-DECLARED brand (via SNMP sysObjectID / HTTP Server header / TLS cert CN); falls back to OUI vendor when none of those fired. |
+| `oui_prefix` | The IEEE assignment block the MAC matched via longest-prefix lookup — 6 hex (MA-L /24), 7 hex (MA-M /28), or 9 hex (MA-S /36). Empty when no OUI table loaded or MAC unknown/locally administered. |
+| `oui_vendor` | The IEEE-registered organization name for `oui_prefix` — the **NIC silicon vendor**, distinct from `vendor` (they differ in OEM/rebrand/virtualization cases). |
+| `mac` | Normalized lowercase MAC (`aa:bb:cc:..`). |
+| `mac_is_locally_administered` | Neutral factual flag: the U/L bit (first octet `& 0x02`) is set — MAC assigned locally, not from an IEEE block. The bit CANNOT distinguish privacy randomization (unstable) from a locally fixed setting (stable), so this is observability-only and does NOT change device identity. |
+| `mac_is_multicast` | The I/G bit (first octet `& 0x01`) is set — a real device should never source from a multicast MAC; data-hygiene flag. |
 
 ### GET /api/v1/devices/stats
 Get device statistics (counts by status and type).

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -265,6 +265,8 @@ The network scanner uses a plugin-based 5-layer architecture (probe → classify
 | `scanner.persist_raw_evidence` | bool | false | Write every probe observation to `service_evidence` (voluminous — enable for debugging only) |
 | `scanner.ebpf.enabled` | bool | false | Enable the eBPF passive observer (no-op unless built with `make build-with-ebpf`) |
 | `scanner.ebpf.interfaces` | []string | [] | Interfaces to attach the TC program to (empty = all non-loopback) |
+| `scanner.oui_path` | string | "" | Path to an IEEE OUI vendor file (MA-L+MA-M+MA-S, produced by `scripts/fetch-oui.sh`). Empty = use the embedded curated CC-BY-SA table (out-of-box coverage of common vendors). Override: `MIBEE_SCANNER_OUI_PATH`. |
+| `scanner.fingerprint_path` | string | "" | Directory of fingerprint YAML rules (see `docs/fingerprint-spec.md`). Empty = rules embedded in the binary. |
 | `scanner.pipeline_defaults.*` | various | — | Per-stage enable flags + `default_ports` (expanded to include camera + prometheus ports) |
 
 **Synchronous scan limit**: `POST /scanner/scan` rejects targets >1024 IPs with HTTP 413. Use the async task API (`POST /scanner/tasks` + `/trigger`) for larger ranges.

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -201,11 +201,24 @@
       "description": "主要 Web 托管服务器",
       "status": "online",
       "ip_address": "192.168.1.100",
-      "mac_address": "00:1A:2B:3C:4D:5E",
+      "mac_address": "00:1a:2b:3c:4d:5e",
       "serial_number": "DELL123456",
       "purchase_date": "2022-01-15",
       "warranty_expiry": "2025-01-15",
       "tags": "web,primary",
+      "scan_attributes": {
+        "vendor": "Dell Inc.",
+        "oui_prefix": "001A2B",
+        "oui_vendor": "Dell Inc.",
+        "mac": "00:1a:2b:3c:4d:5e",
+        "mac_is_locally_administered": false,
+        "mac_is_multicast": false,
+        "hostname": "server-01",
+        "os": "Linux",
+        "inferred_type": "server",
+        "inferred_type_source": "protocol",
+        "scan_source": "scanner_v2"
+      },
       "created_at": "2023-01-01T00:00:00Z",
       "updated_at": "2023-01-01T00:00:00Z"
     }
@@ -213,6 +226,17 @@
   "total": 1
 }
 ```
+
+**`scan_attributes`（引擎写入的扫描发现聚合）** — 每个设备上的 JSON 对象，承载扫描发现的信息。MAC/OUI 相关字段：
+
+| 字段 | 描述 |
+|-------|-------------|
+| `vendor` | 设备**自报**品牌（经 SNMP sysObjectID / HTTP Server 头 / TLS 证书 CN）；以上都未命中时回落到 OUI 厂商。 |
+| `oui_prefix` | MAC 经最长前缀匹配命中的 IEEE 分配块——6 hex（MA-L /24）、7 hex（MA-M /28）或 9 hex（MA-S /36）。未加载 OUI 表或 MAC 未知/本地管理时为空。 |
+| `oui_vendor` | `oui_prefix` 对应的 IEEE 注册组织名——**NIC 芯片厂商**，与 `vendor` 分开（OEM/贴牌/虚拟化场景下两者不同）。 |
+| `mac` | 规范化小写 MAC（`aa:bb:cc:..`）。 |
+| `mac_is_locally_administered` | 中性事实标记：U/L 位（首字节 `& 0x02`）置位——MAC 由本地分配，非 IEEE 块。该位**无法**区分隐私随机化（不稳定）与本地固定设置（稳定），因此仅作观测，**不改变设备身份**。 |
+| `mac_is_multicast` | I/G 位（首字节 `& 0x01`）置位——真实设备不应从多播 MAC 发出；数据卫生标记。 |
 
 ### GET /api/v1/devices/stats
 获取设备统计信息（按状态和类型的计数）。

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -268,6 +268,8 @@ export MIBEE_LOG_FORMAT=json
 | `scanner.persist_raw_evidence` | bool | false | 将每次探测观测写入 `service_evidence`（数据量大——仅调试时开启） |
 | `scanner.ebpf.enabled` | bool | false | 启用 eBPF 被动观测器（除非用 `make build-with-ebpf` 构建否则为 no-op） |
 | `scanner.ebpf.interfaces` | []string | [] | 挂载 TC 程序的网卡（空 = 所有非环回口） |
+| `scanner.oui_path` | string | "" | IEEE OUI 厂商映射文件路径（MA-L+MA-M+MA-S，由 `scripts/fetch-oui.sh` 生成）。空 = 用内嵌精简 CC-BY-SA 表（开箱即用，覆盖常见厂商）。环境变量覆盖：`MIBEE_SCANNER_OUI_PATH`。 |
+| `scanner.fingerprint_path` | string | "" | 指纹 YAML 规则目录（见 `docs/fingerprint-spec.md`）。空 = 用二进制内嵌规则。 |
 | `scanner.pipeline_defaults.*` | various | — | 各阶段开关 + `default_ports`（已扩展含摄像头 + prometheus 端口） |
 
 **同步扫描限制**：`POST /scanner/scan` 对 >1024 IP 的目标返回 HTTP 413。更大范围请用异步任务 API（`POST /scanner/tasks` + `/trigger`）。


### PR DESCRIPTION
文档收尾:补全 #123/#124/#125 三个 PR 后遗漏的 tracked 文档,并在 issue #118 确定性 MAC 提取这条线全闭环后更新发布说明。

调研发现 AGENTS.md(3 个)内容也过时(描述已撤销的身份降级),但它们是 gitignored 本地文件、不进 PR —— 本次同步到本地,提交的只有 tracked 文档。

## CHANGELOG
- 加 #125 的 `[Unreleased]` 条目(oui_vendor UI 展示 + extras 泄漏修复),之前只覆盖了 #123/#124。

## docs/{en,zh}/api.md
- 设备响应示例加 `scan_attributes` 子对象(含 oui_prefix/oui_vendor/mac_is_locally_administered/mac_is_multicast)。
- 加字段表,重点说明 `oui_vendor`(NIC 芯片厂商)与 `vendor`(设备自报品牌)的语义区别,以及 U/L 位是中性观测标记(不改变身份)。

## docs/{en,zh}/configuration.md
- Scanner 配置表加 `scanner.oui_path` 行(空 = 内嵌精简 CC-BY-SA 表,非空 = 用户全量 IEEE 文件),顺带补 `scanner.fingerprint_path`。

## NOTICE
- 加"Embedded curated OUI vendor table"段(说明内嵌表是 CC-BY-SA 手工子集,非 IEEE 复制;全量 IEEE 是可选下载,不内嵌)。
- 修正 IEEE OUI 行措辞:从"freely redistributable"改为"All rights reserved, cited not relicensed"(与 fingerprint-spec §8 / architecture.md 一致,更准确)。

Refs #118。
