### PR TITLE
fix: 扫描任务状态更新 / agent 命令 Complete 静默吞错 (#130)

### DIFF
--- a/internal/api/handler/agent_command.go
+++ b/internal/api/handler/agent_command.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -204,7 +205,14 @@ func (h *AgentCommandHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		Status string `json:"status"` // "done" or "failed"
 		Result string `json:"result"` // optional JSON detail
 	}
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	// Empty body is allowed (defaults to status="done"); a malformed body is
+	// NOT — silently defaulting would record a broken agent payload as a
+	// successful completion, hiding the real outcome (#130).
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		slog.Warn("agent command complete: malformed body", "command_id", id, "error", err)
+		Error(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
 	if req.Status != "done" && req.Status != "failed" {
 		req.Status = "done"
 	}

--- a/internal/service/scannerv2/runner/runner.go
+++ b/internal/service/scannerv2/runner/runner.go
@@ -286,30 +286,38 @@ func (rn *Runner) Run(ctx context.Context, taskID int64, targets string, timeout
 	}); err != nil {
 		rn.logger.Error("scan runner: finalize run failed", "run_id", runID, "error", err)
 	}
-	// 5. Update task last-run status (best-effort).
-	_ = rn.queries.UpdateScanTaskStatus(ctx, db.UpdateScanTaskStatusParams{
+	// 5. Update task last-run status (best-effort) — log on failure so a
+	// stale last_run_status (task UI stuck on "running") is observable.
+	if err := rn.queries.UpdateScanTaskStatus(ctx, db.UpdateScanTaskStatusParams{
 		LastRunAt:     &finish,
 		LastRunStatus: strPtr("completed"),
 		ID:            taskID,
-	})
+	}); err != nil {
+		rn.logger.Debug("scan runner: finalize task status update failed", "task_id", taskID, "run_id", runID, "error", err)
+	}
 }
 
 // failRun marks a run failed and updates the task's last-run status.
 func (rn *Runner) failRun(ctx context.Context, runID, taskID int64, duration time.Duration, msg string) {
 	rn.logger.Error("scan runner: run failed", "run_id", runID, "task_id", taskID, "error", msg)
 	finish := time.Now()
-	_ = rn.queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{
+	// best-effort: log on failure so the run/task status reflects reality.
+	if err := rn.queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{
 		Status:       "failed",
 		DurationMs:   duration.Milliseconds(),
 		ErrorMessage: msg,
 		FinishedAt:   &finish,
 		ID:           runID,
-	})
-	_ = rn.queries.UpdateScanTaskStatus(ctx, db.UpdateScanTaskStatusParams{
+	}); err != nil {
+		rn.logger.Debug("scan runner: failRun run-status update failed", "run_id", runID, "task_id", taskID, "error", err)
+	}
+	if err := rn.queries.UpdateScanTaskStatus(ctx, db.UpdateScanTaskStatusParams{
 		LastRunAt:     &finish,
 		LastRunStatus: strPtr("failed"),
 		ID:            taskID,
-	})
+	}); err != nil {
+		rn.logger.Debug("scan runner: failRun task-status update failed", "task_id", taskID, "run_id", runID, "error", err)
+	}
 }
 
 // persistHost writes the per-host scan_result, then upserts the device and (for

--- a/internal/service/scannerv2/taskservice/taskservice.go
+++ b/internal/service/scannerv2/taskservice/taskservice.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
@@ -307,11 +308,16 @@ func (s *Service) CancelTask(ctx context.Context, id int64) error {
 		return ErrScanNotRunning
 	}
 	if run, err := s.queries.GetLatestRun(ctx, id); err == nil && run.Status == "running" {
-		_ = s.queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{
+		// best-effort: mark the in-flight run cancelled so the UI does not
+		// show "running" forever. Log on failure — without this the run row
+		// stays stuck and the user cannot tell cancel didn't take effect.
+		if uerr := s.queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{
 			Status:       "cancelled",
 			ErrorMessage: "cancelled by user",
 			ID:           run.ID,
-		})
+		}); uerr != nil {
+			slog.Debug("taskservice: cancel run-status update failed", "task_id", id, "run_id", run.ID, "error", uerr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## 背景

Closes #130。重审发现多处 \`_ = queries.Update...( )\` 丢弃错误，导致扫描完成/失败/取消时 \`scan_tasks.last_run_status\` 可能不反映真实状态（UI 卡在 running，用户无法重试），以及 agent 发坏 JSON 被静默记为命令成功。

## 改动（5 处）

| 位置 | 处理 |
|---|---|
| \`runner.go\` \`finalizeRun\` \`_ = UpdateScanTaskStatus\` | 捕获 + \`rn.logger.Debug\` |
| \`runner.go\` \`failRun\` \`_ = UpdateScanTaskRun\` | 捕获 + \`rn.logger.Debug\` |
| \`runner.go\` \`failRun\` \`_ = UpdateScanTaskStatus\` | 捕获 + \`rn.logger.Debug\` |
| \`taskservice.go\` \`Cancel\` \`_ = UpdateScanTaskRun\` | 捕获 + \`slog.Debug\`（taskservice 无 logger 字段，用包级 slog 与 routes.go 一致） |
| \`handler/agent_command.go\` \`Complete\` \`_ = json.Decode\` | **区分空 body（io.EOF，允许，默认 done）vs 畸形 body（返回 400 + Warn 日志）** |

## 设计说明

- **runner.go** 用 \`rn.logger\`（注入的 slog.Logger），与既有 \`finalizeRun\` 的 \`UpdateScanTaskRun\` Error 日志样板一致
- **taskservice.go** 没有 logger 字段。添加会改 \`New()\` 构造签名（横切影响 routes.go wiring），对 \"加日志\" 这个范围是过度改动；改用包级 \`slog\` 与 \`routes.go:455\` 既有 \`slog.Error(\"failed to create scan scheduler\", ...)\` 风格一致
- **agent_command.go** 这是最严重的一处。之前畸形 JSON 被静默当 \`status=\"done\"\`，掩盖 agent 真实结果。新逻辑：空 body（\`io.EOF\`）仍允许（默认 done，向后兼容），只有有 body 但解析失败才返回 400

## 验证

- ✅ \`go build ./...\` 干净
- ✅ \`go vet ./...\` 干净
- ✅ gofmt / goimports 干净
- ✅ \`go test -race\` 通过：

\`\`\`
ok  mibee-steward/internal/service/scannerv2/runner       5.229s
ok  mibee-steward/internal/service/scannerv2/taskservice  2.303s
ok  mibee-steward/internal/api/handler                    54.091s
\`\`\`

## 取舍

用 \`Debug\` 而非 \`Warn\`/ \`Error\` —— 这些是 best-effort 状态更新（注释已说明），失败不致命，但需要在排查 \"UI 卡 running\" 类问题时能通过调高日志级别看到。\`failRun\` 入口本身已有 \`Error\` 日志记录失败原因，状态更新失败用 Debug 即可。