### PR TITLE
fix(store): satellite uuid-transition 让第二次扫描数据陈旧 (#129 regression)

### DIFF
--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -164,17 +164,15 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Replace the host's prior service set. When we have a uuid, scope the delete
-	// to it (the stable identity); otherwise fall back to IP so unresolved hosts
-	// still get a clean replace instead of unbounded row growth.
-	if uuid != "" {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE device_uuid = ?`, uuid); err != nil {
-			return err
-		}
-	} else {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ? AND device_uuid = ?`, ip, ""); err != nil {
-			return err
-		}
+	// Replace the host's prior service set. The rows belong to this IP regardless
+	// of their device_uuid state, so the DELETE keys on IP. This matters across
+	// the uuid-resolution transition: scan 1 (no device row yet) lands rows with
+	// device_uuid='', scan 2 (uuid resolved) must remove those rows — a DELETE
+	// scoped to the resolved uuid would miss the device_uuid='' rows and the
+	// subsequent INSERT would collide on UNIQUE(ip,service,port), silently
+	// dropping the fresh data (regression #129).
+	if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ?`, ip); err != nil {
+		return err
 	}
 	if len(services) == 0 {
 		return tx.Commit()
@@ -253,21 +251,18 @@ func (r *SQLiteRepository) RecordTLSCerts(ctx context.Context, ip string, certs 
 	defer tx.Rollback() //nolint:errcheck
 
 	// Collect the distinct ports in this batch; delete prior rows for each.
-	// Keyed by device_uuid when resolved (follows the device across a roam),
-	// else falls back to IP (unresolved first-discovery host).
+	// Keyed by IP (not device_uuid): the cert chain belongs to whatever device
+	// currently holds this IP, and across the uuid-resolution transition a
+	// uuid-scoped DELETE would leave device_uuid='' rows from the first scan
+	// behind, accumulating duplicates (the (ip,port) index is non-unique, so no
+	// conflict — just stale rows). Mirrors the RecordServices fix (#129).
 	ports := make(map[int]struct{}, len(certs))
 	for _, c := range certs {
 		ports[c.Port] = struct{}{}
 	}
 	for port := range ports {
-		if uuid != "" {
-			if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE device_uuid = ? AND port = ?`, uuid, port); err != nil {
-				return err
-			}
-		} else {
-			if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE ip = ? AND device_uuid = ? AND port = ?`, ip, "", port); err != nil {
-				return err
-			}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE ip = ? AND port = ?`, ip, port); err != nil {
+			return err
 		}
 	}
 

--- a/internal/service/scannerv2/store/sqlite_test.go
+++ b/internal/service/scannerv2/store/sqlite_test.go
@@ -41,6 +41,25 @@ func seedDeviceRow(t *testing.T, db *sql.DB, ip, mac string, networkID sql.NullI
 	return id
 }
 
+// seedDeviceRowWithUUID is seedDeviceRow with an explicit device_uuid, mirroring
+// runner.createDevice which calls uuid.NewString(). Used by tests that need the
+// uuid-resolution path to succeed (the satellite uuid-transition regression).
+func seedDeviceRowWithUUID(t *testing.T, db *sql.DB, ip, mac string, networkID sql.NullInt64, devUUID string) int64 {
+	t.Helper()
+	now := time.Now().UTC()
+	res, err := db.Exec(`
+		INSERT INTO devices (name, type, ip_address, mac_address, status, scan_source,
+		                     scan_attributes, network_id, device_uuid,
+		                     first_seen, last_seen, last_scanned_at, created_at, updated_at)
+		VALUES (?, 'other', ?, ?, 'online', 'scanner_v2', '{}', ?, ?, ?, ?, ?, ?, ?)`,
+		ip, ip, mac, networkID, devUUID, now, now, now, now, now)
+	if err != nil {
+		t.Fatalf("seed device row (with uuid): %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
 func TestRecordServices_ReplaceOnRescan(t *testing.T) {
 	repo, ctx := newRepo(t, Options{})
 	ip := "10.0.0.1"
@@ -76,6 +95,67 @@ func TestRecordServices_ReplaceOnRescan(t *testing.T) {
 	}
 	if m["server"] != "nginx/1.25" {
 		t.Errorf("metadata not updated: %v", m)
+	}
+}
+
+// TestRecordServices_ReplaceAcrossUUIDResolution reproduces the regression from
+// #115/#129: the engine writes satellite rows BEFORE the runner persists the
+// device row, so on first discovery resolveDeviceUUID returns "" and rows land
+// with device_uuid=”. On the next scan the device row exists and the uuid is
+// resolved — but a DELETE scoped to the resolved uuid does NOT remove the
+// prior scan's device_uuid=” rows, so the INSERT collides on the
+// UNIQUE(ip,service,port) index and the fresh data is silently dropped
+// (downgraded to a Warn), leaving the service list frozen at scan-1.
+//
+// This test asserts the second scan's data wins after uuid resolution.
+func TestRecordServices_ReplaceAcrossUUIDResolution(t *testing.T) {
+	repo, ctx := newRepo(t, Options{})
+	ip := "10.0.0.5"
+
+	// Scan 1: no device row yet → resolveDeviceUUID returns "". Rows land with
+	// device_uuid=''. Mirrors first discovery via the orchestrator path.
+	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
+		{Service: "http", Port: 80, Confidence: 0.9, Metadata: map[string]string{"server": "nginx-old"}},
+	}); err != nil {
+		t.Fatalf("record services (scan 1): %v", err)
+	}
+	// Sanity: the row landed with empty device_uuid.
+	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=? AND device_uuid=''`, ip); cnt != 1 {
+		t.Fatalf("scan 1: expected 1 row with empty device_uuid, got %d", cnt)
+	}
+
+	// Device row created between scans (by runner.applyDeviceBridge → createDevice,
+	// which generates a real uuid). Seed one to mirror that.
+	const devUUID = "dev-uuid-aaaaaaaa"
+	seedDeviceRowWithUUID(t, repo.db, ip, "aa:bb:cc:dd:ee:ff", sql.NullInt64{}, devUUID)
+
+	// Scan 2: same http service, refreshed metadata. uuid now resolves → must
+	// replace scan-1's device_uuid='' row, not collide with it.
+	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
+		{Service: "http", Port: 80, Confidence: 0.95, Metadata: map[string]string{"server": "nginx-new"}},
+	}); err != nil {
+		t.Fatalf("record services (scan 2): %v", err)
+	}
+
+	// Exactly ONE row for (ip, http, 80) — not two — and it carries the fresh data.
+	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=? AND service='http' AND port=80`, ip); cnt != 1 {
+		t.Fatalf("scan 2: expected 1 http row, got %d (uuid-transition collision left a stale row)", cnt)
+	}
+	var meta, rowUUID string
+	if err := repo.db.QueryRow(
+		`SELECT metadata, device_uuid FROM host_services WHERE ip=? AND service='http' AND port=80`, ip,
+	).Scan(&meta, &rowUUID); err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(meta), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["server"] != "nginx-new" {
+		t.Errorf("scan 2 data did not win: metadata server=%q, want %q (scan-1 row survived the uuid transition)", m["server"], "nginx-new")
+	}
+	if rowUUID != devUUID {
+		t.Errorf("scan 2 row device_uuid=%q, want %q (heal did not run)", rowUUID, devUUID)
 	}
 }
 


### PR DESCRIPTION
## 背景

Closes #129。这是 #115（satellite 表 IP→device_uuid 迁移）引入的 **P1 regression**。

## 根因

\`host_services\` 的 unique index 是 \`(ip, service, port)\` —— **不含 device_uuid**。首次发现设备时 device 行还没建（引擎在 runner 持久化 device 行之前就写 satellite 行），\`resolveDeviceUUID\` 返回 \`""\`，行以 \`device_uuid=''\` 落库。第二次扫描拿到 resolved uuid 后：

1. \`DELETE WHERE device_uuid = <resolved>\` —— **不命中** scan-1 的 \`device_uuid=''\` 行
2. \`INSERT (ip, svc, port, device_uuid=<resolved>)\` —— **命中 UNIQUE(ip,service,port) 冲突**
3. 冲突被捕获降级为 \`Warn\` 日志（\`sqlite.go:228\`），**新数据被丢弃**
4. 服务表冻结在 scan-1 快照

heal 只在进程启动时跑（\`backfillSatelliteUUIDs\`），两次扫描间不重启就卡住。

## 复现（先 red）

新增 \`TestRecordServices_ReplaceAcrossUUIDResolution\` 精确复现：

\`\`\`
=== RUN   TestRecordServices_ReplaceAcrossUUIDResolution
WARN insert host_service row failed ... error="constraint failed: UNIQUE constraint failed: host_services.ip, host_services.service, host_services.port (2067)"
    sqlite_test.go:155: scan 2 data did not win: metadata server=\"nginx-old\", want \"nginx-new\"
--- FAIL (修复前)
\`\`\`

## 修复

\`RecordServices\` / \`RecordTLSCerts\` 的 DELETE 改为**按 IP**（satellite 行语义上属于 IP），不再按 \`device_uuid\` scope。同一 IP 的 satellite 行无论 \`device_uuid\` 是 \`''\` / 旧值 / 新值，都会被清理后重插，新 INSERT 带 resolved uuid。

\`RecordTLSCerts\` 有同样问题（index 非唯一，所以是累积重复行而非冲突），一并修。

## 设计取舍

- **为何按 IP 而非 uuid**：unique index 本就是按 IP，satellite 行的语义归属是 \"这个 IP 上跑的服务\"。设备 DHCP 漫游后，旧 IP 的残留行由 retention 清理（影响极小，且更符合 \"IP 当前归属\" 语义）。
- **未动 RecordEvidence**：它是 append-only（无 replace），uuid-transition 的影响只是新行带 resolved uuid、旧行带 \`''\`，查询时不影响正确性。

## 验证

- ✅ 新测试 \`TestRecordServices_ReplaceAcrossUUIDResolution\`：red → green（复现 + 修复）
- ✅ 原 \`TestRecordServices_ReplaceOnRescan\` / \`TestRecordTLSCerts_*\` 全过
- ✅ \`go test -race\` store / runner / engine 全绿
- ✅ gofmt / goimports / go vet / go build 干净

## 测试覆盖的盲区（为何 regression 漏测）

原 \`TestRecordServices_ReplaceOnRescan\` **没有 seed device 行**，所以两次 \`RecordServices\` 的 \`resolveDeviceUUID\` 都返回 \`""\`，都走 \`DELETE WHERE ip=? AND device_uuid=''\` 分支，测试通过但没覆盖 \"scan-1 无 device → scan-2 有 device\" 的 uuid 状态转换。新测试显式模拟了这个转换。