### PR TITLE
feat(middleware): trusted-proxy-aware RealIP 替换 deprecated chimw.RealIP (#133)

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -9,6 +9,14 @@ server:
   read_timeout: "15s"
   write_timeout: "5m"
   idle_timeout: "120s"
+  # trusted_proxies authorizes which source IPs may set X-Forwarded-For (used
+  # by rate limiting + audit logs to identify the real client behind a proxy).
+  # Empty (default) = trust NO proxy: the TCP peer IS the client — the safe
+  # default for direct exposure (a client cannot forge its IP). Deploy behind
+  # nginx/another proxy and set this to the proxy's source range so the real
+  # client IP is honored. Bare IPs are treated as /32 (v4) or /128 (v6).
+  # Override at runtime with MIBEE_SERVER_TRUSTED_PROXIES (comma-separated).
+  trusted_proxies: []  # e.g. ["127.0.0.1/32"] for a localhost nginx, or ["10.0.0.5/32"]
 
 database:
   sqlite:

--- a/internal/api/middleware/realip.go
+++ b/internal/api/middleware/realip.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RealIP is a trusted-proxy-aware replacement for chi's deprecated middleware.
+// RealIP (which trusts X-Forwarded-For unconditionally — an IP-spoofing risk
+// when the service is reachable from untrusted networks). It resolves the
+// client IP that downstream middleware/handlers (rate limiting, audit logs,
+// RequireAgentToken) see via r.RemoteAddr.
+//
+// Behavior:
+//   - trustedProxies empty (default): the TCP peer address is the client. No
+//     header is inspected. This is the safe default — direct exposure without
+//     a reverse proxy must not let a client forge its IP via X-Forwarded-For.
+//   - trustedProxies populated (CIDRs, e.g. ["127.0.0.1/8", "10.0.0.0/8"]):
+//     only when the TCP peer is inside one of these networks is X-Forwarded-For
+//     consulted. The LEFTMOST (oldest) entry in the comma-separated list is
+//     taken as the real client — this matches the convention that each trusted
+//     proxy appends the previous hop, so the first hop is the originating
+//     client when all proxies in the chain are trusted. A malformed/non-IP
+//     header value falls back to the TCP peer.
+//
+// Deploy behind nginx/the proxy and set server.trusted_proxies to the proxy's
+// source address range (e.g. ["127.0.0.1/32"] for a localhost nginx, or the
+// proxy's LAN subnet). Without this knob the service correctly refuses to
+// trust the header.
+func RealIP(trustedProxies []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// Fast path: nothing trusted — pass through untouched, behave exactly
+		// like having no RealIP middleware at all (RemoteAddr = TCP peer).
+		if len(trustedProxies) == 0 {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ip := trustedClientIP(r, trustedProxies); ip != "" {
+				r.RemoteAddr = net.JoinHostPort(ip, portOf(r.RemoteAddr))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// trustedClientIP returns the real client IP when the TCP peer is a trusted
+// proxy and X-Forwarded-For is present and well-formed; otherwise "".
+func trustedClientIP(r *http.Request, trustedProxies []*net.IPNet) string {
+	peerIP := hostFromAddr(r.RemoteAddr)
+	if peerIP == "" {
+		return ""
+	}
+	if !anyCIDRContains(trustedProxies, peerIP) {
+		return "" // untrusted source — do not honor the header
+	}
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return ""
+	}
+	// X-Forwarded-For: client, proxy1, proxy2 — the leftmost is the original.
+	parts := strings.Split(xff, ",")
+	first := strings.TrimSpace(parts[0])
+	if first == "" {
+		return ""
+	}
+	// Strip any zone/port; validate it's a usable IP. A malformed value means
+	// we cannot trust the header — fall back to the TCP peer (return "").
+	if ip := net.ParseIP(first); ip != nil {
+		return ip.String()
+	}
+	return ""
+}
+
+// anyCIDRContains reports whether ip falls in any of the CIDRs.
+func anyCIDRContains(cidrs []*net.IPNet, ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, c := range cidrs {
+		if c.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostFromAddr extracts the host part from a host:port RemoteAddr (or returns
+// the input as-is if there's no port, e.g. an already-stripped value).
+func hostFromAddr(addr string) string {
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		return h
+	}
+	return addr
+}
+
+// portOf extracts the port from a host:port RemoteAddr (returns "80" if the
+// value isn't host:port — covers the rare case of a pre-stripped RemoteAddr,
+// where the port is unknown and downstream code only inspects the host).
+func portOf(addr string) string {
+	if _, port, err := net.SplitHostPort(addr); err == nil {
+		return port
+	}
+	return "80"
+}
+
+// ParseCIDRs parses a list of CIDR strings (e.g. ["127.0.0.1/8", "10.0.0.0/8"])
+// into net.IPNet values. A bare IP (no /prefix) is treated as a /32 (v4) or
+// /128 (v6) for convenience. Invalid entries are skipped — callers should
+// validate at config-load time, so this is a defensive best-effort.
+func ParseCIDRs(cidrs []string) []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		// Accept bare IPs as single-host CIDRs.
+		if !strings.Contains(c, "/") {
+			if ip := net.ParseIP(c); ip != nil {
+				if ip.To4() != nil {
+					c += "/32"
+				} else {
+					c += "/128"
+				}
+			} else {
+				continue
+			}
+		}
+		_, ipnet, err := net.ParseCIDR(c)
+		if err != nil {
+			continue
+		}
+		out = append(out, ipnet)
+	}
+	return out
+}

--- a/internal/api/middleware/realip_test.go
+++ b/internal/api/middleware/realip_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package middleware_test
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/middleware"
+)
+
+// capturedRemoteAddr lets the inner handler record what the RealIP middleware
+// set r.RemoteAddr to — that's what downstream code (rate limiters, audit
+// logs) actually consumes.
+func realipTestHandler(captured *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		*captured = r.RemoteAddr
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func doRequest(t *testing.T, h http.Handler, remoteAddr, xff string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	if xff != "" {
+		req.Header.Set("X-Forwarded-For", xff)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "handler did not return 200")
+}
+
+// When trusted_proxies is empty, the TCP peer is the client regardless of any
+// X-Forwarded-For header — a client cannot forge its IP. This is the safe
+// default for direct exposure.
+func TestRealIP_EmptyTrustedProxies_IgnoresHeader(t *testing.T) {
+	var got string
+	h := middleware.RealIP(nil)(realipTestHandler(&got))
+	// Client tries to forge 1.2.3.4 via the header.
+	doRequest(t, h, "203.0.113.9:1000", "1.2.3.4")
+	require.Equal(t, "203.0.113.9:1000", got, "empty trusted_proxies must ignore X-Forwarded-For")
+}
+
+// When the TCP peer is a trusted proxy, the leftmost X-Forwarded-For entry is
+// taken as the real client IP (the proxy appends; the first hop originates).
+func TestRealIP_TrustedProxy_HonorsHeader(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"127.0.0.1/8"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	// nginx on localhost forwards for a real client at 198.51.100.5.
+	doRequest(t, h, "127.0.0.1:40000", "198.51.100.5")
+	require.Equal(t, "198.51.100.5:40000", got, "trusted proxy: client IP should come from X-Forwarded-For")
+}
+
+// A multi-hop chain: client → proxy1 → proxy2(localhost). Leftmost entry wins.
+func TestRealIP_MultiHopChain_LeftmostWins(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"127.0.0.1/8"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	doRequest(t, h, "127.0.0.1:40000", "198.51.100.5, 10.0.0.1, 10.0.0.2")
+	require.Equal(t, "198.51.100.5:40000", got, "multi-hop: leftmost (original client) should win")
+}
+
+// Untrusted source — even with the header, the TCP peer is the client. This
+// is the spoofing defense: a random internet host claiming to be behind a
+// proxy must not be able to forge its IP.
+func TestRealIP_UntrustedSource_IgnoresHeader(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"127.0.0.1/8"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	// An external host (not in 127.0.0.1/8) claims to forward for 1.2.3.4.
+	doRequest(t, h, "203.0.113.99:5000", "1.2.3.4")
+	require.Equal(t, "203.0.113.99:5000", got, "untrusted source must not be able to forge X-Forwarded-For")
+}
+
+// Trusted proxy but no header — fall back to the TCP peer (the proxy itself).
+func TestRealIP_TrustedProxy_NoHeader(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"10.0.0.0/8"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	doRequest(t, h, "10.0.0.1:40000", "")
+	require.Equal(t, "10.0.0.1:40000", got, "no header: must keep TCP peer unchanged")
+}
+
+// A malformed X-Forwarded-For from a trusted proxy must NOT break the request
+// or poison the IP — it falls back to the TCP peer.
+func TestRealIP_MalformedHeader_FallsBackToPeer(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"127.0.0.1/8"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	doRequest(t, h, "127.0.0.1:40000", "not-an-ip")
+	require.Equal(t, "127.0.0.1:40000", got, "malformed header must fall back to TCP peer")
+}
+
+// ParseCIDRs accepts bare IPs (treats them as /32) and skips invalid entries.
+func TestParseCIDRs_BareIPAndInvalid(t *testing.T) {
+	cidrs := middleware.ParseCIDRs([]string{"127.0.0.1", "10.0.0.0/8", "garbage", ""})
+	require.Len(t, cidrs, 2, "bare IP + valid CIDR; empty + garbage skipped")
+	require.True(t, cidrs[0].Contains(net.ParseIP("127.0.0.1")))
+	require.True(t, cidrs[1].Contains(net.ParseIP("10.5.5.5")))
+	require.False(t, cidrs[1].Contains(net.ParseIP("11.0.0.1")))
+}
+
+// IPv6 trusted proxy.
+func TestRealIP_IPv6_TrustedProxy(t *testing.T) {
+	trusted := middleware.ParseCIDRs([]string{"::1/128"})
+	var got string
+	h := middleware.RealIP(trusted)(realipTestHandler(&got))
+	doRequest(t, h, "[::1]:40000", "2001:db8::1")
+	require.Equal(t, "[2001:db8::1]:40000", got, "IPv6 proxy should honor IPv6 X-Forwarded-For")
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -102,13 +102,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Middleware chain: RequestID → RealIP → Logging → Metrics → Recoverer → SecurityHeaders
 	r.Use(chimw.RequestID)
-	// RealIP is deprecated in chi (IP-spoofing risk: it trusts X-Forwarded-For
-	// unconditionally). We keep it because this service is designed to sit behind
-	// a trusted reverse proxy (nginx — see deploy/) that overwrites the header;
-	// direct exposure to untrusted networks is not a supported deployment.
-	// TODO(security): replace with a trusted-proxy-aware RealIP once a
-	// trusted_proxies config knob lands.
-	r.Use(chimw.RealIP) //nolint:staticcheck // SA1019: trusted-proxy deployment, see note above
+	// RealIP is trusted-proxy-aware: X-Forwarded-For is honored ONLY when the
+	// TCP peer is in server.trusted_proxies (default empty = trust no proxy,
+	// use the TCP peer as the client — safe for direct exposure). Deploy behind
+	// nginx and set trusted_proxies to the proxy's source range (#133).
+	r.Use(middleware.RealIP(middleware.ParseCIDRs(cfg.Server.TrustedProxies)))
 	r.Use(middleware.Logging)
 	r.Use(middleware.Metrics)
 	r.Use(chimw.Recoverer)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,14 @@ type ServerConfig struct {
 	WriteTimeout string `koanf:"write_timeout"`
 	// IdleTimeout bounds keep-alive idle connections. Default "120s".
 	IdleTimeout string `koanf:"idle_timeout"`
+	// TrustedProxies is the list of CIDRs (or bare IPs) authorized to set
+	// X-Forwarded-For. When the TCP peer is inside one of these networks, the
+	// RealIP middleware takes the leftmost X-Forwarded-For entry as the client
+	// IP (for rate limiting / audit logs). Empty (default) = trust NO proxy:
+	// the TCP peer is the client — the safe default for direct exposure.
+	// Populate with your reverse proxy's source range when deployed behind
+	// nginx/another proxy (e.g. ["127.0.0.1/32"] for localhost nginx).
+	TrustedProxies []string `koanf:"trusted_proxies"`
 }
 
 type DatabaseConfig struct {


### PR DESCRIPTION
## 背景

Closes #133。收尾全代码库**唯一的 \`TODO(security)\`**。chi 的 \`chimw.RealIP\` 已 deprecated（SA1019），无条件信任 \`X-Forwarded-For\` —— 不在 nginx 后部署时任何客户端可伪造 IP 绕过限流/污染审计日志。原本靠注释 \"trusted-proxy deployment only\" 自我约束，没有配置闸。

## 改动

### 新中间件 \`internal/api/middleware/realip.go\`

\`\`\`go
func RealIP(trustedProxies []*net.IPNet) func(http.Handler) http.Handler
\`\`\`

| trusted_proxies | 行为 |
|---|---|
| **空（默认）** | 用 TCP 直连地址 —— 安全默认，不信任任何代理，IP 不可伪造 |
| 来源 ∈ trusted_proxies | 取 \`X-Forwarded-For\` **最左（最老）一跳**为真实客户端 |
| 来源 ∉ trusted_proxies | 忽略 header，用 TCP peer |

- 畸形 header → 回落 TCP peer（不破坏请求、不毒化 IP）
- \`ParseCIDRs\`：接受 CIDR + bare IP（自动 /32 或 /128），跳过非法项

### routes.go
替换 \`chimw.RealIP\`，移除 \`//nolint:staticcheck\` 和 \`TODO(security)\`。

### config.go + config.example.yaml
\`ServerConfig.TrustedProxies []string\`（koanf: \`trusted_proxies\`），默认 \`[]\`（安全）。

## 设计取舍

**为何最左一跳而非最右**：每跳 trusted proxy 追加前序 hop，所以 trusted 链中首跳是发起客户端。最右一跳是 \"最近的 proxy\"，不是客户端。

**为何默认空 = 安全**：直连场景（无反向代理）IP 不可伪造；部署在 nginx 后才需显式配置代理源范围。这与 \"最安全默认\" 原则一致 —— 显式 opt-in 信任，而非 opt-out。

## 测试（8 个）

\`\`\`
TestRealIP_EmptyTrustedProxies_IgnoresHeader   — 空 trusted: 忽略 header（防伪造）
TestRealIP_TrustedProxy_HonorsHeader           — trusted proxy: 取 header
TestRealIP_MultiHopChain_LeftmostWins          — 多跳: 最左一跳胜出
TestRealIP_UntrustedSource_IgnoresHeader       — 非信任源: 忽略 header（核心防伪造）
TestRealIP_TrustedProxy_NoHeader               — trusted 但无 header: 用 peer
TestRealIP_MalformedHeader_FallsBackToPeer     — 畸形 header: 回落 peer
TestParseCIDRs_BareIPAndInvalid                — bare IP /32 + 跳过非法项
TestRealIP_IPv6_TrustedProxy                   — IPv6 支持
\`\`\`

## 验证

- ✅ \`go build ./...\` 干净
- ✅ \`go vet ./...\` 干净
- ✅ gofmt / goimports 干净
- ✅ \`go test -race\` middleware / config / routes 全绿
- ✅ 生产代码 \`chimw.RealIP\` + \`//nolint:staticcheck\` 已彻底移除（仅 \`ratelimit_test.go\` 测试桩保留，不影响生产）

## 部署须知

合并后，**部署在 nginx 后的实例需显式配置 \`server.trusted_proxies\`**（如 \`[\"127.0.0.1/32\"]\`），否则真实客户端 IP 不会从 header 解析（会显示为 nginx 的地址）。这从 \"隐式信任所有 header\" 变为 \"显式信任配置的代理\" —— 是更安全的方向，但属于行为变化，**CHANGELOG 需记录**。

## 合并冲突预期

\`config.example.yaml\` 与 PR #140（#131）都改了该文件，但位置不同（#140 加 center/retention 块，本 PR 在 server 块加 trusted_proxies 行），git 应能自动合并。