### PR TITLE
fix(web): 批量更新设备状态加确认门 — 防误点批量翻转 (#150)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -147,6 +147,7 @@
 		"Select All": "Select All",
 		"Selected Count": "{count} selected",
 		"Batch Status Success": "{count} devices status updated",
+		"Batch Update Status Confirm": "Mark {count} selected device(s) as \"{status}\"?",
 		"Batch Delete Success": "{count} devices deleted successfully",
 		"Batch Update Status": "Batch Update Status",
 		"Batch Delete Confirm": "Are you sure you want to delete the selected devices?",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -144,6 +144,7 @@
 		"Batch Update Status": "批量更新状态",
 		"Batch Delete Success": "成功删除 {count} 台设备",
 		"Batch Status Success": "成功更新 {count} 台设备状态",
+		"Batch Update Status Confirm": "确定要将选中的 {count} 台设备标记为「{status}」吗？",
 		"Selected Count": "已选择 {count} 项",
 		"Select All": "全选",
 		"Deselect All": "取消全选",

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -123,6 +123,12 @@ interface AddDevicesResponse {
 	let batchDeleteOpen = $state(false);
 	let batchStatusOpen = $state(false);
 	let batchStatusValue = $state('online');
+	// Batch status confirmation: the dropdown no longer fires the mutation
+	// directly — it stages the chosen status here, then a ConfirmDialog gates
+	// the actual API call. Prevents an accidental click from bulk-flipping
+	// dozens of devices to "offline" with no undo (#150).
+	let pendingBatchStatus = $state<string | null>(null);
+	let batchStatusConfirmOpen = $state(false);
 	let batchLoading = $state(false);
 	// Export dropdown — click-toggle (not hover) so keyboard/touch users can
 	// reach it. group-hover:opacity-100 was invisible without a mouse.
@@ -153,7 +159,7 @@ interface AddDevicesResponse {
 		// failure just leaves the dropdown empty — the list still works).
 		api.get<Network[]>('/networks').then((n) => { networks = n || []; networksError = false; }).catch(() => { networksError = true; });
 		pollTimer = setInterval(() => {
-			if (!editOpen && !deleteOpen && !batchDeleteOpen && !batchStatusOpen && !importOpen && !linkOpen) {
+			if (!editOpen && !deleteOpen && !batchDeleteOpen && !batchStatusOpen && !batchStatusConfirmOpen && !importOpen && !linkOpen) {
 				void refreshDevicesSilent();
 			}
 		}, POLL_MS);
@@ -171,6 +177,10 @@ interface AddDevicesResponse {
 	$effect(() => {
 		function onKeydown(e: KeyboardEvent) {
 			if (e.key !== 'Escape') return;
+			// The batch-status ConfirmDialog manages its own Escape via Modal; let
+			// it through (it sits on top of the dropdown) so the confirm closes
+			// before the dropdown does.
+			if (batchStatusConfirmOpen) return;
 			if (exportOpen) { exportOpen = false; e.stopPropagation(); }
 			else if (batchStatusOpen) { batchStatusOpen = false; e.stopPropagation(); }
 		}
@@ -392,11 +402,11 @@ interface AddDevicesResponse {
 	}
 
 	async function confirmBatchStatus() {
-		if (selectedIds.size === 0) return;
+		if (selectedIds.size === 0 || !pendingBatchStatus) return;
 		batchLoading = true;
 		try {
-			await api.post('/devices/batch-update-status', { ids: Array.from(selectedIds), status: batchStatusValue });
-			addToast('success', m['devices.Batch Status Success']().replace('{count}', String(selectedIds.size)));
+			await api.post('/devices/batch-update-status', { ids: Array.from(selectedIds), status: pendingBatchStatus });
+			addToast('success', m['devices.Batch Status Success']({ count: selectedIds.size }));
 			selectedIds = new Set();
 			fetchDevices();
 		} catch (err: unknown) {
@@ -404,7 +414,17 @@ interface AddDevicesResponse {
 		} finally {
 			batchLoading = false;
 			batchStatusOpen = false;
+			batchStatusConfirmOpen = false;
+			pendingBatchStatus = null;
 		}
+	}
+
+	// Map a status key to its localized display label, for the confirm dialog's
+	// human-readable message ("mark as offline" — not "mark as 'offline'").
+	function statusLabel(status: string): string {
+		if (status === 'online') return m['devices.Online']();
+		if (status === 'offline') return m['devices.Offline']();
+		return m['devices.Unknown']();
 	}
 
 	// --- CSV Import ---
@@ -1116,7 +1136,7 @@ interface AddDevicesResponse {
 					<div class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg z-20 min-w-[140px]" style="box-shadow: var(--shadow-md);" role="menu">
 						{#each ['online', 'offline', 'unknown'] as status}
 							<button
-								onclick={() => { batchStatusValue = status; batchStatusOpen = false; confirmBatchStatus(); }}
+								onclick={() => { pendingBatchStatus = status; batchStatusValue = status; batchStatusOpen = false; batchStatusConfirmOpen = true; }}
 								role="menuitem"
 								class="w-full text-left px-4 py-2 text-sm text-text hover:bg-surface-2 last:rounded-b-lg first:rounded-t-lg"
 							>
@@ -1308,6 +1328,18 @@ interface AddDevicesResponse {
 	confirmVariant="danger"
 	onConfirm={confirmBatchDelete}
 	onCancel={() => { batchDeleteOpen = false; }}
+/>
+
+<!-- Batch status-update confirmation: the dropdown stages the chosen status
+     here, and only this confirm fires the mutation. Stops an accidental
+     click from bulk-flipping the selected devices (#150). -->
+<ConfirmDialog
+	bind:open={batchStatusConfirmOpen}
+	title={m['devices.Batch Update Status']()}
+	message={m['devices.Batch Update Status Confirm']({ count: selectedIds.size, status: pendingBatchStatus ? statusLabel(pendingBatchStatus) : '' })}
+	confirmLabel={m['common.Confirm']()}
+	onConfirm={confirmBatchStatus}
+	onCancel={() => { pendingBatchStatus = null; }}
 />
 
 <!-- CSV Import Modal -->


### PR DESCRIPTION
## 问题

设备页「批量更新状态」下拉点击后**直接执行** mutation —— 无确认、无撤销。误点「离线」会让选中的 N 台设备瞬间被批量翻转,用户无法回退。这是与批量删除(已正确用 ConfirmDialog)不对称的危险操作。

> Closes #150

## 改动

- 批量状态下拉的 menuitem 不再直接调 \`confirmBatchStatus()\`,而是先 stage 到 \`pendingBatchStatus\`,关闭下拉并打开新的 \`ConfirmDialog\`
- \`ConfirmDialog\` 提示「确定要将选中的 {count} 台设备标记为「{status}」吗?」,确认后才真正调 API
- \`confirmBatchStatus()\` 改读 \`pendingBatchStatus\`,成功/失败后清空 pending 状态
- polling 与全局 Esc 守卫纳入 \`batchStatusConfirmOpen\`,避免 confirm 开着时被静默刷新/误关
- **顺带修**:原 \`Batch Status Success\` toast 用 \`.replace('{count}', ...)\`,但 paraglide 把 \`{count}\` 编译成了函数参数(不是字面占位符),导致 toast 实际显示 \`undefined devices status updated\`。改为正确的参数化调用 \`m['devices.Batch Status Success']({ count })\`
- 新增 i18n key \`devices.Batch Update Status Confirm\`(zh + en)

## 验证

- \`npm test\` 191 passed(8 文件全绿)
- \`npm run build\` 通过,无 a11y warning 回潮
- **浏览器实测(192.168.63.101)**:选中 2 台设备 → 批量更新状态 → 选离线 → 弹确认「确定要将选中的 2 台设备标记为「离线」吗?」
  - 取消路径:不执行变更 ✅
  - 确认路径:执行 + toast「成功更新 2 台设备状态」,API 确认状态变更 ✅
  - console 无 JS error ✅

## 类型

bug / 前端 UX 安全网(P1)。