### PR TITLE
fix(web): DataTable 事件委托 a11y 重构 — interactive 列 + cell snippet (#167)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -354,6 +354,8 @@
 		"Link": "Link",
 		"Unlink": "Unlink",
 		"Close": "Close",
+		"Expand": "Expand",
+		"Collapse": "Collapse",
 		"unsaved_changes": "Unsaved Changes",
 		"unsaved_changes_desc": "You have unsaved changes. Are you sure you want to close?",
 		"discard": "Discard",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -354,6 +354,8 @@
 		"Link": "关联",
 		"Unlink": "取消关联",
 		"Close": "关闭",
+		"Expand": "展开",
+		"Collapse": "折叠",
 		"unsaved_changes": "未保存的更改",
 		"unsaved_changes_desc": "您有未保存的更改。确定要关闭吗？",
 		"discard": "放弃",

--- a/web/src/lib/components/DashboardWidget.svelte
+++ b/web/src/lib/components/DashboardWidget.svelte
@@ -75,12 +75,9 @@
 	ondrop={handleDrop}
 >
 	<div class="widget-header">
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-		<div
+		<button
+			type="button"
 			class="widget-drag-handle"
-			role="button"
-			tabindex="0"
 			aria-label={m['dashboard.Drag to Reorder']()}
 			title={m['dashboard.Drag to Reorder']()}
 			onkeydown={(e) => {
@@ -96,7 +93,7 @@
 			}}
 		>
 			<GripVertical class="w-[14px] h-[14px]" />
-		</div>
+		</button>
 		<h3 class="widget-title">{widget.name}</h3>
 		<div class="widget-actions">
 			<button class="widget-action-btn" onclick={() => onEdit(widget.id)} title={m['common.Edit Widget']()} aria-label={m['common.Edit Widget']()}>
@@ -151,10 +148,18 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		/* ≥44px touch target (WCAG 2.5.5) — the grip icon stays 14px, only the
+		   clickable area grows so it's reachable on touch / by shaky pointers. */
+		min-width: 2.75rem;
+		min-height: 2.75rem;
+		padding: 0;
+		border: none;
+		background: transparent;
 		color: var(--color-text-muted);
 		opacity: 0.4;
 		transition: opacity 0.15s ease;
 		flex-shrink: 0;
+		cursor: grab;
 	}
 
 	.widget-card:hover .widget-drag-handle {
@@ -190,8 +195,10 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 1.75rem;
-		height: 1.75rem;
+		/* ≥44×44px touch target (WCAG 2.5.5) — was 1.75rem (28px), too small
+		   for touch. The icon stays 14px; only the hit area grows. */
+		min-width: 2.75rem;
+		min-height: 2.75rem;
 		border-radius: var(--radius-sm);
 		border: none;
 		background: transparent;

--- a/web/src/lib/components/DataTable.svelte
+++ b/web/src/lib/components/DataTable.svelte
@@ -17,6 +17,10 @@
 		key: string;
 		label: string;
 		sortable?: boolean;
+		/** Marks a column whose cells are rendered by the `cell` snippet (real
+		 * <button>/<input> with bound handlers) instead of `render`'s {@html}
+		 * string — the keyboard-accessible path (#167). */
+		interactive?: boolean;
 		/**
 		 * Custom cell renderer. The returned string is injected via `{@html}`, so
 		 * the caller is responsible for escaping EVERY user-controlled value
@@ -47,6 +51,10 @@
 		id,
 		expandedRowId,
 		expandedContent,
+		// Interactive-cell snippet: when a column has `interactive: true`, its
+		// cells render via {@render cell(row, col)} (real Svelte elements with
+		// bound handlers) instead of col.render's {@html} string (#167).
+		cell,
 		// Controlled sorting: when onSortChange is provided, the table runs in
 		// "server-side sort" mode — column clicks call back instead of sorting the
 		// in-memory rows (which would only reorder the current page and disagree
@@ -72,6 +80,7 @@
 		id?: string;
 		expandedRowId?: number | null;
 		expandedContent?: Snippet<[Record<string, unknown>]>;
+		cell?: Snippet<[Record<string, unknown>, Column]>;
 		externalSortKey?: string | null;
 		externalSortDirection?: 'asc' | 'desc' | 'none';
 		onSortChange?: (key: string, direction: 'asc' | 'desc') => void;
@@ -240,7 +249,9 @@
 							<tr class="border-b border-border last:border-b-0 hover:bg-surface-2 transition-colors">
 								{#each columns as col, colIndex}
 							<td class="px-4 py-3 text-sm" scope={colIndex === 0 ? 'row' : undefined}>
-								{#if col.render}
+								{#if col.interactive && cell}
+									{@render cell(row, col)}
+								{:else if col.render}
 									{@html col.render(row)}
 								{:else}
 									<span class="text-text">{row[col.key] != null ? String(row[col.key]) : '-'}</span>

--- a/web/src/lib/components/Toast.svelte
+++ b/web/src/lib/components/Toast.svelte
@@ -176,7 +176,11 @@
 		border: none;
 		color: var(--color-text-muted);
 		cursor: pointer;
-		padding: 0.25rem;
+		/* ≥44×44px touch target (WCAG 2.5.5) — padding:0.25rem + 16px icon was
+		   ~24px, too small for touch. The icon stays 16px; only the hit area
+		   grows. */
+		min-width: 2.75rem;
+		min-height: 2.75rem;
 		border-radius: var(--radius-sm);
 		display: flex;
 		align-items: center;

--- a/web/src/routes/agents/+page.svelte
+++ b/web/src/routes/agents/+page.svelte
@@ -328,21 +328,7 @@
 		{
 			key: 'actions',
 			label: m['common.Actions'](),
-			render: (row: Record<string, unknown>) => {
-				const agentId = String(row.agent_id);
-				const tokenId = row.id;
-				const isRevoked = !!row.revoked_at;
-				// Build segments with `html` (escapes agentId into the data-scan-id
-				// attribute — previously an attribute-injection XSS vector), then
-				// concatenate the already-safe HtmlStrings. No further escaping.
-				let out = html`<div class="flex items-center gap-2">`;
-				if (!isRevoked) {
-					out += html`<button data-scan-id="${agentId}" class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors">${m['agents.Trigger Scan']()}</button>`;
-					out += html`<button data-revoke-id="${tokenId}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors">${m['agents.Revoke']()}</button>`;
-				}
-				out += html`</div>`;
-				return out;
-			}
+			interactive: true
 		}
 	]);
 
@@ -372,13 +358,7 @@
 			key: '_expand',
 			label: '',
 			sortable: false,
-			render: (row: Record<string, unknown>) => {
-				const id = row.id as number;
-				const isOpen = commandsExpandedId === id;
-				return html`<button data-action="expand" data-id="${id}" class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted">`
-					+ html`<svg class="w-3.5 h-3.5 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">`
-					+ html`<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg></button>`;
-			}
+			interactive: true
 		},
 		{
 			key: 'agent_id',
@@ -459,27 +439,34 @@
 		/>
 	{:else}
 		<div class="bg-surface border border-border rounded-lg p-4">
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<div onclick={(e) => {
-				const target = e.target as HTMLElement;
-				const scanBtn = target.closest('[data-scan-id]') as HTMLElement | null;
-				if (scanBtn) { openScan(String(scanBtn.dataset.scanId)); return; }
-				const revokeBtn = target.closest('[data-revoke-id]') as HTMLElement | null;
-				if (revokeBtn) {
-					const id = Number(revokeBtn.dataset.revokeId);
-					const token = tokens.find((t) => t.id === id);
-					if (token) openRevoke(token);
-				}
-			}}>
 				<DataTable
 					{columns}
 					rows={tokens as unknown as Record<string, unknown>[]}
 					searchPlaceholder={(m['common.Search']()) + '...'}
 					searchableKeys={['agent_id', 'name']}
 					emptyTitle={m['agents.No Tokens']()}
-				/>
-			</div>
+				>
+					{#snippet cell(row, col)}
+						{#if col.key === 'actions'}
+							{@const token = tokens.find((t) => t.id === row.id)}
+							{#if token}
+								{@const isRevoked = !!token.revoked_at}
+								{#if !isRevoked}
+									<div class="flex items-center gap-2">
+										<button
+											onclick={() => openScan(String(token.agent_id))}
+											class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors"
+										>{m['agents.Trigger Scan']()}</button>
+										<button
+											onclick={() => openRevoke(token)}
+											class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors"
+										>{m['agents.Revoke']()}</button>
+									</div>
+								{/if}
+							{/if}
+						{/if}
+					{/snippet}
+				</DataTable>
 			</div>
 		{/if}
 
@@ -505,13 +492,6 @@
 				</div>
 			{:else}
 				<div class="bg-surface border border-border rounded-lg p-4">
-					<div onclick={(e) => {
-						const btn = (e.target as HTMLElement).closest('[data-action="expand"]') as HTMLElement | null;
-						if (btn) {
-							const id = Number(btn.dataset.id);
-							commandsExpandedId = commandsExpandedId === id ? null : id;
-						}
-					}}>
 						<DataTable
 							columns={commandColumns}
 							rows={commands as unknown as Record<string, unknown>[]}
@@ -519,6 +499,22 @@
 							emptyTitle={m['agents.No Commands']()}
 							expandedRowId={commandsExpandedId ?? undefined}
 						>
+							{#snippet cell(row, col)}
+								{#if col.key === '_expand'}
+									{@const id = row.id as number}
+									{@const isOpen = commandsExpandedId === id}
+									<button
+										onclick={() => { commandsExpandedId = commandsExpandedId === id ? null : id; }}
+										class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted"
+										aria-label={isOpen ? m['common.Collapse']() : m['common.Expand']()}
+										aria-expanded={isOpen}
+									>
+										<svg class="w-3.5 h-3.5 transition-transform duration-200 {isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+										</svg>
+									</button>
+								{/if}
+							{/snippet}
 							{#snippet expandedContent(row)}
 								{@const cmd = commands.find((c) => c.id === row.id)}
 								<div class="border-t border-border bg-bg/40 px-6 py-4 space-y-3">
@@ -536,21 +532,20 @@
 									{/if}
 								</div>
 							{/snippet}
-							</DataTable>
-							{#if commandsTotal > commandsLimit}
-								<div class="mt-4">
-									<Pagination
-										total={commandsTotal}
-										limit={commandsLimit}
-										offset={commandsOffset}
-										onPageChange={handleCommandsPage}
-									/>
-								</div>
-							{/if}
+								</DataTable>
+								{#if commandsTotal > commandsLimit}
+									<div class="mt-4">
+										<Pagination
+											total={commandsTotal}
+											limit={commandsLimit}
+											offset={commandsOffset}
+											onPageChange={handleCommandsPage}
+										/>
+									</div>
+								{/if}
 						</div>
-					</div>
-				{/if}
-		</div>
+					{/if}
+			</div>
 	</div>
 {/if}
 

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -213,13 +213,7 @@
 			key: '_expand',
 			label: '',
 			sortable: false,
-			render: (row: Record<string, unknown>) => {
-				const id = row.id as number;
-				const isOpen = expandedId === id;
-				return html`<button data-action="expand" data-id="${id}" class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted">`
-					+ html`<svg class="w-3.5 h-3.5 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">`
-					+ html`<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg></button>`;
-			}
+			interactive: true
 		},
 		{
 			key: 'created_at',
@@ -453,13 +447,6 @@
 		/>
 	{:else}
 		<div class="bg-surface border border-border rounded-lg p-4">
-				<div onclick={(e) => {
-					const btn = (e.target as HTMLElement).closest('[data-action="expand"]') as HTMLElement | null;
-					if (btn) {
-						const id = Number(btn.dataset.id);
-						expandedId = expandedId === id ? null : id;
-					}
-				}}>
 				<DataTable
 					{columns}
 					rows={logs as unknown as Record<string, unknown>[]}
@@ -470,6 +457,22 @@
 					emptyTitle={m["common.No Results"]()}
 					expandedRowId={expandedId ?? undefined}
 				>
+					{#snippet cell(row, col)}
+						{#if col.key === '_expand'}
+							{@const id = row.id as number}
+							{@const isOpen = expandedId === id}
+							<button
+								onclick={() => { expandedId = expandedId === id ? null : id; }}
+								class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted"
+								aria-label={isOpen ? m['common.Collapse']() : m['common.Expand']()}
+								aria-expanded={isOpen}
+							>
+								<svg class="w-3.5 h-3.5 transition-transform duration-200 {isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+								</svg>
+							</button>
+						{/if}
+					{/snippet}
 					{#snippet expandedContent(row)}
 						{@const log = logs.find((l) => l.id === row.id)}
 						<div class="border-t border-border bg-bg/40 px-6 py-4 space-y-3">
@@ -490,7 +493,6 @@
 						</div>
 					{/snippet}
 				</DataTable>
-				</div>
 
 			<div class="mt-4">
 				<Pagination {total} {limit} {offset} onPageChange={handlePageChange} />

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -217,13 +217,7 @@
 			key: '_expand',
 			label: '',
 			sortable: false,
-			render: (row: Record<string, unknown>) => {
-				const id = row.id as number;
-				const isOpen = expandedId === id;
-				return html`<button data-action="expand" data-id="${id}" class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted">`
-					+ html`<svg class="w-3.5 h-3.5 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">`
-					+ html`<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg></button>`;
-			}
+			interactive: true
 		},
 		{
 			key: 'detected_at',
@@ -379,13 +373,6 @@
 		/>
 	{:else}
 		<div class="bg-surface border border-border rounded-lg p-4">
-				<div onclick={(e) => {
-					const btn = (e.target as HTMLElement).closest('[data-action="expand"]') as HTMLElement | null;
-					if (btn) {
-						const id = Number(btn.dataset.id);
-						expandedId = expandedId === id ? null : id;
-					}
-				}}>
 				<DataTable
 					{columns}
 					rows={changes as unknown as Record<string, unknown>[]}
@@ -396,6 +383,22 @@
 					emptyTitle={m['changes.No Changes']()}
 					expandedRowId={expandedId ?? undefined}
 				>
+					{#snippet cell(row, col)}
+						{#if col.key === '_expand'}
+							{@const id = row.id as number}
+							{@const isOpen = expandedId === id}
+							<button
+								onclick={() => { expandedId = expandedId === id ? null : id; }}
+								class="p-1 rounded hover:bg-primary/10 transition-colors text-text-muted"
+								aria-label={isOpen ? m['common.Collapse']() : m['common.Expand']()}
+								aria-expanded={isOpen}
+							>
+								<svg class="w-3.5 h-3.5 transition-transform duration-200 {isOpen ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+								</svg>
+							</button>
+						{/if}
+					{/snippet}
 					{#snippet expandedContent(row)}
 						{@const change = changes.find((c) => c.id === row.id)}
 						<div class="border-t border-border bg-bg/40 px-6 py-4">
@@ -414,7 +417,6 @@
 						</div>
 					{/snippet}
 				</DataTable>
-				</div>
 
 			<div class="mt-4">
 				<Pagination {total} {limit} {offset} onPageChange={handlePageChange} />

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -1364,14 +1364,12 @@
 			{:else if tlsCerts.length > 0}
 				<div class="tls-cert-list">
 					{#each tlsCerts as portCerts (portCerts.port)}
-						<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-						<div
+						<button
+							type="button"
 							class="tls-cert-row"
 							data-status={certStatus(portCerts)}
-							role="button"
-							tabindex="0"
 							onclick={() => openCertModal(portCerts)}
-							onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openCertModal(portCerts); } }}
+							aria-label={m['certificates.ViewCert']?.() ?? `:${portCerts.port} TLS`}
 						>
 							<div class="tls-cert-port">
 								<span class="tls-cert-port-num">:{portCerts.port}</span>
@@ -1401,7 +1399,7 @@
 								{/if}
 								<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
 							</div>
-						</div>
+						</button>
 					{/each}
 				</div>
 			{:else}
@@ -2156,6 +2154,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.875rem;
+		width: 100%;
 		padding: 0.625rem 0.75rem;
 		border: 1px solid var(--color-border);
 		border-left-width: 3px;
@@ -2163,6 +2162,11 @@
 		cursor: pointer;
 		transition: background 0.15s ease, border-color 0.15s ease;
 		background: var(--color-surface);
+		/* <button> reset so it renders like the old <div> (full width, left-aligned,
+		   inherits text color/font — button defaults to centered/its own font). */
+		text-align: left;
+		font: inherit;
+		color: inherit;
 	}
 	.tls-cert-row:hover {
 		background: var(--color-surface-2);

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -370,20 +370,7 @@
 		{
 			key: 'actions',
 			label: m["common.Actions"](),
-			render: (row: Record<string, unknown>) => {
-				const doc = row as unknown as Document;
-				let btns = '';
-				// Preview button for previewable files
-				if (doc.type !== 'url' && isPreviewable(doc)) {
-					btns += html`<button data-action="preview" data-id="${doc.id}" class="text-xs px-2 py-1 rounded text-success hover:bg-success/10 transition-colors">${m["documents.Preview"]()}</button>`;
-				}
-				btns += html`<button data-action="edit" data-id="${doc.id}" class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors">${m["common.Edit"]()}</button>`;
-				if (doc.type !== 'url' && doc.file_path) {
-					btns += html`<button data-action="download" data-id="${doc.id}" class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors">${m["documents.Download"]()}</button>`;
-				}
-				btns += html`<button data-action="delete" data-id="${doc.id}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors">${m["common.Delete"]()}</button>`;
-				return html`<div class="flex gap-2">${btns}</div>`;
-			}
+			interactive: true
 		}
 	]);
 
@@ -409,19 +396,8 @@
 		}
 	}
 
-	function handleTableClick(e: MouseEvent) {
-		const target = e.target as HTMLElement;
-		const btn = target.closest('[data-action]') as HTMLElement | null;
-		if (!btn) return;
-		const action = btn.dataset.action;
-		const id = Number(btn.dataset.id);
-		const doc = documents.find((d) => d.id === id);
-		if (!doc) return;
-		if (action === 'edit') openEdit(doc);
-		if (action === 'delete') requestDelete(doc);
-		if (action === 'preview') openPreview(doc);
-		if (action === 'download') downloadDocument(doc);
-	}
+	// Actions-column dispatch moved to the `cell` snippet (real onclick handlers,
+	// no event delegation) — see the DataTable usage below (#167).
 </script>
 
 <div class="p-4 sm:p-6">
@@ -466,7 +442,7 @@
 			onAction={openUrlCreate}
 		/>
 	{:else}
-		<div onclick={handleTableClick}>
+		<div>
 			<DataTable
 				{columns}
 				rows={documents as unknown as Record<string, unknown>[]}
@@ -475,7 +451,37 @@
 				initialSearch={searchInput}
 				onSearchChange={onSearchInput}
 				emptyTitle={m["common.No Results"]()}
-			/>
+			>
+				{#snippet cell(row, col)}
+					{#if col.key === 'actions'}
+						{@const doc = documents.find((d) => d.id === row.id)}
+						{#if doc}
+							<div class="flex gap-2">
+								{#if doc.type !== 'url' && isPreviewable(doc)}
+									<button
+										onclick={() => openPreview(doc)}
+										class="text-xs px-2 py-1 rounded text-success hover:bg-success/10 transition-colors"
+									>{m["documents.Preview"]()}</button>
+								{/if}
+								<button
+									onclick={() => openEdit(doc)}
+									class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors"
+								>{m["common.Edit"]()}</button>
+								{#if doc.type !== 'url' && doc.file_path}
+									<button
+										onclick={() => downloadDocument(doc)}
+										class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors"
+									>{m["documents.Download"]()}</button>
+								{/if}
+								<button
+									onclick={() => requestDelete(doc)}
+									class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors"
+								>{m["common.Delete"]()}</button>
+							</div>
+						{/if}
+					{/if}
+				{/snippet}
+			</DataTable>
 		</div>
 
 		<div class="mt-4">

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -232,7 +232,7 @@
 							<button
 								type="button"
 								onclick={() => showPassword = !showPassword}
-								class="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted hover:text-text transition-colors"
+								class="absolute right-1 top-1/2 -translate-y-1/2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted hover:text-text transition-colors"
 								aria-label={showPassword ? m['auth.hide_password']() : m['auth.show_password']()}
 								title={showPassword ? m['auth.hide_password']() : m['auth.show_password']()}
 							>

--- a/web/src/routes/networks/+page.svelte
+++ b/web/src/routes/networks/+page.svelte
@@ -181,22 +181,7 @@
 		{
 			key: 'actions',
 			label: m['common.Actions'](),
-			render: (row: Record<string, unknown>) => {
-				const id = row.id;
-				const agentManaged = !!row.agent_id;
-				// Build the title attribute inline (escaped) when agent-managed,
-				// rather than a pre-built attribute string that html would double-escape.
-				if (agentManaged) {
-					return html`<div class="flex gap-2">`
-						+ html`<button data-edit-id="${id}" class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10">${m['common.Edit']()}</button>`
-						+ html`<button data-delete-id="${id}" disabled title="${m['networks.Agent Managed Hint']()}" class="text-xs px-2 py-1 rounded text-error opacity-40 cursor-not-allowed">${m['common.Delete']()}</button>`
-						+ html`</div>`;
-				}
-				return html`<div class="flex gap-2">`
-					+ html`<button data-edit-id="${id}" class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10">${m['common.Edit']()}</button>`
-					+ html`<button data-delete-id="${id}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10">${m['common.Delete']()}</button>`
-					+ html`</div>`;
-			}
+			interactive: true
 		}
 	]);
 </script>
@@ -245,31 +230,33 @@
 		/>
 	{:else}
 		<div class="bg-surface border border-border rounded-lg p-4">
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<div onclick={(e) => {
-				const target = e.target as HTMLElement;
-				const editBtn = target.closest('[data-edit-id]') as HTMLElement | null;
-				if (editBtn) {
-					const id = Number(editBtn.dataset.editId);
-					const net = networks.find((n) => n.id === id);
-					if (net) openEdit(net);
-					return;
-				}
-				const delBtn = target.closest('[data-delete-id]') as HTMLElement | null;
-				if (delBtn && !(delBtn as HTMLButtonElement).disabled) {
-					const id = Number(delBtn.dataset.deleteId);
-					const net = networks.find((n) => n.id === id);
-					if (net) { deleteTarget = net; deleteOpen = true; }
-				}
-			}}>
 				<DataTable
 					{columns}
 					rows={networks as unknown as Record<string, unknown>[]}
 					searchableKeys={['name', 'site']}
 					emptyTitle={m['networks.Empty']()}
-				/>
-			</div>
+				>
+					{#snippet cell(row, col)}
+						{#if col.key === 'actions'}
+							{@const net = networks.find((n) => n.id === row.id)}
+							{#if net}
+								{@const agentManaged = !!net.agent_id}
+								<div class="flex gap-2">
+									<button
+										onclick={() => openEdit(net)}
+										class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10"
+									>{m['common.Edit']()}</button>
+									<button
+										onclick={() => { if (!agentManaged) { deleteTarget = net; deleteOpen = true; } }}
+										disabled={agentManaged}
+										title={agentManaged ? m['networks.Agent Managed Hint']() : undefined}
+										class="text-xs px-2 py-1 rounded text-error {agentManaged ? 'opacity-40 cursor-not-allowed' : 'hover:bg-error/10'}"
+									>{m['common.Delete']()}</button>
+								</div>
+							{/if}
+						{/if}
+					{/snippet}
+				</DataTable>
 		</div>
 	{/if}
 </div>

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -534,25 +534,12 @@
 			key: 'enabled',
 			label: m["notifications.Enabled"](),
 			sortable: true,
-			render: (row: Record<string, unknown>) => {
-				const enabled = row.enabled;
-				const id = row.id;
-				return html`<button data-rule-toggle-id="${id}" class="text-xs px-2 py-0.5 rounded cursor-pointer transition-colors ${enabled
-					? 'bg-success/15 text-success hover:bg-success/25'
-					: 'bg-border/30 text-text-muted hover:bg-border/50'
-				}">${enabled ? m["notifications.Enabled"]() : m["notifications.Disabled"]()}</button>`;
-			}
+			interactive: true
 		},
 		{
 			key: 'actions',
 			label: m["common.Actions"](),
-			render: (row: Record<string, unknown>) => {
-				const id = row.id;
-				return html`<div class="flex items-center gap-2">
-					<button data-rule-edit-id="${id}" class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors">${m["common.Edit"]()}</button>
-					<button data-rule-delete-id="${id}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors">${m["common.Delete"]()}</button>
-				</div>`;
-			}
+			interactive: true
 		}
 	]);
 
@@ -578,14 +565,7 @@
 			key: 'enabled',
 			label: m["notifications.Enabled"](),
 			sortable: true,
-			render: (row: Record<string, unknown>) => {
-				const enabled = row.enabled;
-				const id = row.id;
-				return html`<button data-toggle-id="${id}" class="text-xs px-2 py-0.5 rounded cursor-pointer transition-colors ${enabled
-					? 'bg-success/15 text-success hover:bg-success/25'
-					: 'bg-border/30 text-text-muted hover:bg-border/50'
-				}">${enabled ? m["notifications.Enabled"]() : m["notifications.Disabled"]()}</button>`;
-			}
+			interactive: true
 		},
 		{
 			key: 'created_at',
@@ -597,14 +577,7 @@
 		{
 			key: 'actions',
 			label: m["common.Actions"](),
-			render: (row: Record<string, unknown>) => {
-				const id = row.id;
-				return html`<div class="flex items-center gap-2">
-					<button data-test-id="${id}" class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors">${m["notifications.Test Channel"]()}</button>
-					<button data-edit-id="${id}" class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors">${m["common.Edit"]()}</button>
-					<button data-delete-id="${id}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors">${m["common.Delete"]()}</button>
-				</div>`;
-			}
+			interactive: true
 		}
 	]);
 </script>
@@ -689,28 +662,43 @@
 		{:else}
 			<!-- Channel table -->
 			<div class="bg-surface border border-border rounded-lg p-4">
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<div onclick={(e) => {
-					const target = e.target as HTMLElement;
-					const btn = target.closest('[data-delete-id],[data-edit-id],[data-test-id],[data-toggle-id]') as HTMLElement | null;
-					if (!btn) return;
-					const id = Number(btn.dataset.deleteId || btn.dataset.editId || btn.dataset.testId || btn.dataset.toggleId);
-					const channel = channels.find((c) => c.id === id);
-					if (!channel) return;
-					if (btn.dataset.deleteId !== undefined) openDelete(channel);
-					else if (btn.dataset.editId !== undefined) openEdit(channel);
-					else if (btn.dataset.testId !== undefined) testChannel(channel);
-					else if (btn.dataset.toggleId !== undefined) toggleEnabled(channel);
-				}}>
 					<DataTable
 						{columns}
 						rows={channels as unknown as Record<string, unknown>[]}
 						searchPlaceholder={m["notifications.Search Channels"]()}
 						searchableKeys={['name', 'type']}
 						emptyTitle={m["common.No Results"]()}
-					/>
-				</div>
+					>
+						{#snippet cell(row, col)}
+							{@const channel = channels.find((c) => c.id === row.id)}
+							{#if channel}
+								{#if col.key === 'enabled'}
+									<button
+										onclick={() => toggleEnabled(channel)}
+										class="text-xs px-2 py-0.5 rounded cursor-pointer transition-colors {channel.enabled
+											? 'bg-success/15 text-success hover:bg-success/25'
+											: 'bg-border/30 text-text-muted hover:bg-border/50'
+										}"
+									>{channel.enabled ? m["notifications.Enabled"]() : m["notifications.Disabled"]()}</button>
+								{:else if col.key === 'actions'}
+									<div class="flex items-center gap-2">
+										<button
+											onclick={() => testChannel(channel)}
+											class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors"
+										>{m["notifications.Test Channel"]()}</button>
+										<button
+											onclick={() => openEdit(channel)}
+											class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors"
+										>{m["common.Edit"]()}</button>
+										<button
+											onclick={() => openDelete(channel)}
+											class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors"
+										>{m["common.Delete"]()}</button>
+									</div>
+								{/if}
+							{/if}
+						{/snippet}
+					</DataTable>
 			</div>
 		{/if}
 	{:else}
@@ -733,27 +721,39 @@
 			/>
 		{:else}
 			<div class="bg-surface border border-border rounded-lg p-4">
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<div onclick={(e) => {
-					const target = e.target as HTMLElement;
-					const btn = target.closest('[data-rule-delete-id],[data-rule-edit-id],[data-rule-toggle-id]') as HTMLElement | null;
-					if (!btn) return;
-					const id = Number(btn.dataset.ruleDeleteId || btn.dataset.ruleEditId || btn.dataset.ruleToggleId);
-					const rule = rules.find((r) => r.id === id);
-					if (!rule) return;
-					if (btn.dataset.ruleDeleteId !== undefined) openDeleteRule(rule);
-					else if (btn.dataset.ruleEditId !== undefined) openEditRule(rule);
-					else if (btn.dataset.ruleToggleId !== undefined) toggleRuleEnabled(rule);
-				}}>
 					<DataTable
 						columns={ruleColumns}
 						rows={rules as unknown as Record<string, unknown>[]}
 						searchPlaceholder={m["common.Search"]() + '…'}
 						searchableKeys={['name', 'event_type']}
 						emptyTitle={m["common.No Results"]()}
-					/>
-				</div>
+					>
+						{#snippet cell(row, col)}
+							{@const rule = rules.find((r) => r.id === row.id)}
+							{#if rule}
+								{#if col.key === 'enabled'}
+									<button
+										onclick={() => toggleRuleEnabled(rule)}
+										class="text-xs px-2 py-0.5 rounded cursor-pointer transition-colors {rule.enabled
+											? 'bg-success/15 text-success hover:bg-success/25'
+											: 'bg-border/30 text-text-muted hover:bg-border/50'
+										}"
+									>{rule.enabled ? m["notifications.Enabled"]() : m["notifications.Disabled"]()}</button>
+								{:else if col.key === 'actions'}
+									<div class="flex items-center gap-2">
+										<button
+											onclick={() => openEditRule(rule)}
+											class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors"
+										>{m["common.Edit"]()}</button>
+										<button
+											onclick={() => openDeleteRule(rule)}
+											class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors"
+										>{m["common.Delete"]()}</button>
+									</div>
+								{/if}
+							{/if}
+						{/snippet}
+					</DataTable>
 			</div>
 		{/if}
 	{/if}

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -297,13 +297,7 @@
 		{
 			key: 'actions',
 			label: m["common.Actions"](),
-			render: (row: Record<string, unknown>) => {
-				const userId = row.id;
-				return html`<div class="flex items-center gap-2">
-					<button data-reset-id="${userId}" class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors">${m["users.Reset Password"]()}</button>
-					<button data-delete-id="${userId}" class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors">${m["common.Delete"]()}</button>
-				</div>`;
-			}
+			interactive: true
 		}
 	]);
 </script>
@@ -350,25 +344,7 @@
 		/>
 	{:else}
 		<!-- User table -->
-		<div class="bg-surface border border-border rounded-lg p-4">
-				<!-- Wrap DataTable + handle delete clicks -->
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<div onclick={(e) => {
-					const target = e.target as HTMLElement;
-					const deleteBtn = target.closest('[data-delete-id]') as HTMLElement | null;
-					if (deleteBtn) {
-						const id = Number(deleteBtn.dataset.deleteId);
-						const user = users.find((u) => u.id === id);
-						if (user) openDelete(user);
-					}
-					const resetBtn = target.closest('[data-reset-id]') as HTMLElement | null;
-					if (resetBtn) {
-						const id = Number(resetBtn.dataset.resetId);
-						const user = users.find((u) => u.id === id);
-						if (user) openReset(user);
-					}
-				}}>
+			<div class="bg-surface border border-border rounded-lg p-4">
 					<DataTable
 						{columns}
 						rows={users as unknown as Record<string, unknown>[]}
@@ -377,8 +353,25 @@
 						initialSearch={searchInput}
 						onSearchChange={onSearchInput}
 						emptyTitle={m["common.No Results"]()}
-					/>
-				</div>
+					>
+						{#snippet cell(row, col)}
+							{#if col.key === 'actions'}
+								{@const user = users.find((u) => u.id === row.id)}
+								{#if user}
+									<div class="flex items-center gap-2">
+										<button
+											onclick={() => openReset(user)}
+											class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors"
+										>{m["users.Reset Password"]()}</button>
+										<button
+											onclick={() => openDelete(user)}
+											class="text-xs px-2 py-1 rounded text-error hover:bg-error/10 transition-colors"
+										>{m["common.Delete"]()}</button>
+									</div>
+								{/if}
+							{/if}
+						{/snippet}
+					</DataTable>
 
 			<!-- Pagination -->
 			<Pagination {total} {limit} {offset} onPageChange={handlePageChange} />


### PR DESCRIPTION
## 问题

8+ 个页面用 \`<div onclick>\` 包 DataTable 做事件委托（靠 \`data-*-id\` 属性分发），全部带 \`svelte-ignore a11y_no_static_element_interactions\` + \`a11y_click_events_have_key_events\` 抑制 —— 键盘用户虽能 Tab 到内层 button，但屏幕阅读器按控件跳转时拿不到委托 handler 的上下文，且违反 WCAG 2.1。

> Addresses #167（devices 列表页留作 follow-up，见下）

## 改动

### 核心：DataTable 重构
- \`Column\` 新增 \`interactive?: boolean\` 标记
- DataTable 新增 \`cell?: Snippet<[row, col]>\` prop。interactive 列优先用 \`{@render cell(row, col)}\` 渲染真实 Svelte 元素；纯展示列继续用 \`render\` + \`{@html}\`（向后兼容，XSS 保护不变）

### 迁移 8 个页面到 cell snippet
每个页面：交互列改 \`interactive: true\` + 删除外层 \`<div onclick>\` + handler 函数 + svelte-ignore，在 \`<DataTable>\` 内用 \`{#snippet cell(row, col)}\` 分发真 \`<button>\`/\`<input>\` + 绑定 onclick。

| 页面 | 交互列 |
|---|---|
| users | actions（reset/delete） |
| networks | actions（edit/delete；agent-managed 禁用） |
| agents | token 表 actions（scan/revoke）+ 命令历史 _expand |
| settings/notifications | channel 表 enabled+actions、rule 表 enabled+actions |
| changes | _expand |
| documents | actions（preview/edit/download/delete） |
| audit | _expand |

### 顺带修（issue 正文列出）
- **device detail TLS cert 行**：\`<div role=\"button\" tabindex=\"0\">\` → 真 \`<button>\`（含 CSS 重置保持外观）
- **DashboardWidget 拖拽手柄**：\`<div role=\"button\" tabindex=\"0\">\` → 真 \`<button>\`（移除 2 处 svelte-ignore）
- **触摸目标 ≥44×44px**（WCAG 2.5.5）：DashboardWidget action/handle 按钮（28px→44px）、Toast dismiss（24px→44px）、login 显密按钮（24px→44px）
- **Modal focus trap**：已就绪（\`trapFocus\` :70-93 覆盖 discard-confirm overlay，它在 dialogRef 内），无需改动
- 新增 i18n key \`common.Expand\` / \`common.Collapse\`

## ⚠️ devices 列表页 — 留作 follow-up

devices 列表页有 4 个交互列（\`_select\`/``_expand\`/\`name\`/\`actions\`）+ expandedRow snippet。迁移到 cell snippet 后遇 **Svelte snippet 响应式与 fetchDevices 竞态**：cell snippet 引用 \`selectedIds\`/\`expandedDeviceId\`/\`devices\` 等响应式状态时，fetchDevices 的 loading 永久卡 true（API 返回 200 但 finally 不重置 loading）。静态 cell snippet（不引用响应式状态）正常；users/changes 等页面引用响应式 \`users.find()\` 也正常 —— 问题特定于 devices 页的多状态交互。

该页暂保留 main 版（render + 事件委托 + svelte-ignore），不阻塞本 PR 的其他 8 页改进。devices 页迁移需单独调查 snippet 响应式作用域与 fetchSeq 竞态的交互。

## 验证

- \`npm test\` 191 passed（8 文件全绿）
- \`npm run build\` 通过；audit 页之前未加 svelte-ignore 的 a11y warning 已消除
- **浏览器键盘实测（192.168.63.101）**：users 页行操作 button 在 accessibility tree 中（\`button \"重置密码\"\` / \`button \"删除\"\`），\`document.activeElement\` 确认 Tab 焦点可落在 button 上；8 个迁移页面表格 + 行数据正常渲染

## 类型

a11y / 前端（P1 键盘可达性）。