### PR TITLE
fix(web): 搜索无结果 empty state 区分 — 不再误导显示创建 CTA (#169)

### DIFF
--- a/internal/service/scannerv2/runner/device_bridge_test.go
+++ b/internal/service/scannerv2/runner/device_bridge_test.go
@@ -201,3 +201,42 @@ func TestApplyDeviceBridge_MACFirstResolveNotReplacement(t *testing.T) {
 	require.Equal(t, "aa:bb:cc:dd:ee:20", filled.MAC, "mac filled on the existing row")
 	require.Equal(t, "online", filled.Status)
 }
+
+// TestApplyDeviceBridge_NameSelfHealsFromIP guards the name=ip_address
+// self-heal in buildExistingUpdate (#169 part d): when a device is first
+// discovered with NO resolvable hostname, its name falls back to the IP
+// (deviceDisplayName). A later scan that DOES resolve a hostname must
+// overwrite the IP-as-name — the SQL `name = CASE WHEN (name = ” OR name =
+// ip_address) THEN ? ELSE name END` covers exactly this. This is intentional
+// fallback behaviour (NOT a ghost to clean up); the test pins it so a future
+// refactor doesn't silently drop the self-heal and leave devices stuck
+// showing their IP as a name forever.
+func TestApplyDeviceBridge_NameSelfHealsFromIP(t *testing.T) {
+	rn, _, conn := setupChangeDetectDB(t)
+	ctx := context.Background()
+
+	// First scan: device at .190 with no hostname sources at all. deviceDisplayName
+	// falls through node_hostname / sys_name / scan_attributes.hostname → returns
+	// the IP, so devices.name = "192.168.63.190".
+	noName := reportFor("192.168.63.190", "other", "", "de:ad:be:ef:19:00")
+	_, _ = rn.applyDeviceBridge(ctx, noName, rn.networkID, "")
+
+	var id int64
+	require.NoError(t, conn.QueryRow(
+		`SELECT id FROM devices WHERE ip_address='192.168.63.190' AND network_id=?`, rn.networkID.Int64).Scan(&id))
+	require.Equal(t, "192.168.63.190", fetchDevice(t, conn, id).Name,
+		"first scan with no hostname: name falls back to the IP")
+
+	// Second scan of the same (ip, mac): now a hostname IS resolved (e.g. via
+	// rDNS / TLS CN / mDNS). The CASE in buildExistingUpdate sees name == ip_address
+	// and overwrites it with the resolved hostname.
+	withName := reportFor("192.168.63.190", "other", "", "de:ad:be:ef:19:00")
+	withName.Device.Fields["node_hostname"] = "sensor-living-room"
+	_, _ = rn.applyDeviceBridge(ctx, withName, rn.networkID, "")
+
+	require.Equal(t, 1, countDevices(t, conn), "rescan updates the existing row, no new device")
+	healed := fetchDevice(t, conn, id)
+	require.Equal(t, "sensor-living-room", healed.Name,
+		"name self-heals: IP-as-name overwritten once a hostname is resolved")
+	require.Equal(t, "192.168.63.190", healed.IP, "ip unchanged")
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -344,6 +344,8 @@
 		"Error": "Error",
 		"Success": "Success",
 		"No Results": "No Results",
+		"No Results Desc": "No matches for \"{query}\". Try a different search or clear filters.",
+		"Clear Filters": "Clear filters",
 		"Confirm": "Confirm",
 		"Are you sure?": "Are you sure?",
 		"Total": "Total",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -344,6 +344,8 @@
 		"Error": "错误",
 		"Success": "成功",
 		"No Results": "无结果",
+		"No Results Desc": "没有匹配「{query}」的结果。试试其他关键词或清除筛选。",
+		"Clear Filters": "清除筛选",
 		"Confirm": "确认",
 		"Are you sure?": "确定吗？",
 		"Total": "总数",

--- a/web/src/lib/components/DataTable.svelte
+++ b/web/src/lib/components/DataTable.svelte
@@ -67,6 +67,13 @@
 		// filtering the in-memory page slice. Mirrors the onSortChange server-side
 		// pattern. Without it, search stays client-side (backward-compatible).
 		onSearchChange,
+		// When non-empty, the caller is actively filtering on the server (search
+		// term and/or filter params). In that mode an empty `rows` array means
+		// "the filter returned nothing" rather than "nothing exists", so the
+		// table shows a no-results state (Search icon + clear) instead of the
+		// create-first-item CTA. Pass the current query string for the message
+		// (#169). For DataTable's own search box, this falls back to searchQuery.
+		serverFilterQuery = '',
 	}: {
 		columns: Column[];
 		rows: Record<string, unknown>[];
@@ -85,6 +92,7 @@
 		externalSortDirection?: 'asc' | 'desc' | 'none';
 		onSortChange?: (key: string, direction: 'asc' | 'desc') => void;
 		onSearchChange?: (query: string) => void;
+		serverFilterQuery?: string;
 	} = $props();
 
 	let sortKey = $state<string | null>(null);
@@ -148,6 +156,9 @@
 	const displayRows = $derived(sortedRows());
 	const isEmpty = $derived(displayRows.length === 0 && rows.length > 0);
 	const isTotallyEmpty = $derived(rows.length === 0);
+	// The active server-side query term: caller-provided (covers pages with an
+	// external search box like devices) falling back to DataTable's own box.
+	const activeQuery = $derived(serverFilterQuery || searchQuery);
 
 	function handleSort(key: string) {
 		if (onSortChange) {
@@ -275,17 +286,30 @@
 
 	<!-- Empty state — no rows at all -->
 	{#if isTotallyEmpty}
-		<div class="flex flex-col items-center justify-center py-12 px-4 text-center">
-			<Inbox class="w-12 h-12 mb-3 text-muted opacity-40" strokeWidth={1.5} />
-			<h3 class="text-sm font-medium text-text mb-1">{emptyTitle}</h3>
-			{#if emptyDescription}
-				<p class="text-xs text-muted mb-4">{emptyDescription}</p>
-			{/if}
-			{#if emptyAction && emptyActionLabel}
-				<button onclick={emptyAction} class="btn btn-primary">
-					{emptyActionLabel}
+		{#if activeQuery}
+			<!-- Server-side search returned nothing: NOT a "create first item" case.
+			     Show a no-results state with a clear-search affordance instead (#169). -->
+			<div class="flex flex-col items-center justify-center py-12 px-4 text-center">
+				<Search class="w-12 h-12 mb-3 text-muted opacity-40" strokeWidth={1.5} />
+				<h3 class="text-sm font-medium text-text mb-1">{m['common.No Results']()}</h3>
+				<p class="text-xs text-muted mb-4">{m['common.No Results Desc']({ query: activeQuery })}</p>
+				<button onclick={() => { searchQuery = ''; onSearchChange?.(''); }} class="btn btn-secondary">
+					{m['common.Clear Search']()}
 				</button>
-			{/if}
-		</div>
+			</div>
+		{:else}
+			<div class="flex flex-col items-center justify-center py-12 px-4 text-center">
+				<Inbox class="w-12 h-12 mb-3 text-muted opacity-40" strokeWidth={1.5} />
+				<h3 class="text-sm font-medium text-text mb-1">{emptyTitle}</h3>
+				{#if emptyDescription}
+					<p class="text-xs text-muted mb-4">{emptyDescription}</p>
+				{/if}
+				{#if emptyAction && emptyActionLabel}
+					<button onclick={emptyAction} class="btn btn-primary">
+						{emptyActionLabel}
+					</button>
+				{/if}
+			</div>
+		{/if}
 	{/if}
 </div>

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -439,6 +439,14 @@
 	<!-- Content -->
 	{#if loading}
 		<PageSkeleton type="table" />
+	{:else if logs.length === 0 && (searchQuery || filterUser || filterAction || filterResourceType || filterDateFrom || filterDateTo)}
+		<EmptyState
+			icon="🔍"
+			title={m["common.No Results"]()}
+			description={m['common.No Results Desc']({ query: searchQuery || m['common.Clear Filters']() })}
+			actionLabel={m['common.Clear Filters']()}
+			onAction={() => { searchQuery = ''; searchInput = ''; filterUser = ''; filterAction = ''; filterResourceType = ''; filterDateFrom = ''; filterDateTo = ''; fetchLogs(); }}
+		/>
 	{:else if logs.length === 0}
 		<EmptyState
 			icon="📋"

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -365,6 +365,14 @@
 	<!-- Content -->
 	{#if loading}
 		<PageSkeleton type="table" />
+	{:else if changes.length === 0 && (searchQuery || filterNetwork || filterChangeType)}
+		<EmptyState
+			icon="🔍"
+			title={m['common.No Results']()}
+			description={m['common.No Results Desc']({ query: searchQuery || m['common.Clear Filters']() })}
+			actionLabel={m['common.Clear Filters']()}
+			onAction={() => { searchQuery = ''; searchInput = ''; filterNetwork = ''; filterChangeType = ''; fetchChanges(); }}
+		/>
 	{:else if changes.length === 0}
 		<EmptyState
 			icon="📊"

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -1290,6 +1290,7 @@ interface AddDevicesResponse {
 				externalSortKey={sortKey || null}
 				externalSortDirection={sortKey ? sortDir : 'none'}
 				onSortChange={onSortChange}
+				serverFilterQuery={searchQuery}
 			/>
 		</div>
 

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -409,7 +409,15 @@
 		<PageSkeleton type="table" />
 	{:else if activeTab === 'results'}
 		<!-- Results table -->
-			{#if results.length === 0}
+			{#if results.length === 0 && (debouncedIp || taskIdFilter || aliveFilter)}
+				<EmptyState
+					icon="🔍"
+					title={m['scanner.No Results']()}
+					description={m['common.No Results Desc']({ query: debouncedIp || m['common.Clear Filters']() })}
+					actionLabel={m['common.Clear Filters']()}
+					onAction={() => { ipSearch = ''; debouncedIp = ''; taskIdFilter = ''; aliveFilter = ''; fetchResults(); }}
+				/>
+			{:else if results.length === 0}
 				<EmptyState
 					icon={ClipboardList}
 					title={m['scanner.No Results']()}

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -433,6 +433,14 @@
 			actionLabel={m["common.Back"]()}
 			onAction={fetchDocuments}
 		/>
+	{:else if documents.length === 0 && searchQuery}
+		<EmptyState
+			icon="🔍"
+			title={m["common.No Results"]()}
+			description={m['common.No Results Desc']({ query: searchQuery })}
+			actionLabel={m['common.Clear Search']()}
+			onAction={() => { searchQuery = ''; searchInput = ''; fetchDocuments(); }}
+		/>
 	{:else if documents.length === 0}
 		<EmptyState
 			icon="📄"

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -334,6 +334,14 @@
 	<!-- Loading skeleton -->
 	{#if loading}
 		<PageSkeleton type="table" />
+	{:else if users.length === 0 && searchQuery}
+		<EmptyState
+			icon="🔍"
+			title={m["common.No Results"]()}
+			description={m['common.No Results Desc']({ query: searchQuery })}
+			actionLabel={m['common.Clear Search']()}
+			onAction={() => { searchQuery = ''; searchInput = ''; fetchUsers(); }}
+		/>
 	{:else if users.length === 0}
 		<EmptyState
 			icon={UsersIcon}


### PR DESCRIPTION
## 问题

搜索框输入不匹配关键词时,empty state 显示「暂无设备 — 点击创建第一个设备」+ 创建 CTA,误导用户(他想要的是改搜索词,不是创建)。这是因为 server-side 搜索页传空 \`rows\` 给 DataTable,\`isTotallyEmpty=true\` 触发 create-CTA。

> Closes #169

## 改动

### 主体:empty state 两层修复(6 页)
- **Pattern A(DataTable 内部)**:新增 \`serverFilterQuery\` prop。当 \`rows.length === 0 && activeQuery\`(server-side 搜索/筛选激活)时,渲染「无结果」态(Search 图标 + \`common.No Results Desc\` + 清除搜索按钮),而非 create-CTA。devices 页传 \`serverFilterQuery={searchQuery}\`。
- **Pattern B(页面外层 EmptyState)**:changes / audit / users / documents / scan-results 5 页的外层 \`{:else if data.length === 0}\` 守卫拆两分支,照 scan-tasks 页的参考模式:搜索/筛选激活 → 无结果态 + 清除;真空 → 原 create-CTA。

### 顺带(a/b/c/d)
- **a(FOUC)**:审计确认 15 个路由 loading 时都用 \`PageSkeleton\`,全覆盖,无需改动
- **b(密码校验时序)**:审计确认 login/settings/users 所有密码字段都用 \`bind:value\`(Svelte 5 双向同步),实机手输无问题,无需改动
- **c(拓扑视图)**:探索发现 DeviceTopologyView **已有**力导向布局 + 节点数阈值切换(\`recommendedForceParams\`)+ pan/zoom(\`roam\`)+ legend(issue 描述过时,系 #136 实现),无需改动
- **d(name=ip 幽灵数据)**:\`name = ip\` 是 \`deviceDisplayName\` 的**有意 fallback**(设备无 hostname 时用 IP),\`buildExistingUpdate:702\` 已有**自愈**(后续扫描解析到 hostname 会覆盖)。**不做破坏性 cleanup**(会误删合法 IP-only 设备)。改为补 \`TestApplyDeviceBridge_NameSelfHealsFromIP\` 测试防回归。

### i18n
新增 \`common.No Results Desc\`(带 {query})+ \`common.Clear Filters\`(zh + en)。

## 验证
- \`npm test\` 191 passed;\`go test ./internal/service/scannerv2/runner/\` 全绿(含新测试)
- **浏览器实测(192.168.63.101)**:
  - devices 搜索 \`zzz_no_match\` → 「无结果 / 没有匹配「zzz_no_match」的结果...清除搜索」(无 Inbox 图标、无创建 CTA)✅
  - users / changes 搜索无匹配 → 「无结果 + 清除搜索/筛选」✅