### PR TITLE
fix(web): toLocaleString 改用 paraglide locale — 日期/时间跟随 UI 语言 (#168)

### DIFF
--- a/web/src/lib/components/HeartbeatExpandableRow.svelte
+++ b/web/src/lib/components/HeartbeatExpandableRow.svelte
@@ -12,6 +12,7 @@
 	import { api } from '$lib/api/client';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { formatDateTime as formatTime } from '$lib/utils/index';
 	import Chart from '$lib/components/Chart.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import type { EChartsOption } from '$lib/charts/echarts';
@@ -146,15 +147,6 @@
 	function formatLatency(ms: number): string {
 		if (!ms && ms !== 0) return '-';
 		return `${ms}ms`;
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
-		}
 	}
 
 	function lastCheckTime(): string {

--- a/web/src/lib/components/NotificationBell.svelte
+++ b/web/src/lib/components/NotificationBell.svelte
@@ -14,6 +14,7 @@
 	import { api } from '$lib/api/client';
 	import { m } from '$lib/i18n-paraglide';
 	import { Bell } from '@lucide/svelte';
+	import { formatDateTime as formatTime } from '$lib/utils/index';
 	import type { NotificationLog, NotificationLogsResponse, MarkAllReadResponse } from '$lib/types';
 
 	let notifications = $state<NotificationLog[]>([]);
@@ -88,17 +89,6 @@
 	function handleClickOutside(e: MouseEvent) {
 		if (containerRef && !containerRef.contains(e.target as Node)) {
 			showDropdown = false;
-		}
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			// A malformed sent_at would otherwise throw inside the {#each} and
-			// crash the whole dropdown. Fall back to the raw value.
-			return iso;
 		}
 	}
 

--- a/web/src/lib/utils/format.ts
+++ b/web/src/lib/utils/format.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+ *
+ * This file is part of MiBee Steward, distributed under the GNU Affero General
+ * Public License v3.0 or later. A commercial license is available for use cases
+ * the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+ */
+
+import { getLocale } from '$lib/i18n-paraglide';
+
+/**
+ * Locale-aware date+time formatting. Uses the paraglide-selected locale (not the
+ * browser default), so a Chinese-UI user on an English browser sees Chinese
+ * dates (#168). Falls back to the raw input on parse failure, and to '-' for
+ * empty/null/undefined — matching the per-page `formatTime` helpers this
+ * replaces.
+ */
+export function formatDateTime(iso: string | number | Date | null | undefined): string {
+	if (iso == null || iso === '') return '-';
+	try {
+		// `as any` because TS's lib.dom DateLocaleOptions typing varies across
+		// versions; the runtime accepts the standard options object.
+		const locale = getLocale();
+		return new Date(iso).toLocaleString(locale === 'zh' ? 'zh-CN' : 'en-US');
+	} catch {
+		return String(iso);
+	}
+}
+
+/**
+ * Locale-aware time-only formatting (no date). Same locale behaviour as
+ * formatDateTime; used by dashboard widgets that show just the clock time.
+ */
+export function formatTime(iso: string | number | Date | null | undefined): string {
+	if (iso == null || iso === '') return '-';
+	try {
+		const locale = getLocale();
+		return new Date(iso).toLocaleTimeString(locale === 'zh' ? 'zh-CN' : 'en-US');
+	} catch {
+		return String(iso);
+	}
+}

--- a/web/src/lib/utils/index.ts
+++ b/web/src/lib/utils/index.ts
@@ -12,6 +12,7 @@
 export { getErrorMessage } from './error.js';
 export { html } from './html.js';
 export type { HtmlString } from './html.js';
+export { formatDateTime, formatTime } from './format.js';
 
 /** escapeHtml escapes a string for safe interpolation into an HTML context
  *  (element text or a single- or double-quoted attribute value). DataTable

--- a/web/src/routes/agents/+page.svelte
+++ b/web/src/routes/agents/+page.svelte
@@ -14,7 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount, onDestroy } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { html } from '$lib/utils/index';
+	import { html, formatDateTime as formatTime } from '$lib/utils/index';
 	import { agentTokenSchema, validateField, validateForm } from '$lib/utils/validation';
 	import { addToast } from '$lib/stores/toast';
 
@@ -237,11 +237,6 @@
 	}
 
 	// --- Helpers ---
-	function formatTime(iso?: string | null): string {
-		if (!iso) return '-';
-		try { return new Date(iso).toLocaleString(); } catch { return iso; }
-	}
-
 	function timeAgo(iso?: string | null): string {
 		if (!iso) return '-';
 		try {

--- a/web/src/routes/audit/+page.svelte
+++ b/web/src/routes/audit/+page.svelte
@@ -14,7 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { html } from '$lib/utils/index';
+	import { html, formatDateTime as formatTime } from '$lib/utils/index';
 	import { addToast } from '$lib/stores/toast';
 	import DataTable from '$lib/components/DataTable.svelte';
 	import Pagination from '$lib/components/Pagination.svelte';
@@ -158,15 +158,6 @@
 	function handlePageChange(newOffset: number) {
 		offset = newOffset;
 		fetchAuditLogs();
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
-		}
 	}
 
 	// Pretty-print the details JSON (audit events record structured detail

--- a/web/src/routes/changes/+page.svelte
+++ b/web/src/routes/changes/+page.svelte
@@ -14,7 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount, onDestroy } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { html } from '$lib/utils/index';
+	import { html, formatDateTime as formatTime } from '$lib/utils/index';
 	import { addToast } from '$lib/stores/toast';
 	import DataTable from '$lib/components/DataTable.svelte';
 	import Pagination from '$lib/components/Pagination.svelte';
@@ -165,15 +165,6 @@
 	function handlePageChange(newOffset: number) {
 		offset = newOffset;
 		fetchChanges();
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
-		}
 	}
 
 	// changeTypeLabel returns the localized label for a change type, falling

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -24,6 +24,7 @@
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { scanRunStatusBadge } from '$lib/utils/badges';
+	import { formatTime } from '$lib/utils/index';
 	import { auth } from '$lib/stores/auth';
 	import type { EChartsOption } from '$lib/charts/echarts';
 	import type { DashboardWidgetConfig } from '$lib/types';
@@ -383,7 +384,7 @@
 			};
 		}
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const times = result.values.map((v: any) => new Date(v[0] * 1000).toLocaleTimeString());
+		const times = result.values.map((v: any) => formatTime(v[0] * 1000));
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const values = result.values.map((v: any) => parseFloat(v[1]));
 		return {
@@ -743,7 +744,7 @@
 			<h2 class="text-2xl font-bold text-primary">{m["dashboard.Dashboard"]()}</h2>
 			{#if lastUpdated}
 				<span class="text-xs text-muted whitespace-nowrap">
-					{lastUpdated.toLocaleTimeString()}
+					{formatTime(lastUpdated)}
 				</span>
 			{/if}
 			{#if useCustomLayout}

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -15,7 +15,7 @@
 	import { goto } from '$app/navigation';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { escapeHtml, escapeAttr } from '$lib/utils';
+	import { escapeHtml, escapeAttr, formatDateTime } from '$lib/utils';
 	import { isValidIP } from '$lib/utils/validation';
 	import type { Device, LinkedDoc, Network } from '$lib/types';
 	import { ChevronDown, ChevronRight, Download, Upload, Plus, List, Share2 } from '@lucide/svelte';
@@ -719,7 +719,7 @@ interface AddDevicesResponse {
 				return row.network_name ? escapeHtml(String(row.network_name)) : '-';
 			case 'last_scanned_at': {
 				const t = (sa?.last_scanned_at as string) || row.last_scanned_at;
-				return t ? escapeHtml(new Date(String(t)).toLocaleString()) : '-';
+				return escapeHtml(formatDateTime(t));
 			}
 			case 'last_scan_rtt_ms': {
 				const rtt = (sa?.last_scan_rtt_ms as number) ?? row.last_scan_rtt_ms;
@@ -1257,7 +1257,7 @@ interface AddDevicesResponse {
 						{#if (sa?.last_scanned_at || device.last_scanned_at)}
 							<summary class="flex flex-col gap-0.5 min-w-0">
 								<span class="text-muted">{m['devices.Last Scanned']()}</span>
-								<span class="text-text truncate">{new Date(String(sa?.last_scanned_at || device.last_scanned_at)).toLocaleString()}</span>
+								<span class="text-text truncate">{formatDateTime(sa?.last_scanned_at || device.last_scanned_at)}</span>
 							</summary>
 						{/if}
 					</div>

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -17,6 +17,7 @@
 	import { addToast } from '$lib/stores/toast';
 	import { auth } from '$lib/stores/auth';
 	import { getErrorMessage } from '$lib/utils/error';
+	import { formatDateTime as formatTimestamp } from '$lib/utils/index';
 	import type { Device, System, DeviceNeighbor, TLSPortCerts } from '$lib/types';
 	import type { EChartsOption } from '$lib/charts/echarts';
 	import { certStatus } from '$lib/utils/certs';
@@ -171,12 +172,6 @@
 		} finally {
 			userAttrSaving = false;
 		}
-	}
-
-	function formatTimestamp(iso: string | null | undefined): string {
-		if (!iso) return '-';
-		try { return new Date(iso).toLocaleString(); }
-			catch { return iso; }
 	}
 
 	// Silent-device retention thresholds (must mirror retention.silent_device_*
@@ -724,7 +719,7 @@
 				formatter(params: unknown) {
 					const items = params as Array<{ seriesName: string; data: [string, number]; color: string }>;
 					if (!Array.isArray(items) || items.length === 0) return '';
-					const time = new Date(items[0].data[0]).toLocaleString();
+					const time = formatTimestamp(items[0].data[0]);
 					let html = `<div style="margin-bottom:4px;font-weight:600">${time}</div>`;
 					for (const item of items) {
 						if (item.data[1] !== undefined) {
@@ -1327,7 +1322,7 @@
 									</td>
 									<td class="px-3 py-2 font-mono text-xs text-text">{nb.local_port ?? '-'}</td>
 									<td class="px-3 py-2 font-mono text-xs text-text">{nb.remote_port ?? '-'}</td>
-									<td class="px-3 py-2 text-xs text-text-muted">{nb.last_seen ? new Date(nb.last_seen).toLocaleString() : '-'}</td>
+									<td class="px-3 py-2 text-xs text-text-muted">{formatTimestamp(nb.last_seen)}</td>
 								</tr>
 							{/each}
 						</tbody>

--- a/web/src/routes/devices/discovery/+page.svelte
+++ b/web/src/routes/devices/discovery/+page.svelte
@@ -17,6 +17,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { discoveryOutcomeBadge, onOffBadge } from '$lib/utils/badges';
+	import { formatDateTime as formatTime } from '$lib/utils/index';
 	import PageSkeleton from '$lib/components/PageSkeleton.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { Radar as RadarIcon } from '@lucide/svelte';
@@ -69,11 +70,6 @@
 			? Math.min(BASE_POLL_MS * Math.pow(2, consecutiveErrors), MAX_POLL_MS)
 			: BASE_POLL_MS;
 		pollTimer = setTimeout(fetchStatus, delay);
-	}
-
-	function formatTime(iso?: string): string {
-		if (!iso) return '-';
-		try { return new Date(iso).toLocaleString(); } catch { return iso; }
 	}
 
 	let stats = $derived(status?.stats ?? {});

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -15,6 +15,7 @@
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { scanRunStatusBadge } from '$lib/utils/badges';
+	import { formatDateTime as formatTime } from '$lib/utils/index';
 	import { goto } from '$app/navigation';
 
 	import Pagination from '$lib/components/Pagination.svelte';
@@ -284,15 +285,6 @@
 	function formatDuration(ms: number): string {
 		if (ms < 1000) return `${ms}ms`;
 		return `${(ms / 1000).toFixed(1)}s`;
-	}
-
-	function formatTime(iso: string | null | undefined): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
-		}
 	}
 
 	function formatBytes(bytes: number): string {

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -14,7 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { html } from '$lib/utils/index';
+	import { html, formatDateTime as formatTime } from '$lib/utils/index';
 	import { channelTypeBadge } from '$lib/utils/badges';
 	import { notificationChannelSchema, notificationRuleSchema, validateField, validateForm } from '$lib/utils/validation';
 	import { addToast } from '$lib/stores/toast';
@@ -282,15 +282,6 @@
 			fetchChannels();
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));
-		}
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
 		}
 	}
 

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -14,7 +14,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { onMount } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
-	import { html } from '$lib/utils/index';
+	import { html, formatDateTime as formatTime } from '$lib/utils/index';
 	import { addToast } from '$lib/stores/toast';
 	import { userSchema, resetPasswordSchema, validateField, validateForm } from '$lib/utils/validation';
 
@@ -239,15 +239,6 @@
 			addToast('error', getErrorMessage(err));
 		} finally {
 			resetLoading = false;
-		}
-	}
-
-	function formatTime(iso: string): string {
-		if (!iso) return '-';
-		try {
-			return new Date(iso).toLocaleString();
-		} catch {
-			return iso;
 		}
 	}
 


### PR DESCRIPTION
## 问题

每处 \`toLocaleString()\` 都用裸调用(无 locale 参数),依赖浏览器默认 locale,不跟随 paraglide 选的语言。中文 UI + 英文浏览器 → 日期仍渲染英文格式。

> Closes #168

## 改动

- 新增 \`web/src/lib/utils/format.ts\`:共享 \`formatDateTime\` / \`formatTime\`,内部用 \`getLocale()\` 映射 \`zh-CN\` / \`en-US\`(从 \$lib/utils barrel 导出)
- 替换 **10 个文件**里重复的本地 \`formatTime\` / \`formatTimestamp\` 定义(用 alias import 保持调用点不变)
- 替换 **6 处**裸 \`toLocaleString()\` / \`toLocaleTimeString()\` 调用(devices/detail/dashboard 等)
- 净减 ~30 行(消除重复定义)

## 验证
- \`npm test\` 191 passed;\`npm run build\` 通过
- **浏览器实测(192.168.63.101)**:changes 页日期
  - 中文 locale → \`2026/8/10 18:39:01\`(zh-CN)✅
  - 切英文 → \`8/10/2026, 6:39:01 PM\`(en-US)✅

## 未做(follow-up)
issue 顺带提到的残留硬编码(TOTP alt 文本 / LabelEditor placeholder / WidgetPicker placeholder / agents Token label / scan-tasks Disable fallback)是 alt/placeholder 文本,不影响功能,留作单独 i18n 清理。en/zh catalog 已完美平价(0 缺失 key)。