### PR TITLE
fix(api): credential.go 不再泄露内部错误 + http.Error 改 JSON + sentinel 错误 (#164)

### DIFF
--- a/internal/api/handler/credential.go
+++ b/internal/api/handler/credential.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -96,7 +97,8 @@ func (h *CredentialHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	authEnc, privEnc, err := h.encryptPassphrases(&req, "", "")
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "encrypt passphrases: "+err.Error())
+		slog.Error("encrypt passphrases", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to encrypt passphrases")
 		return
 	}
 
@@ -117,13 +119,15 @@ func (h *CredentialHandler) Create(w http.ResponseWriter, r *http.Request) {
 			Error(w, http.StatusConflict, "a credential with this name already exists")
 			return
 		}
-		Error(w, http.StatusInternalServerError, "create credential: "+err.Error())
+		slog.Error("create credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to create credential")
 		return
 	}
 	// Re-fetch to populate timestamps for the response.
 	row, err := credresolver.GetSNMPCredential(r.Context(), h.db, id)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "fetch created credential: "+err.Error())
+		slog.Error("fetch created credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to fetch created credential")
 		return
 	}
 	Created(w, toCredentialResponse(row))
@@ -134,7 +138,8 @@ func (h *CredentialHandler) List(w http.ResponseWriter, r *http.Request) {
 	limit, offset := parseListPaging(r)
 	rows, err := credresolver.ListSNMPCredentials(r.Context(), h.db, limit, offset)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "list credentials: "+err.Error())
+		slog.Error("list credentials", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to list credentials")
 		return
 	}
 	out := make([]snmpCredentialResponse, 0, len(rows))
@@ -157,7 +162,8 @@ func (h *CredentialHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "fetch credential: "+err.Error())
+		slog.Error("fetch credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to fetch credential")
 		return
 	}
 	Success(w, toCredentialResponse(row))
@@ -194,12 +200,14 @@ func (h *CredentialHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "fetch existing credential: "+err.Error())
+		slog.Error("fetch credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to fetch credential")
 		return
 	}
 	authEnc, privEnc, err := h.encryptPassphrases(&req, existing.AuthPassphraseEnc, existing.PrivPassphraseEnc)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "encrypt passphrases: "+err.Error())
+		slog.Error("encrypt passphrases", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to encrypt passphrases")
 		return
 	}
 
@@ -218,7 +226,8 @@ func (h *CredentialHandler) Update(w http.ResponseWriter, r *http.Request) {
 			Error(w, http.StatusConflict, "a credential with this name already exists")
 			return
 		}
-		Error(w, http.StatusInternalServerError, "update credential: "+err.Error())
+		slog.Error("update credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to update credential")
 		return
 	}
 	// Invalidate the resolver cache so the next scan sees the new values
@@ -229,7 +238,8 @@ func (h *CredentialHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Re-fetch for the response.
 	row, err := credresolver.GetSNMPCredential(r.Context(), h.db, id)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "fetch updated credential: "+err.Error())
+		slog.Error("fetch updated credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to fetch updated credential")
 		return
 	}
 	Success(w, toCredentialResponse(row))
@@ -243,7 +253,8 @@ func (h *CredentialHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	affected, err := credresolver.DeleteSNMPCredential(r.Context(), h.db, id)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "delete credential: "+err.Error())
+		slog.Error("delete credential", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to delete credential")
 		return
 	}
 	if affected == 0 {

--- a/internal/api/handler/discovery.go
+++ b/internal/api/handler/discovery.go
@@ -30,7 +30,7 @@ func DiscoveryStatusHandler(svc *scannerv2discovery.Service) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			// Non-fatal: the client either gets partial JSON or an empty body.
-			http.Error(w, "failed to encode discovery status", http.StatusInternalServerError)
+			Error(w, http.StatusInternalServerError, "failed to encode discovery status")
 		}
 	}
 }

--- a/internal/api/handler/export.go
+++ b/internal/api/handler/export.go
@@ -49,7 +49,7 @@ func (h *ExportHandler) ExportDevices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.svc.Devices(r.Context(), format, w); err != nil {
-		http.Error(w, "export failed", http.StatusInternalServerError)
+		Error(w, http.StatusInternalServerError, "export failed")
 	}
 }
 
@@ -81,7 +81,7 @@ func (h *ExportHandler) ExportHeartbeatResults(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := h.svc.HeartbeatResults(r.Context(), id, format, w); err != nil {
-		http.Error(w, "export failed", http.StatusInternalServerError)
+		Error(w, http.StatusInternalServerError, "export failed")
 	}
 }
 
@@ -106,7 +106,7 @@ func (h *ExportHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.svc.AuditLogs(r.Context(), format, w); err != nil {
-		http.Error(w, "export failed", http.StatusInternalServerError)
+		Error(w, http.StatusInternalServerError, "export failed")
 	}
 }
 

--- a/internal/api/handler/scanner.go
+++ b/internal/api/handler/scanner.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"mibee-steward/internal/domain"
@@ -69,7 +68,7 @@ func (h *ScannerHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	// (POST /scanner/tasks + /scanner/tasks/{id}/trigger + GET .../runs).
 	count, err := h.engine.EstimateTargetCount(req.Targets)
 	if err != nil {
-		if isInvalidTargetError(err.Error()) {
+		if isTargetError(err) {
 			Error(w, http.StatusBadRequest, "invalid IP address or CIDR range")
 			return
 		}
@@ -96,7 +95,7 @@ func (h *ScannerHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	reports, err := h.engine.ScanTargets(r.Context(), req.Targets, false, req.CredentialID)
 	duration := time.Since(start)
 	if err != nil {
-		if isInvalidTargetError(err.Error()) {
+		if isTargetError(err) {
 			Error(w, http.StatusBadRequest, "invalid IP address or CIDR range")
 			return
 		}
@@ -176,19 +175,23 @@ func (h *ScannerHandler) AddDevices(w http.ResponseWriter, r *http.Request) {
 	Success(w, resp)
 }
 
-// isInvalidTargetError recognizes target-parse failures from the engine so the
-// handler can map them to HTTP 400.
-func isInvalidTargetError(errMsg string) bool {
-	if errMsg == "" {
+// isTargetError reports whether err wraps one of the engine's target-parsing
+// sentinel errors (engine.ErrInvalidTarget, ErrInvalidIPRange, etc.). Such
+// errors are user-supplied-bad-targets and map to HTTP 400; everything else is
+// an internal/scan failure. Uses errors.Is rather than string matching so
+// wrapped sentinels are recognized regardless of detail text.
+func isTargetError(err error) bool {
+	switch {
+	case errors.Is(err, engine.ErrEmptyTargets),
+		errors.Is(err, engine.ErrNoValidTargets),
+		errors.Is(err, engine.ErrInvalidTarget),
+		errors.Is(err, engine.ErrInvalidIPRange),
+		errors.Is(err, engine.ErrIPv6RangeUnsupported),
+		errors.Is(err, engine.ErrTargetRangeTooLarge):
+		return true
+	default:
 		return false
 	}
-	lower := strings.ToLower(errMsg)
-	for _, frag := range []string{"invalid target", "no targets", "invalid ip", "invalid cidr", "invalid ip range", "invalid targets format", "invalid end ip", "invalid start ip"} {
-		if strings.Contains(lower, frag) {
-			return true
-		}
-	}
-	return false
 }
 
 // reportToHost converts a v2 HostReport into the API's domain.ScanHost,

--- a/internal/api/handler/scanner_test.go
+++ b/internal/api/handler/scanner_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"mibee-steward/internal/service/scannerv2/engine"
+)
+
+// TestIsTargetError verifies the handler's isTargetError classifier recognizes
+// every engine target-parse sentinel (even when wrapped with extra detail via
+// fmt.Errorf("%w")) and rejects unrelated errors. This is the behavior the
+// /scanner/scan + /scanner/scan (ScanTargets) error paths rely on to map
+// bad-target errors to HTTP 400 rather than 500.
+func TestIsTargetError(t *testing.T) {
+	targetSentinels := []error{
+		engine.ErrEmptyTargets,
+		engine.ErrNoValidTargets,
+		engine.ErrInvalidTarget,
+		engine.ErrInvalidIPRange,
+		engine.ErrIPv6RangeUnsupported,
+		engine.ErrTargetRangeTooLarge,
+	}
+	for _, sentinel := range targetSentinels {
+		// Direct sentinel.
+		if !isTargetError(sentinel) {
+			t.Errorf("isTargetError(%v) = false, want true for direct sentinel", sentinel)
+		}
+		// Wrapped sentinel with detail text — must still match via errors.Is.
+		wrapped := fmt.Errorf("%w: some detail", sentinel)
+		if !isTargetError(wrapped) {
+			t.Errorf("isTargetError(wrapped %v) = false, want true", sentinel)
+		}
+		// errors.Is itself must resolve the wrap (sanity check of the %w wrapping).
+		if !errors.Is(wrapped, sentinel) {
+			t.Errorf("errors.Is(wrapped, %v) = false, want true (bad %%w wrap?)", sentinel)
+		}
+	}
+
+	// Unrelated errors must NOT classify as target errors — otherwise a real
+	// internal failure would be masked as a 400 "bad targets".
+	if isTargetError(errors.New("scan failed: timeout")) {
+		t.Errorf("isTargetError(generic error) = true, want false")
+	}
+	if isTargetError(nil) {
+		t.Errorf("isTargetError(nil) = true, want false")
+	}
+}

--- a/internal/api/handler/sd.go
+++ b/internal/api/handler/sd.go
@@ -78,7 +78,7 @@ func (h *SDHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Offset:  0,
 	})
 	if err != nil {
-		http.Error(w, "failed to list devices", http.StatusInternalServerError)
+		Error(w, http.StatusInternalServerError, "failed to list devices")
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *SDHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(targets); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		Error(w, http.StatusInternalServerError, "failed to encode response")
 		return
 	}
 }

--- a/internal/service/scannerv2/engine/targets.go
+++ b/internal/service/scannerv2/engine/targets.go
@@ -10,10 +10,23 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
+)
+
+// Sentinel errors for target parsing. Callers (e.g. the scanner handler) use
+// errors.Is against these to distinguish user-supplied-bad-targets (HTTP 400)
+// from internal failures, rather than brittle string matching on error text.
+var (
+	ErrEmptyTargets         = errors.New("targets is empty")
+	ErrNoValidTargets       = errors.New("no valid targets")
+	ErrInvalidTarget        = errors.New("invalid target")
+	ErrInvalidIPRange       = errors.New("invalid IP range")
+	ErrIPv6RangeUnsupported = errors.New("IPv6 ranges unsupported")
+	ErrTargetRangeTooLarge  = errors.New("target range too large")
 )
 
 // ParseScanTargets is the exported form of parseScanTargets, exposed so other
@@ -37,7 +50,7 @@ func ParseScanTargets(targets string) ([]string, error) {
 func parseScanTargets(targets string) ([]string, error) {
 	targets = strings.TrimSpace(targets)
 	if targets == "" {
-		return nil, fmt.Errorf("targets is empty")
+		return nil, ErrEmptyTargets
 	}
 
 	// Comma-separated list of any of the above.
@@ -55,7 +68,7 @@ func parseScanTargets(targets string) ([]string, error) {
 			ips = append(ips, expanded...)
 		}
 		if len(ips) == 0 {
-			return nil, fmt.Errorf("no valid targets")
+			return nil, ErrNoValidTargets
 		}
 		return ips, nil
 	}
@@ -76,7 +89,7 @@ func parseSingleTarget(t string) ([]string, error) {
 	if strings.Contains(t, "-") {
 		return parseIPRange(t)
 	}
-	return nil, fmt.Errorf("invalid target: %s", t)
+	return nil, fmt.Errorf("%w: %s", ErrInvalidTarget, t)
 }
 
 func enumerateCIDR(ipNet *net.IPNet) []string {
@@ -94,17 +107,17 @@ func enumerateCIDR(ipNet *net.IPNet) []string {
 func parseIPRange(s string) ([]string, error) {
 	parts := strings.SplitN(s, "-", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid IP range: %s", s)
+		return nil, fmt.Errorf("%w: %s", ErrInvalidIPRange, s)
 	}
 	startStr := strings.TrimSpace(parts[0])
 	endStr := strings.TrimSpace(parts[1])
 	startIP := net.ParseIP(startStr)
 	if startIP == nil {
-		return nil, fmt.Errorf("invalid range start: %s", startStr)
+		return nil, fmt.Errorf("%w: invalid range start %s", ErrInvalidIPRange, startStr)
 	}
 	start4 := startIP.To4()
 	if start4 == nil {
-		return nil, fmt.Errorf("IPv6 ranges unsupported: %s", s)
+		return nil, fmt.Errorf("%w: %s", ErrIPv6RangeUnsupported, s)
 	}
 
 	var end4 net.IP
@@ -115,13 +128,13 @@ func parseIPRange(s string) ([]string, error) {
 		// Suffix range: "192.168.1.1-10" → replace last octet.
 		n, err := strconv.Atoi(endStr)
 		if err != nil || n < 0 || n > 255 {
-			return nil, fmt.Errorf("invalid range end: %s", endStr)
+			return nil, fmt.Errorf("%w: invalid range end %s", ErrInvalidIPRange, endStr)
 		}
 		end4 = append(net.IP{}, start4...)
 		end4[3] = byte(n)
 	}
 	if end4 == nil {
-		return nil, fmt.Errorf("invalid range end: %s", endStr)
+		return nil, fmt.Errorf("%w: invalid range end %s", ErrInvalidIPRange, endStr)
 	}
 
 	// Ensure start <= end by comparing the full 32-bit value. The previous code
@@ -143,7 +156,7 @@ func parseIPRange(s string) ([]string, error) {
 	const maxRangeIPs = 65536
 	count := int(endU-startU) + 1
 	if count > maxRangeIPs {
-		return nil, fmt.Errorf("range too large: %d IPs (max %d); use a CIDR with the async task API", count, maxRangeIPs)
+		return nil, fmt.Errorf("%w: %d IPs (max %d); use a CIDR with the async task API", ErrTargetRangeTooLarge, count, maxRangeIPs)
 	}
 
 	ips := make([]string, 0, count)


### PR DESCRIPTION
## 问题
1. credential.go 10 处把内部错误(\`err.Error()\`)拼进 HTTP body → 泄露 SQL 错误/加密细节给客户端
2. export/sd/discovery 6 处用 \`http.Error()\`(text/plain)而非 \`Error()\` helper → 破坏 API JSON 一致性
3. scanner.go \`isInvalidTargetError\` 用 \`strings.Contains\` 字符串匹配 engine 错误 → 措辞改动会静默误判

> Closes #164

## 改动
- **credential.go**:10 处 500 错误改为 generic 消息(\`failed to create credential\` 等),内部错误只进 \`slog.Error\`(加 \`log/slog\` import)。validation 的 400 + UNIQUE 409 保留(用户友好)
- **export.go / sd.go / discovery.go**:6 处 \`http.Error(w, msg, 500)\` → \`Error(w, http.StatusInternalServerError, msg)\`(JSON 一致)
- **engine/targets.go**:加 6 个 sentinel(\`ErrInvalidTarget\` / \`ErrEmptyTargets\` / \`ErrNoValidTargets\` / \`ErrInvalidIPRange\` / \`ErrIPv6RangeUnsupported\` / \`ErrTargetRangeTooLarge\`),用 \`%w\` 包装
- **scanner.go**:\`isInvalidTargetError(err.Error())\` 字符串匹配 → \`isTargetError(err)\` 用 \`errors.Is\` 检查 sentinel;删 \`strings\` import
- **scanner_test.go**(新):覆盖 sentinel 分类(包装/直接/nil/generic)

## 验证
- \`go build ./...\` / \`go test ./...\`(含 race)/ \`gofmt -l\` / \`go vet\` 全绿
- \`go test ./internal/api/handler/ ./internal/service/scannerv2/engine/\` 通过(含新测试)