### PR TITLE
feat(web): 扫描页加 cancel 机制 — AbortController 中断长扫描 (#153)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -59,6 +59,15 @@ export class ApiError extends Error {
 	}
 }
 
+/** Thrown when a request is aborted by the caller (user cancel), distinct
+ *  from a timeout or network failure so callers can skip the error toast. */
+export class RequestCancelledError extends Error {
+	constructor() {
+		super('request cancelled');
+		this.name = 'RequestCancelledError';
+	}
+}
+
 /**
  * Shared 401 handling: logs the user out, redirects to /login, and returns a
  * SessionExpiredError for the caller to throw (request/download) or reject
@@ -104,13 +113,35 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	let lastError: unknown;
 
 	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		// Combine the caller's abort signal (user cancel) with a 30s timeout into
+		// a single controller. Manual combiner instead of AbortSignal.any() — the
+		// build target is es2020 and the repo has no prior usage of .any(), so a
+		// listener-based merge is the safe, dependency-free path (#153).
+		const ctrl = new AbortController();
+		const timer = setTimeout(
+			() => ctrl.abort(new DOMException('request timeout', 'TimeoutError')),
+			30000
+		);
+		const callerSignal = options?.signal;
+		const onCallerAbort = () => ctrl.abort(callerSignal?.reason);
+		if (callerSignal) {
+			if (callerSignal.aborted) {
+				ctrl.abort(callerSignal.reason);
+			} else {
+				callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+			}
+		}
 		try {
 			const res = await fetch(`${API_BASE}${path}`, {
 				...options,
-				signal: AbortSignal.timeout(30000),
+				signal: ctrl.signal,
 				credentials: 'include',
 				headers: { ...headers, ...(options?.headers as Record<string, string>) }
 			});
+			// A cancel that races with the response arriving: the server may have
+			// already written a (likely 500, context-cancelled) status, but the user
+			// cancelled — treat it as a cancel, not an error (#153).
+			if (callerSignal?.aborted) throw new RequestCancelledError();
 			if (res.status === 401) {
 				throw handleUnauthorized();
 			}
@@ -128,16 +159,23 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 			if (res.status === 204) return undefined as T;
 			return res.json();
 		} catch (err: unknown) {
+			// A user-triggered cancel (caller's signal aborted with AbortError)
+			// must propagate as a distinct, non-retryable error so callers can
+			// skip the error toast (#153). Timeout / network errors wrap as before.
+			if (callerSignal?.aborted) {
+				throw new RequestCancelledError();
+			}
 			// Typed errors we created (SessionExpiredError / ApiError) propagate
 			// as-is. A retryable ApiError (5xx GET) was already handled above
 			// via `continue`; if it reaches here the retry budget is exhausted.
 			if (err instanceof SessionExpiredError) throw err;
 			if (err instanceof ApiError) throw err;
 			// Anything else is a network/abort/parse failure. Distinguish:
-			//  - AbortError (timeout/explicit cancel): never retry, surface now.
+			//  - AbortError (timeout): never retry, surface now.
 			//  - network TypeError on a GET: retry, then surface if exhausted.
+			const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
 			const isAbort = err instanceof DOMException && err.name === 'AbortError';
-			if (canRetry && !isAbort && attempt < MAX_RETRIES) {
+			if (canRetry && !isAbort && !isTimeout && attempt < MAX_RETRIES) {
 				lastError = err;
 				await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
 				continue;
@@ -145,6 +183,9 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 			// Wrap the genuine network/abort/parse error (no HTTP status) into a
 			// plain Error. Callers distinguish it from ApiError via instanceof.
 			throw new Error(getErrorMessage(err));
+		} finally {
+			clearTimeout(timer);
+			callerSignal?.removeEventListener('abort', onCallerAbort);
 		}
 	}
 	// Retry budget exhausted — surface the last error.
@@ -155,8 +196,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 export const api = {
 	get: <T>(path: string) => request<T>(path),
-	post: <T>(path: string, body: unknown) =>
-		request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+	post: <T>(path: string, body: unknown, signal?: AbortSignal) =>
+		request<T>(path, { method: 'POST', body: JSON.stringify(body), signal }),
 	put: <T>(path: string, body: unknown) =>
 		request<T>(path, { method: 'PUT', body: JSON.stringify(body) }),
 	patch: <T>(path: string, body: unknown) =>

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -9,7 +9,7 @@
 -->
 
 <script lang="ts">
-	import { api } from '$lib/api/client';
+	import { api, RequestCancelledError } from '$lib/api/client';
 	import { m } from '$lib/i18n-paraglide';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
@@ -17,7 +17,7 @@
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import Pagination from '$lib/components/Pagination.svelte';
-	import { LoaderCircle, Radar } from '@lucide/svelte';
+	import { LoaderCircle, Radar, CircleStop } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 
 	// All 9 device types matching internal/domain/device.go
@@ -73,6 +73,10 @@
 
 	// Results state
 	let scanning = $state(false);
+	// AbortController for the in-flight scan request — lets the user cancel a
+	// long scan. The backend honors request-context cancellation (ScanTargets
+	// listens on ctx.Done), so aborting here actually stops the server scan.
+	let scanController: AbortController | null = null;
 	let result = $state<ScanResponse | null>(null);
 	// Inline error for a failed whole-scan run. Previously a scan failure only
 	// surfaced as a corner toast and the result pane stayed silently empty —
@@ -135,6 +139,7 @@
 		}
 
 		scanning = true;
+		scanController = new AbortController();
 		result = null;
 		scanError = '';
 		selectedIps = new Set();
@@ -153,7 +158,7 @@
 				community: community || 'public',
 				timeout: timeout || 2,
 				credential_id: selectedCredentialId ?? undefined
-			});
+			}, scanController?.signal);
 			result = res;
 
 			// Initialize form fields for alive hosts, pre-fill from enriched data
@@ -201,13 +206,26 @@
 
 			addToast('success', m['scanner.Scan Complete']());
 		} catch (err) {
+			// User-triggered cancel: the toast was already shown by cancelScan;
+			// don't also surface a generic error banner.
+			if (err instanceof RequestCancelledError) return;
 			// Inline banner so the user sees the failure in context (not just a
 			// corner toast) — the result pane stays empty otherwise.
 			scanError = getErrorMessage(err);
 			addToast('error', scanError);
 		} finally {
 			scanning = false;
+			scanController = null;
 		}
+	}
+
+	// Abort the in-flight scan. The backend honors request-context cancellation,
+	// so the server actually stops probing (#153).
+	function cancelScan() {
+		if (!scanController) return;
+		scanController.abort();
+		scanController = null;
+		addToast('info', m['scanner.Scan Cancelled']());
 	}
 
 	function toggleSelect(ip: string) {
@@ -359,6 +377,16 @@
 					{m['scanner.Start Scan']()}
 				{/if}
 			</button>
+			{#if scanning}
+				<button
+					onclick={cancelScan}
+					class="btn btn-danger"
+					title={m['common.Cancel']()}
+				>
+					<CircleStop class="w-4 h-4" />
+					{m['common.Cancel']()}
+				</button>
+			{/if}
 		</div>
 	</div>
 


### PR DESCRIPTION
## 问题
scanner 页扫描启动后只有 spinner,无法取消。大子网(如 /16)扫描数分钟,用户只能等。

> Closes #153

## 改动
- **API client**(\`client.ts\`):\`request()\` 用手动 combiner 组合外部 signal(用户 cancel)+ 30s timeout(es2020 target,避免 \`AbortSignal.any\` 兼容性);\`post()\` 加可选 \`signal\` 参数;新增 \`RequestCancelledError\` 区分 user-cancel vs timeout/error
- **scanner 页**:启动扫描建 \`AbortController\` 传 \`api.post\`;Cancel 按钮(扫描中显示,btn-danger)调 \`abort()\` + toast \`scanner.Scan Cancelled\`;catch 块遇 \`RequestCancelledError\` 跳过 error toast
- **race fix**:cancel 与 500 响应竞争时,若 \`callerSignal\` 已 aborted 即使收到响应也当 cancel(handler ctx cancelled 后返回 500,不显示 error banner)

## 后端
\`/scanner/scan\` handler 用 \`r.Context()\`(scanner.go:95)→ \`ScanTargets\` 监听 \`ctx.Done()\`(engine.go:381/412)→ orchestrator 全链路传 ctx。**abort 真正停止服务端扫描**(Go HTTP server 连接断开时取消 request context)。

## 验证
- \`npm test\` 191 passed;\`npm run build\` 通过
- **浏览器实测(192.168.63.101)**:扫描 192.168.63.0/24 → 点 Cancel → toast「扫描已取消」+ 无 error banner + UI 回 ready 态 + 服务端日志显示 ctx cancelled(扫描 9.6s 后中断,status 500)