### PR TITLE
fix(web): login 2FA — 去除 as any + 强制改密弹窗 (#155 #156)

### DIFF
--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -65,10 +65,11 @@
 			const res = await api.post<LoginResponse>('/auth/login', { username, password });
 			loginResponse = res;
 
-			// Check if 2FA is required
-			if ((res as any).two_factor_required) {
+			// Check if 2FA is required. LoginResponse models these fields
+			// (two_factor_required / user_id) directly — no `as any` needed.
+			if (res.two_factor_required) {
 				twoFactorRequired = true;
-				twoFactorUserId = (res as any).user_id ?? null;
+				twoFactorUserId = res.user_id ?? null;
 				return; // Don't navigate yet
 			}
 
@@ -135,12 +136,24 @@
 		if (!twoFactorCode || twoFactorCode.length !== 6) return;
 		twoFactorLoading = true;
 		try {
-			const res = await api.post<{ token: string; user: { username: string; role: string; must_change_password: boolean } }>('/auth/2fa/verify', {
+			// The verify endpoint returns the same LoginResponse shape as
+			// /auth/login (Token + full User, including must_change_password).
+			const res = await api.post<LoginResponse>('/auth/2fa/verify', {
 				user_id: twoFactorUserId,
 				code: twoFactorCode
 			});
+			loginResponse = res;
 			auth.login(res.user, res.token);
-			goto(res.user.must_change_password ? '/settings' : '/dashboard');
+
+			// Keep the user on the login page and show the same focused
+			// force-password-change modal the non-2FA flow uses (#156) —
+			// previously this dumped them onto the generic /settings page.
+			if (res.user.must_change_password) {
+				twoFactorRequired = false;
+				showForceDialog = true;
+			} else {
+				goto('/dashboard');
+			}
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));
 		} finally {


### PR DESCRIPTION
## Summary

修复两个 P2 前端 issue，均在登录/2FA 流程（同一文件 `login/+page.svelte`）：

**#155 — 2FA 流程 `as any` 类型断言**
- `LoginResponse` 类型**已含** `two_factor_required` / `user_id` 字段（types/index.ts:407-408），删除登录检查里冗余的 `(res as any).two_factor_required` / `(res as any).user_id`。
- `/auth/2fa/verify` 响应此前用内联结构体 `{ token; user: { username; role; must_change_password } }` 接收，丢掉了 `id`/`email` 等字段 —— 改用完整 `LoginResponse` 类型（后端 `totp.go:233` 确实返回 `domain.LoginResponse{Token, User}`）。

**#156 — 2FA 后强制改密跳到 /settings**
- 2FA 验证通过且 `must_change_password=true` 时，原先 `goto('/settings')` 把用户丢到通用设置页。
- 改为：留在 login 页 → 关闭 2FA 视图 → 打开与非 2FA 流程**完全一致**的 force-password-change 弹窗（已有的 `showForceDialog` Modal），体验对齐。

## Test
- [x] `npm test` 191 passed
- [x] `npm run build` clean
- [x] `svelte-check` login 页无错误
- [ ] 浏览器实测：2FA + must_change_password 流程 → 弹改密弹窗（部署后补）

Closes #155
Closes #156