### PR TITLE
fix(web): 验证缺口统一 — scan-tasks / agent / login (#154)

### DIFF
--- a/web/src/lib/utils/validation.ts
+++ b/web/src/lib/utils/validation.ts
@@ -131,6 +131,20 @@ export const resetPasswordSchema = z
 		path: ['confirm'],
 	});
 
+// --- Force-password-change form (login page) ---
+// Same policy as resetPasswordSchema (8-char min + match) but standalone so the
+// login flow validates via the shared schema instead of hand-rolled length /
+// mismatch checks (#154 part 3 — keeps the password policy in ONE place).
+export const forcePasswordSchema = z
+	.object({
+		new_password: z.string().min(8, 'validation.Password Min Length'),
+		confirm: z.string().min(1, 'validation.Confirm Password Required'),
+	})
+	.refine((data) => data.new_password === data.confirm, {
+		message: 'validation.Passwords Do Not Match',
+		path: ['confirm'],
+	});
+
 // --- 2FA verify code (login page) ---
 // Exactly 6 digits. Used for the verify hint; the disabled-button gate stays
 // in the markup.
@@ -241,6 +255,7 @@ export type LoginFormData = z.infer<typeof loginSchema>;
 export type SettingsFormData = z.infer<typeof settingsSchema>;
 export type ProfileFormData = z.infer<typeof profileSchema>;
 export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+export type ForcePasswordFormData = z.infer<typeof forcePasswordSchema>;
 export type TwoFactorCodeFormData = z.infer<typeof twoFactorCodeSchema>;
 export type NetworkFormData = z.infer<typeof networkSchema>;
 export type AgentTokenFormData = z.infer<typeof agentTokenSchema>;

--- a/web/src/routes/agents/+page.svelte
+++ b/web/src/routes/agents/+page.svelte
@@ -15,7 +15,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { html, formatDateTime as formatTime } from '$lib/utils/index';
-	import { agentTokenSchema, validateField, validateForm } from '$lib/utils/validation';
+	import { agentTokenSchema, validateField, validateForm, validateScanTarget } from '$lib/utils/validation';
 	import { addToast } from '$lib/stores/toast';
 
 	import Modal from '$lib/components/Modal.svelte';
@@ -75,6 +75,7 @@
 	let scanModalOpen = $state(false);
 	let scanAgentId = $state('');
 	let scanTargets = $state('');
+	let scanTargetsError = $state('');
 	let scanTimeout = $state(120);
 	let scanLoading = $state(false);
 
@@ -213,13 +214,24 @@
 	function openScan(agentId: string) {
 		scanAgentId = agentId;
 		scanTargets = '';
+		scanTargetsError = '';
 		scanTimeout = 120;
 		scanModalOpen = true;
 	}
 
+	// Validate scan targets on blur (same validator the scanner page uses) —
+	// previously this modal only empty-checked at submit, so a user could enter
+	// an over-broad range like 192.168.0.0/16 (65k IPs) with no warning
+	// (#154 part 2).
+	function validateScanTargets() {
+		scanTargetsError = validateScanTarget(scanTargets) ?? '';
+	}
+
 	async function handleScanSubmit(e: Event) {
 		e.preventDefault();
-		if (!scanTargets) { addToast('error', m['agents.Targets Required']()); return; }
+		const targetsErr = validateScanTarget(scanTargets);
+		scanTargetsError = targetsErr ?? '';
+		if (targetsErr) return;
 		scanLoading = true;
 		try {
 			await api.post(`/agents/${scanAgentId}/commands/`, {
@@ -652,7 +664,16 @@
 		<!-- Targets -->
 		<div>
 			<label class="block text-xs text-text-muted mb-1">{m['agents.Scan Targets']()} *</label>
-			<input bind:value={scanTargets} required placeholder={m['agents.Scan Targets Placeholder']()} class="input" />
+			<input
+				bind:value={scanTargets}
+				required
+				placeholder={m['agents.Scan Targets Placeholder']()}
+				onblur={validateScanTargets}
+				class="input {scanTargetsError ? '!border-error' : ''}"
+			/>
+			{#if scanTargetsError}
+				<p class="text-error text-xs mt-1">{scanTargetsError}</p>
+			{/if}
 		</div>
 
 		<!-- Timeout -->

--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -75,8 +75,10 @@
 	let formCommunity = $state('public');
 	let formEnabled = $state(true);
 	let formPipelineConfig = $state<PipelineConfig>(defaultPipeline());
-	let formTargetsError = $state('');
-	let formCronError = $state('');
+	// Unified field-error map for the whole form (targets / cron / name /
+	// timeout all read/write here — #154 part 1). Previously targets + cron
+	// used two dedicated state vars while name + timeout used fieldErrors,
+	// giving three different error-display patterns in one form.
 	let fieldErrors = $state<Record<string, string>>({});
 	// SNMP credential binding (issue #135). null = use the global community.
 	let credentials = $state<Array<{ id: number; name: string; security_level: string }>>([]);
@@ -172,8 +174,7 @@
 		formEnabled = true;
 		formPipelineConfig = defaultPipeline();
 		formError = '';
-		formTargetsError = '';
-		formCronError = '';
+		fieldErrors = {};
 		editingTask = null;
 	}
 
@@ -211,28 +212,33 @@
 
 	function validateTargets(): string | null {
 		const err = validateScanTarget(formTargets);
-		formTargetsError = err || '';
+		fieldErrors = err
+			? { ...fieldErrors, targets: err }
+			: (() => { const { targets: _, ...rest } = fieldErrors; return rest; })();
 		return err;
 	}
 
 	function validateCron(): string | null {
 		const err = validateCronExpr(formCronExpr);
-		formCronError = err || '';
+		fieldErrors = err
+			? { ...fieldErrors, cron: err }
+			: (() => { const { cron: _, ...rest } = fieldErrors; return rest; })();
 		return err;
 	}
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 
-		formTargetsError = '';
-		formCronError = '';
+		fieldErrors = {};
 
 		// Validate targets + cron via the standalone validators (return localized
 		// strings, wired to onblur). Then name + timeout range via scannerTaskSchema.
+		// All four fields now write to the same fieldErrors map (previously
+		// targets/cron used dedicated vars — #154 part 1).
 		const targetsErr = validateTargets();
 		const cronErr = validateCron();
 		const taskValidation = validateForm(scannerTaskSchema, { name: formName, timeout: formTimeout });
-		if (!taskValidation.valid) fieldErrors = taskValidation.errors; else fieldErrors = {};
+		fieldErrors = { ...fieldErrors, ...taskValidation.errors };
 		if (targetsErr || cronErr || !taskValidation.valid) {
 			return;
 		}
@@ -665,11 +671,11 @@
 					placeholder={m['scanner.Targets Placeholder']()}
 					class="w-full px-3 py-2 bg-bg border rounded-lg text-sm text-text font-mono
 					focus:border-primary focus:outline-none
-					{formTargetsError ? 'border-error' : 'border-border'}"
+					{fieldErrors.targets ? 'border-error' : 'border-border'}"
 					onblur={validateTargets}
 				/>
-				{#if formTargetsError}
-					<p class="text-error text-xs mt-1">{formTargetsError}</p>
+				{#if fieldErrors.targets}
+					<p class="text-error text-xs mt-1">{fieldErrors.targets}</p>
 				{/if}
 			</div>
 
@@ -682,11 +688,11 @@
 					placeholder={m['scanner.Cron Placeholder']()}
 					class="w-full px-3 py-2 bg-bg border rounded-lg text-sm text-text font-mono
 					focus:border-primary focus:outline-none
-					{formCronError ? 'border-error' : 'border-border'}"
+					{fieldErrors.cron ? 'border-error' : 'border-border'}"
 					onblur={validateCron}
 				/>
-				{#if formCronError}
-					<p class="text-error text-xs mt-1">{formCronError}</p>
+				{#if fieldErrors.cron}
+					<p class="text-error text-xs mt-1">{fieldErrors.cron}</p>
 				{/if}
 			</div>
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -14,7 +14,7 @@
 	import { auth } from '$lib/stores/auth';
 	import type { LoginResponse } from '$lib/types';
 	import { getErrorMessage } from '$lib/utils/error.js';
-	import { loginSchema } from '$lib/utils/validation.js';
+	import { loginSchema, forcePasswordSchema, validateForm } from '$lib/utils/validation.js';
 	import { goto } from '$app/navigation';
 	import { fly } from 'svelte/transition';
 	import { addToast } from '$lib/stores/toast';
@@ -110,12 +110,18 @@
 		e.preventDefault();
 		forceError = '';
 
-		if (forceNewPassword.length < 8) {
-			forceError = m["auth.password_min_length"]();
-			return;
-		}
-		if (forceNewPassword !== forceConfirmPassword) {
-			forceError = m["auth.passwords_no_match"]();
+		// Validate via the shared forcePasswordSchema (8-char min + match) so the
+		// password policy lives in ONE place (#154 part 3) — previously these
+		// were hand-rolled length / mismatch checks that would silently drift
+		// from the users-page reset-password modal if the policy changed.
+		const validation = validateForm(forcePasswordSchema, {
+			new_password: forceNewPassword,
+			confirm: forceConfirmPassword
+		});
+		if (!validation.valid) {
+			// The schema attaches the error to `confirm` for a mismatch, or to
+			// `new_password` for the length rule — surface the first one.
+			forceError = validation.errors.new_password ?? validation.errors.confirm ?? '';
 			return;
 		}
 


### PR DESCRIPTION
## Summary

修复 P2 issue #154 的三处表单验证不一致：

**Part 1 — scan-tasks 表单三种错误显示模式**
- `devices/scan-tasks/+page.svelte`：targets/cron 用专用变量 `formTargetsError`/`formCronError`，name/timeout 用 `fieldErrors` map —— 同一表单三套显示。
- 统一进 `fieldErrors` map（`fieldErrors.targets`/`fieldErrors.cron`），保留 `validateScanTarget`/`validateCronExpr` 独立校验器（返回本地化串、多 IP/cron 逻辑无法用单个 zod 表达）。
- **顺带修 bug**：`handleSubmit` 里 `fieldErrors = taskValidation.errors` 直接覆盖了 `validateTargets()`/`validateCron()` 刚写入的 targets/cron 错误 → 改为 spread 合并。

**Part 2 — agent 扫描触发 modal 无 target 校验**
- `agents/+page.svelte` 的 scan targets 输入此前只有 submit 时空检查，用户能输入 `192.168.0.0/16`(65k IP) 无任何警告。
- 加 `validateScanTarget` onblur + 内联错误显示（`scanTargetsError`），与 scanner 页对齐。

**Part 3 — login 强制改密手写校验**
- `login/+page.svelte` 的 `forceNewPassword.length<8` + mismatch 手写检查，与 users 页的 `resetPasswordSchema` 重复。
- 新增 `forcePasswordSchema`（8 字符 min + match，同策略），`handleForcePasswordChange` 改用 `validateForm` —— 密码策略只留一处，policy 变更不会静默漂移。

## Test
- [x] `npm test` 191 passed
- [x] `npm run build` clean
- [ ] 浏览器实测：scan-tasks 错误显示统一 + agent modal 校验 + login 改密（部署后补）

Closes #154