### PR TITLE
fix(web): mutation 反馈一致 — users / documents / scanner (#152)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -421,6 +421,7 @@
 		"Deselect All": "Deselect All",
 		"Add Selected": "Add Selected to Devices",
 		"Added N Devices": "{count} devices added successfully",
+		"Add N Failed": "{count} device(s) failed to add: {reason}",
 		"Import N Failed": "{count} row(s) failed: {reason}",
 		"No Alive Hosts": "No alive hosts found",
 		"No Alive Hosts Desc": "Try a different IP range or check network connectivity.",
@@ -683,7 +684,9 @@
 		"Confirm Password": "Confirm Password",
 		"Passwords Do Not Match": "Passwords do not match",
 		"Password Reset Success": "Password reset successfully. The user must change it on next login.",
-		"Password Required": "Password is required"
+		"Password Required": "Password is required",
+		"Created": "User created",
+		"Deleted": "User deleted"
 	},
 	"notifications": {
 		"Notifications": "Notifications",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -421,6 +421,7 @@
 		"Deselect All": "取消全选",
 		"Add Selected": "添加选中到设备列表",
 		"Added N Devices": "成功添加 {count} 台设备",
+		"Add N Failed": "{count} 台设备添加失败：{reason}",
 		"Import N Failed": "{count} 行导入失败：{reason}",
 		"No Alive Hosts": "未发现存活主机",
 		"No Alive Hosts Desc": "请尝试其他 IP 范围或检查网络连接。",
@@ -683,7 +684,9 @@
 		"Confirm Password": "确认密码",
 		"Passwords Do Not Match": "两次输入的密码不一致",
 		"Password Reset Success": "密码重置成功，用户下次登录时需要修改密码",
-		"Password Required": "密码为必填项"
+		"Password Required": "密码为必填项",
+		"Created": "用户已创建",
+		"Deleted": "用户已删除"
 	},
 	"notifications": {
 		"Notifications": "通知管理",

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -281,9 +281,10 @@
 			const res = await api.post<AddDevicesResponse>('/scanner/add-devices', { devices });
 
 			if (res.errors && res.errors.length > 0) {
-				for (const err of res.errors) {
-					addToast('error', err);
-				}
+				// Single summary warning (count + first reason) instead of one
+				// toast per failure — floods the toast stack when many devices
+				// fail (e.g. duplicates). Matches the CSV-import path. #152 part 3.
+				addToast('warning', m['scanner.Add N Failed']().replace('{count}', String(res.errors.length)).replace('{reason}', res.errors[0]));
 			}
 
 			if (res.added > 0) {

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -101,8 +101,10 @@
 			total = res.total || 0;
 			syncUrl();
 		} catch (err: unknown) {
+			// Inline banner only on initial load — the parallel toast was
+			// noisy (double-notified on fetch failure, unlike every other
+			// list page). #152 part 2.
 			error = getErrorMessage(err);
-			addToast('error', error);
 		} finally {
 			loading = false;
 		}

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -180,7 +180,7 @@
 			await api.post('/auth/register', formData);
 			createModalOpen = false;
 			resetForm();
-			addToast('success', m["common.Success"]());
+			addToast('success', m["users.Created"]());
 			fetchUsers();
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));
@@ -199,7 +199,7 @@
 		try {
 			await api.delete(`/users/${deleteTarget.id}`);
 			deleteTarget = null;
-			addToast('success', m["common.Success"]());
+			addToast('success', m["users.Deleted"]());
 			fetchUsers();
 		} catch (err: unknown) {
 			addToast('error', getErrorMessage(err));


### PR DESCRIPTION
## Summary

修复 P2 issue #152 的三处 mutation 反馈不一致：

**Part 1 — users 页通用 \"Success\" toast**
- `users/+page.svelte`：create/delete 用 `common.Success`，看不出哪个操作成功。新增 `users.Created`/`users.Deleted`（"User created"/"User deleted"，"用户已创建"/"用户已删除"），与 networks/notifications 的专用消息对齐。

**Part 2 — documents 页 fetch 失败双重通知**
- `documents/+page.svelte`：fetch 失败同时弹 toast + inline banner，其余 list 页（networks/users/notifications）只用 inline banner（有注释 \"parallel toast was noisy\"）。删掉 `addToast`，保留 inline banner，加一致注释。

**Part 3 — scanner 添加设备 per-error toast 刷屏**
- `devices/scanner/+page.svelte`：多台设备添加失败时每条错误各弹一个 toast。改为单条 summary warning（count + 首条原因），与 CSV 导入路径（`scanner.Import N Failed`）一致。新增 i18n `scanner.Add N Failed`。

## Test
- [x] `npm test` 191 passed
- [x] `npm run build` clean
- [ ] 浏览器实测（部署后补）

Closes #152