### PR TITLE
fix(web): 五个 create/edit modal 加 confirmDiscard 脏状态守卫 (#151)

### DIFF
--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -164,6 +164,18 @@
 		}
 	}
 	// --- Form helpers ---
+	// Snapshot of the form state captured when the modal opens. Used by
+	// formDirty ($derived) to detect unsaved edits so the Modal can warn
+	// before discarding them (Esc / backdrop / X). #151.
+	let formSnapshot = $state('');
+
+	function snapshotForm(): string {
+		return JSON.stringify([formName, formTargets, formCronExpr, formTimeout,
+			formCommunity, formEnabled, formPipelineConfig, formCredentialId]);
+	}
+
+	const formDirty = $derived(formOpen && snapshotForm() !== formSnapshot);
+
 	function resetForm() {
 		formName = '';
 		formTargets = '';
@@ -180,6 +192,7 @@
 
 	function openCreate() {
 		resetForm();
+		formSnapshot = snapshotForm();
 		formOpen = true;
 	}
 
@@ -207,6 +220,7 @@
 			formPipelineConfig = defaultPipeline();
 		}
 		formError = '';
+		formSnapshot = snapshotForm();
 		formOpen = true;
 	}
 
@@ -632,7 +646,7 @@
 </div>
 
 <!-- Create/Edit Modal -->
-<Modal bind:open={formOpen} title={editingTask ? m['scanner.Edit Task']() : m['scanner.Create Task']()} maxWidth="48rem" onClose={resetForm}>
+<Modal bind:open={formOpen} title={editingTask ? m['scanner.Edit Task']() : m['scanner.Create Task']()} maxWidth="48rem" onClose={resetForm} confirmDiscard={() => formDirty}>
 	{#if formError}
 		<div class="mb-4 px-4 py-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
 			{formError}

--- a/web/src/routes/networks/+page.svelte
+++ b/web/src/routes/networks/+page.svelte
@@ -67,6 +67,14 @@
 		}
 	}
 
+	// Snapshot of form state captured on open; formDirty ($derived) detects
+	// unsaved edits so the Modal warns before discarding (Esc / backdrop / X). #151
+	let formSnapshot = $state('');
+	function snapshotForm(): string {
+		return JSON.stringify([formName, formCidr, formSite]);
+	}
+	const formDirty = $derived(formOpen && snapshotForm() !== formSnapshot);
+
 	function resetForm() {
 		formName = '';
 		formCidr = '';
@@ -77,6 +85,7 @@
 
 	function openCreate() {
 		resetForm();
+		formSnapshot = snapshotForm();
 		formOpen = true;
 	}
 
@@ -86,6 +95,7 @@
 		formCidr = net.cidr ?? '';
 		formSite = net.site ?? '';
 		formError = '';
+		formSnapshot = snapshotForm();
 		formOpen = true;
 	}
 
@@ -263,7 +273,7 @@
 {/if}
 
 <!-- Create/Edit Modal -->
-<Modal bind:open={formOpen} title={editingId !== null ? (m['networks.Edit']()) : (m['networks.Create']())} maxWidth="36rem" onClose={resetForm}>
+<Modal bind:open={formOpen} title={editingId !== null ? (m['networks.Edit']()) : (m['networks.Create']())} maxWidth="36rem" onClose={resetForm} confirmDiscard={() => formDirty}>
 	{#if formError}
 		<div class="mb-4 px-4 py-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
 			{formError}

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -97,6 +97,17 @@
 		}
 	}
 
+	// Snapshot of channel form state captured on open; formDirty ($derived)
+	// detects unsaved edits so the Modal warns before discarding (Esc /
+	// backdrop / X). #151
+	let formSnapshot = $state('');
+	function snapshotForm(): string {
+		return JSON.stringify([formName, formType, formEnabled, formUrl, formHeaders,
+			formSmtpHost, formSmtpPort, formSmtpUsername, formSmtpPassword,
+			formFromAddress, formToAddress]);
+	}
+	const formDirty = $derived(modalOpen && snapshotForm() !== formSnapshot);
+
 	function resetForm() {
 		formName = '';
 		formType = 'webhook';
@@ -114,6 +125,7 @@
 
 	function openCreate() {
 		resetForm();
+		formSnapshot = snapshotForm();
 		modalOpen = true;
 	}
 
@@ -149,6 +161,7 @@
 			formHeaders = [{ key: '', value: '' }];
 		}
 
+		formSnapshot = snapshotForm();
 		modalOpen = true;
 	}
 
@@ -354,6 +367,16 @@
 		}
 	}
 
+	// Snapshot of rule form state captured on open; ruleFormDirty ($derived)
+	// detects unsaved edits so the Modal warns before discarding (Esc /
+	// backdrop / X). #151
+	let ruleFormSnapshot = $state('');
+	function snapshotRuleForm(): string {
+		return JSON.stringify([ruleName, ruleEventType, ruleScopeType,
+			ruleScopeNetworkId, ruleScopeDeviceUuid, ruleChannelId, ruleCooldown]);
+	}
+	const ruleFormDirty = $derived(ruleModalOpen && snapshotRuleForm() !== ruleFormSnapshot);
+
 	function resetRuleForm() {
 		ruleName = '';
 		ruleEventType = 'device_lost';
@@ -368,6 +391,7 @@
 
 	function openCreateRule() {
 		resetRuleForm();
+		ruleFormSnapshot = snapshotRuleForm();
 		ruleModalOpen = true;
 	}
 
@@ -381,6 +405,7 @@
 		ruleChannelId = rule.channel_id;
 		ruleCooldown = rule.cooldown_minutes;
 		ruleFieldErrors = {};
+		ruleFormSnapshot = snapshotRuleForm();
 		ruleModalOpen = true;
 	}
 
@@ -752,7 +777,7 @@
 {/if}
 
 <!-- Create/Edit Channel Modal -->
-<Modal bind:open={modalOpen} title={editingChannel ? m["notifications.Edit Channel"]() : m["notifications.Create Channel"]()} onClose={resetForm} maxWidth="36rem">
+<Modal bind:open={modalOpen} title={editingChannel ? m["notifications.Edit Channel"]() : m["notifications.Create Channel"]()} onClose={resetForm} maxWidth="36rem" confirmDiscard={() => formDirty}>
 	<form onsubmit={handleSubmit} class="space-y-4">
 		<!-- Name -->
 		<div>
@@ -969,7 +994,7 @@
 />
 
 <!-- Rule create/edit modal (#139) -->
-<Modal bind:open={ruleModalOpen} title={editingRule ? m["notifications.Edit Rule"]() : m["notifications.Create Rule"]()} onClose={resetRuleForm} maxWidth="36rem">
+<Modal bind:open={ruleModalOpen} title={editingRule ? m["notifications.Edit Rule"]() : m["notifications.Create Rule"]()} onClose={resetRuleForm} maxWidth="36rem" confirmDiscard={() => ruleFormDirty}>
 	<form onsubmit={handleRuleSubmit} class="space-y-4">
 		<!-- Name -->
 		<div>

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -131,6 +131,14 @@
 		if (!Number.isNaN(o) && o >= 0) offset = o;
 	}
 
+	// Snapshot of form state captured on open; formDirty ($derived) detects
+	// unsaved edits so the Modal warns before discarding (Esc / backdrop / X). #151
+	let formSnapshot = $state('');
+	function snapshotForm(): string {
+		return JSON.stringify([formUsername, formEmail, formPassword, formRole]);
+	}
+	const formDirty = $derived(createModalOpen && snapshotForm() !== formSnapshot);
+
 	function resetForm() {
 		formUsername = '';
 		formEmail = '';
@@ -142,6 +150,7 @@
 
 	function openCreate() {
 		resetForm();
+		formSnapshot = snapshotForm();
 		createModalOpen = true;
 	}
 
@@ -380,7 +389,7 @@
 {/if}
 
 <!-- Create User Modal -->
-<Modal bind:open={createModalOpen} title={m["users.Add User"]()} onClose={resetForm}>
+<Modal bind:open={createModalOpen} title={m["users.Add User"]()} onClose={resetForm} confirmDiscard={() => formDirty}>
 	<form onsubmit={handleSubmit} class="space-y-4">
 		<!-- Username -->
 		<div>


### PR DESCRIPTION
## Summary

修复 P2 issue #151：五个 create/edit modal 点 X / 按 Esc / 点 backdrop 会静默丢弃全部表单输入。agent token modal 已有 `confirmDiscard` 守卫，这五个对齐。

| Page | Modal | 字段 |
|------|-------|------|
| scan-tasks | Create/Edit task | pipeline config (targets/cron/timeout/plugins/credential) |
| networks | Create/Edit network | name/cidr/site |
| users | Create user | username/password/role |
| notifications | Create/Edit channel | SMTP/host/headers/auth |
| notifications | Create/Edit rule | triggers/channel refs/cooldown |

## 实现方式

每个 modal 在 `openCreate`/`openEdit` 时快照表单状态（`JSON.stringify` 串），`formDirty` 用 `$derived` 比对当前值与快照 → `confirmDiscard={() => formDirty}`。Modal 组件已有的 "unsaved changes" 弹层负责实际拦截。

**优点**：
- 无改动输入框、无新增 handler
- 复杂嵌套对象（pipeline config / headers 数组）也能正确比对
- 与 agent token modal 的 `confirmDiscard` API 一致

## Test
- [x] `npm test` 191 passed
- [x] `npm run build` clean
- [ ] 浏览器实测：编辑表单 → Esc/X/backdrop 弹确认；未改动直接关不弹（部署后补）

Closes #151