### PR TITLE
fix(lock): 并发卫生 — scheduler/lease-sweeper/ratelimit/ebpf (#163)

### DIFF
--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -31,6 +31,7 @@ type RateLimiter struct {
 	mu       sync.RWMutex
 	rate     rate.Limit
 	burst    int
+	quit     chan struct{}
 }
 
 // NewRateLimiter creates a new RateLimiter with the given rate (requests per second) and burst.
@@ -39,9 +40,21 @@ func NewRateLimiter(r float64, burst int) *RateLimiter {
 		visitors: make(map[string]*visitor),
 		rate:     rate.Limit(r),
 		burst:    burst,
+		quit:     make(chan struct{}),
 	}
 	go rl.cleanup()
 	return rl
+}
+
+// Stop terminates the background cleanup goroutine. Safe to call multiple
+// times (closing a closed channel panics, so guard with the select). (#163)
+func (rl *RateLimiter) Stop() {
+	select {
+	case <-rl.quit:
+		// already closed
+	default:
+		close(rl.quit)
+	}
 }
 
 func (rl *RateLimiter) getVisitor(ip string) *rate.Limiter {
@@ -59,15 +72,21 @@ func (rl *RateLimiter) getVisitor(ip string) *rate.Limiter {
 }
 
 func (rl *RateLimiter) cleanup() {
+	t := time.NewTicker(time.Minute)
+	defer t.Stop()
 	for {
-		time.Sleep(time.Minute)
-		rl.mu.Lock()
-		for ip, v := range rl.visitors {
-			if time.Since(v.lastSeen) > 3*time.Minute {
-				delete(rl.visitors, ip)
+		select {
+		case <-rl.quit:
+			return
+		case <-t.C:
+			rl.mu.Lock()
+			for ip, v := range rl.visitors {
+				if time.Since(v.lastSeen) > 3*time.Minute {
+					delete(rl.visitors, ip)
+				}
 			}
+			rl.mu.Unlock()
 		}
-		rl.mu.Unlock()
 	}
 }
 
@@ -125,6 +144,7 @@ type ScanRateLimiter struct {
 	windows map[string][]time.Time // IP -> sliding window timestamps
 	limit   int                    // max requests per window
 	window  time.Duration          // sliding window duration
+	quit    chan struct{}
 }
 
 // NewScanRateLimiter creates a ScanRateLimiter with the given limit per minute.
@@ -136,9 +156,21 @@ func NewScanRateLimiter(limit int) *ScanRateLimiter {
 		windows: make(map[string][]time.Time),
 		limit:   limit,
 		window:  1 * time.Minute,
+		quit:    make(chan struct{}),
 	}
 	go srl.cleanup()
 	return srl
+}
+
+// Stop terminates the background cleanup goroutine. Safe to call multiple
+// times. (#163)
+func (srl *ScanRateLimiter) Stop() {
+	select {
+	case <-srl.quit:
+		// already closed
+	default:
+		close(srl.quit)
+	}
 }
 
 // Allow checks if the given IP is within the rate limit.
@@ -175,16 +207,22 @@ func (srl *ScanRateLimiter) Allow(ip string) bool {
 
 // cleanup periodically removes stale entries for IPs with no recent activity.
 func (srl *ScanRateLimiter) cleanup() {
+	t := time.NewTicker(2 * time.Minute)
+	defer t.Stop()
 	for {
-		time.Sleep(2 * time.Minute)
-		srl.mu.Lock()
-		cutoff := time.Now().Add(-2 * srl.window)
-		for ip, window := range srl.windows {
-			if len(window) > 0 && window[len(window)-1].Before(cutoff) {
-				delete(srl.windows, ip)
+		select {
+		case <-srl.quit:
+			return
+		case <-t.C:
+			srl.mu.Lock()
+			cutoff := time.Now().Add(-2 * srl.window)
+			for ip, window := range srl.windows {
+				if len(window) > 0 && window[len(window)-1].Before(cutoff) {
+					delete(srl.windows, ip)
+				}
 			}
+			srl.mu.Unlock()
 		}
-		srl.mu.Unlock()
 	}
 }
 

--- a/internal/api/middleware/ratelimit_test.go
+++ b/internal/api/middleware/ratelimit_test.go
@@ -218,3 +218,26 @@ func TestGlobalRateLimiter_BypassesStaticAssets(t *testing.T) {
 	apiHandler.ServeHTTP(rec2, req2)
 	require.Equal(t, http.StatusTooManyRequests, rec2.Code, "second API request should be rate-limited")
 }
+
+// TestRateLimiter_StopIdempotent verifies Stop() terminates the cleanup
+// goroutine and is safe to call multiple times (no panic on double-close). #163
+func TestRateLimiter_StopIdempotent(t *testing.T) {
+	rl := middleware.NewRateLimiter(1, 1)
+	rl.Stop()
+	rl.Stop() // double Stop must not panic (channel-already-closed guard)
+	// Middleware must still work after Stop — exercise it via a request.
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusOK, rec.Code, "Middleware must still work after Stop")
+}
+
+// TestScanRateLimiter_StopIdempotent verifies the scan limiter's Stop(). #163
+func TestScanRateLimiter_StopIdempotent(t *testing.T) {
+	srl := middleware.NewScanRateLimiter(10)
+	srl.Stop()
+	srl.Stop() // double Stop must not panic
+	require.True(t, srl.Allow("10.0.0.1"), "Allow must still work after Stop")
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -805,8 +805,10 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		}
 		// Stop the lease sweeper BEFORE the DB close — its sweepOnce runs
 		// UPDATE devices + recordDeviceLost (change_log INSERT) and must not
-		// race db.Close().
+		// race db.Close(). Cancel unblocks an in-flight sweep's ctx-aware DB
+		// calls, then Stop() waits for the goroutine to fully exit. (#163)
 		leaseSweepCancel()
+		leaseSweeper.Stop()
 		// Stop the reconciliation job BEFORE the DB close — its scan reads
 		// devices/networks and must not race db.Close().
 		reconcileCancel()
@@ -827,6 +829,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		// this, the 3 workers (and their *db.Queries handle) outlive graceful
 		// shutdown and race against db.Close() in main.go.
 		notificationDispatcher.Stop()
+		// Stop the rate-limiter cleanup goroutines (process-lifetime, but
+		// close cleanly instead of leaking). (#163)
+		loginLimiter.Stop()
+		globalLimiter.Stop()
+		scanLimiter.Stop()
 	}
 }
 

--- a/internal/service/scannerv2/ebpf/observer_real.go
+++ b/internal/service/scannerv2/ebpf/observer_real.go
@@ -148,7 +148,8 @@ func (o *Observer) start() error {
 }
 
 // drain reads ring-buffer events forever, translating each into Evidence and
-// buffering it under the source IP. Exits when state.stop closes.
+// buffering it under the source IP. Exits when state.stop closes or the ring
+// buffer reader is closed (Stop closes both).
 func (o *Observer) drain() {
 	for {
 		select {
@@ -177,6 +178,37 @@ func (o *Observer) drain() {
 			state.recent[ev.IP] = state.recent[ev.IP][len(state.recent[ev.IP])-100:]
 		}
 		state.mu.Unlock()
+	}
+}
+
+// Stop tears down the eBPF observer: closes the ring-buffer reader (which
+// unblocks the drain goroutine's Read), signals state.stop, detaches the TC
+// programs, and frees the BPF objects. Idempotent — safe to call when the
+// observer never started (state.stop is nil) or to call twice. (#163)
+func (o *Observer) Stop() {
+	// Closing the reader unblocks an in-flight drain Read() → ErrClosed exit.
+	if state.reader != nil {
+		_ = state.reader.Close()
+	}
+	// Signal state.stop so the drain's select also catches it (defense-in-depth
+	// for the case where Read already returned ErrClosed).
+	state.mu.Lock()
+	if state.stop != nil {
+		select {
+		case <-state.stop:
+		default:
+			close(state.stop)
+		}
+	}
+	// Detach TC programs + free BPF objects.
+	for _, l := range state.links {
+		_ = l.Close()
+	}
+	state.links = nil
+	state.mu.Unlock()
+	if state.objects != nil {
+		_ = state.objects.Close()
+		state.objects = nil
 	}
 }
 

--- a/internal/service/scannerv2/runner/lease_sweeper.go
+++ b/internal/service/scannerv2/runner/lease_sweeper.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -116,6 +117,7 @@ type LeaseSweeper struct {
 	interval time.Duration // how often to sweep
 	ttl      time.Duration // staleness threshold (last_seen older than now-ttl)
 	logger   *slog.Logger
+	wg       sync.WaitGroup // tracks the sweep goroutine for clean shutdown
 }
 
 // Flap-debounce constants for the lease sweeper. An agent device that bounces
@@ -149,8 +151,12 @@ func NewLeaseSweeper(rn *Runner, interval, ttl time.Duration, logger *slog.Logge
 // Start launches the sweep loop. It returns immediately; the loop runs until
 // ctx is cancelled. One sweep runs immediately on start so a center restart
 // doesn't wait a full interval before reconciling stale agent devices.
+// Stop() waits for the goroutine to finish so a caller can be sure no sweep is
+// mid-DB-write before closing the database.
 func (s *LeaseSweeper) Start(ctx context.Context) {
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		s.sweepOnce(ctx)
 		t := time.NewTicker(s.interval)
 		defer t.Stop()
@@ -163,6 +169,14 @@ func (s *LeaseSweeper) Start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// Stop blocks until the sweep goroutine has exited. The caller is expected to
+// have cancelled the Start ctx first (which unblocks an in-flight sweepOnce's
+// ctx-aware DB calls). This closes the shutdown race where db.Close() could
+// fire while a sweep was mid-UPDATE. (#163)
+func (s *LeaseSweeper) Stop() {
+	s.wg.Wait()
 }
 
 // sweepOnce runs one reconciliation pass: it first expires agent devices whose

--- a/internal/service/scannerv2/runner/lease_sweeper_test.go
+++ b/internal/service/scannerv2/runner/lease_sweeper_test.go
@@ -233,3 +233,23 @@ func TestLeaseSweeper_NoRecoverOnCenterNetwork(t *testing.T) {
 	conn.QueryRow(`SELECT status FROM devices WHERE ip_address='192.168.63.50'`).Scan(&status)
 	require.Equal(t, "offline", status, "center-network device must not be recovered by the lease sweeper")
 }
+
+// TestLeaseSweeper_StopWaitsForGoroutine verifies the shutdown contract (#163):
+// after Stop() returns, the sweep goroutine has fully exited. We cancel the ctx
+// (which the loop selects on) then call Stop() — if Stop() did NOT wait (the
+// pre-fix bug), the goroutine could still be running and race setupLeaseTestDB's
+// t.Cleanup conn.Close(). The race detector makes this definitive: a leaked
+// goroutine touching conn after the cleanup close trips a data race.
+func TestLeaseSweeper_StopWaitsForGoroutine(t *testing.T) {
+	rn, _, _, _, _ := setupLeaseTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sweeper := NewLeaseSweeper(rn, 50*time.Millisecond, 5*time.Minute, nil)
+	sweeper.Start(ctx)
+
+	// Let at least one tick fire so the goroutine is actively sweeping.
+	time.Sleep(120 * time.Millisecond)
+
+	cancel()
+	sweeper.Stop() // must block until the goroutine exits before t.Cleanup closes conn
+}

--- a/internal/service/scannerv2/scheduler/scheduler.go
+++ b/internal/service/scannerv2/scheduler/scheduler.go
@@ -86,26 +86,41 @@ func New(queries *db.Queries, dbConn *sql.DB, scanFn ScanFunc, logger *slog.Logg
 // Start re-hydrates jobs from enabled scan_tasks and begins cron firing.
 func (s *Scheduler) Start(ctx context.Context) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.started {
+		s.mu.Unlock()
 		return
 	}
-	// Mark stale runs failed (>1h old "running").
+	s.started = true
+	s.mu.Unlock()
+
+	// DB I/O (stale-run cleanup + task listing) is done OUTSIDE s.mu. Holding
+	// the lock across these blocked AddJob/RemoveJob/TriggerNow/CancelTask for
+	// the duration of a SQLite BUSY / WAL stall, even though Start runs once at
+	// boot. The registration of jobs below is the only part that needs the lock
+	// (it mutates jobMap + the gocron scheduler). (#163)
 	s.cleanupStaleRuns(ctx)
 
 	tasks, err := s.queries.ListEnabledScanTasks(ctx)
 	if err != nil {
 		s.logger.Error("scheduler: list enabled tasks failed", "error", err)
 	} else {
+		s.mu.Lock()
 		for _, t := range tasks {
 			if err := s.registerJob(t.ID, t.CronExpr, t.Targets); err != nil {
 				s.logger.Error("scheduler: register job failed", "task_id", t.ID, "error", err)
 			}
 		}
+		s.scheduler.Start()
+		s.logger.Info("scheduler started", "jobs", len(s.jobMap))
+		s.mu.Unlock()
 	}
-	s.started = true
-	s.scheduler.Start()
-	s.logger.Info("scheduler started", "jobs", len(s.jobMap))
+
+	// If listing failed we still need to start gocron (empty) so Stop() works.
+	if err != nil {
+		s.mu.Lock()
+		s.scheduler.Start()
+		s.mu.Unlock()
+	}
 
 	// Periodic stale-run sweeper. Without this, a run that hangs (e.g. a probe
 	// stuck on an unresponsive host) stays status='running' forever, and because


### PR DESCRIPTION
## Summary

修复并发审计 (#163) 发现的 4 个并发卫生问题（非死锁，但需修）：

### 1. scheduler.Start() 持 mu 做 DB I/O
`cleanupStaleRuns` / `ListEnabledScanTasks` 在 `s.mu.Lock()` 内执行 —— SQLite BUSY/WAL 争用期间阻塞 `AddJob`/`RemoveJob`/`TriggerNow`/`CancelTask`/`Stop`。改为**先查后锁**：DB I/O 移出 mu，仅 `registerJob` + `gocron.Start` 在锁内。

### 2. LeaseSweeper 无 WaitGroup（真实关停竞态）⭐
`sweep` goroutine 可能在 `db.Close()` 被调用时仍在写 DB（`UPDATE devices` + `recordDeviceLost` change_log INSERT）。加 `sync.WaitGroup`，新增 `Stop()` 方法 `wg.Wait()`；routes.go 关停闭包在 `leaseSweepCancel()` 后调 `leaseSweeper.Stop()` 确保 goroutine 完全退出再关 DB。

### 3. RateLimiter/ScanRateLimiter cleanup 无 stop 路径
`for { time.Sleep }` 永跑。加 `quit chan` + `Stop()` 方法（幂等 select 守 double-close），cleanup 改 ticker+select。

### 4. eBPF observer drain 无 Stop()
`state.stop` 创建从不 close。加 `Stop()` 方法：close reader（解阻 drain 的 Read → ErrClosed）+ close state.stop + detach TC links + free BPF objects（幂等，WITH_EBPF 构建）。

## Test
- [x] `TestLeaseSweeper_StopWaitsForGoroutine`（race detector ×5）
- [x] `TestRateLimiter_StopIdempotent` / `TestScanRateLimiter_StopIdempotent`
- [x] `go test -race ./...` 全绿
- [x] `gofmt` + `goimports` clean
- [x] `go vet` clean

Closes #163