### PR TITLE
refactor(handler): 样板坍缩 — server/TLS 家族数据驱动注册 (#158)

### DIFF
--- a/internal/service/scannerv2/handler/registry.go
+++ b/internal/service/scannerv2/handler/registry.go
@@ -15,7 +15,7 @@ import "mibee-steward/internal/service/scannerv2"
 // register into a scannerv2.Registry. Each handler maps 1:1 to a service name
 // emitted by a classifier in package classify.
 func DefaultHandlers() []scannerv2.ServiceHandler {
-	return []scannerv2.ServiceHandler{
+	handlers := []scannerv2.ServiceHandler{
 		SSHHandler{},
 		HTTPHandler{},
 		PrometheusHandler{},
@@ -24,26 +24,11 @@ func DefaultHandlers() []scannerv2.ServiceHandler {
 		ONVIFHandler{},
 		SNMPHandler{},
 		CameraHandler{},
-		// Services that classifiers identify but previously had no handler, so
-		// hosts whose only service was one of these dropped to type "other".
-		// Each marks the host as a server (see handler/services.go).
-		MySQLHandler{}, PostgreSQLHandler{}, RedisHandler{}, MongoDBHandler{},
-		MSSQLHandler{}, MemcachedHandler{},
-		SMTPHandler{}, POP3Handler{}, IMAPHandler{},
-		VNCHandler{}, RDPHandler{},
-		LDAPHandler{}, SMBHandler{},
-		// TLS-wrapped service handlers — each performs the full certificate
-		// chain grab (leaf + issuers) in Collect() and persists via the
-		// orchestrator's RecordTLSCerts path. https covers any TLS port the
-		// TLSClassifier flags; the rest are the well-known TLS-wrapped service
-		// ports asserted by MiscClassifier.
-		NewHTTPSHandler(),
-		NewLDAPSHandler(),
-		NewSMTPSHandler(),
-		NewIMAPSHandler(),
-		NewPOP3SHandler(),
-		NewFTPSHandler(),
-		NewIRCSSHandler(),
-		NewTelnetSSHandler(),
 	}
+	// Server-class + TLS-wrapped handlers are data-driven (one type per family,
+	// registered once per service name) — see handler/services.go and
+	// handler/tls_collect.go. (#158)
+	handlers = append(handlers, newServerHandlers()...)
+	handlers = append(handlers, newTLSCollectHandlers()...)
+	return handlers
 }

--- a/internal/service/scannerv2/handler/services.go
+++ b/internal/service/scannerv2/handler/services.go
@@ -3,9 +3,8 @@
 // Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later. A commercial license is available for use cases
+// the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 
 package handler
 
@@ -21,17 +20,27 @@ import (
 // EnrichDevice for these services, so a host whose only detected service was
 // (say) mysql or smb ended up with an empty inferred_type → "other".
 //
-// Each handler below marks the device as a "server" (these services — DBs,
+// Each handler marks the device as a "server" (these services — DBs,
 // mail, remote-access, directory, file-sharing — all imply a server-class
 // host). The classification itself (port/banner → service name) is unchanged;
 // this only fills in the missing type-inference step.
+//
+// Data-driven registration (#158): a SINGLE serverServiceHandler type,
+// parameterized by name, replaces ~13 named stub types (MySQLHandler,
+// SMTPHandler, VNCHandler, …). The registry matches handlers by Service()
+// output, so one value-per-name is all the interface needs — adding a new
+// server-class service is now one entry in serverServiceNames, not a new type
+// + 4 method stubs.
 
-// serverServiceHandler is the shared implementation: a TCP heartbeat on the
-// service port + a server type assignment. Embedded by each named handler so
-// we don't repeat the 4-method boilerplate per service.
+// serverServiceHandler is the ONE handler for every server-class service. It
+// generates a TCP heartbeat on the service port and assigns inferred_type =
+// "server". The service name (returned by Service()) is the dispatch key the
+// registry uses to match it to a classifier's output.
 type serverServiceHandler struct {
 	name string
 }
+
+func (h serverServiceHandler) Service() string { return h.name }
 
 func (h serverServiceHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
 	return &scannerv2.HeartbeatSpec{
@@ -51,173 +60,27 @@ func (serverServiceHandler) EnrichDevice(svc scannerv2.ServiceContext, _ scanner
 	preserveExisting(svc, "inferred_type", "server")
 }
 
-// Per-service handlers. Service() returns the name a classifier emits; the
-// registry matches handlers by that name (handler/registry.go).
-
-type MySQLHandler struct{}
-type RedisHandler struct{}
-type PostgreSQLHandler struct{}
-type MongoDBHandler struct{}
-type MSSQLHandler struct{}
-type MemcachedHandler struct{}
-
-func (MySQLHandler) Service() string      { return "mysql" }
-func (RedisHandler) Service() string      { return "redis" }
-func (PostgreSQLHandler) Service() string { return "postgresql" }
-func (MongoDBHandler) Service() string    { return "mongodb" }
-func (MSSQLHandler) Service() string      { return "mssql" }
-func (MemcachedHandler) Service() string  { return "memcached" }
-
-func (h MySQLHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "mysql"}.GenerateHeartbeat(svc)
-}
-func (h MySQLHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h MySQLHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
+// serverServiceNames is the complete list of server-class service names a
+// classifier can emit. Each becomes a registered serverServiceHandler. Grouped
+// by family (database / mail / remote-access / directory & file-share) to
+// mirror how classifiers discover them.
+var serverServiceNames = []string{
+	// Databases.
+	"mysql", "postgresql", "redis", "mongodb", "mssql", "memcached",
+	// Mail.
+	"smtp", "pop3", "imap",
+	// Remote access (VNC/RDP imply a server/host offering GUI access).
+	"vnc", "rdp",
+	// Directory & file-share.
+	"ldap", "smb",
 }
 
-func (h RedisHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "redis"}.GenerateHeartbeat(svc)
+// newServerHandlers returns one serverServiceHandler per name in
+// serverServiceNames, ready to register.
+func newServerHandlers() []scannerv2.ServiceHandler {
+	handlers := make([]scannerv2.ServiceHandler, len(serverServiceNames))
+	for i, name := range serverServiceNames {
+		handlers[i] = serverServiceHandler{name: name}
+	}
+	return handlers
 }
-func (h RedisHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h RedisHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-func (h PostgreSQLHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "postgresql"}.GenerateHeartbeat(svc)
-}
-func (h PostgreSQLHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h PostgreSQLHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-func (h MongoDBHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "mongodb"}.GenerateHeartbeat(svc)
-}
-func (h MongoDBHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h MongoDBHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-func (h MSSQLHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "mssql"}.GenerateHeartbeat(svc)
-}
-func (h MSSQLHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h MSSQLHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-func (h MemcachedHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "memcached"}.GenerateHeartbeat(svc)
-}
-func (h MemcachedHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h MemcachedHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-// Mail handlers.
-type SMTPHandler struct{}
-type POP3Handler struct{}
-type IMAPHandler struct{}
-
-func (SMTPHandler) Service() string { return "smtp" }
-func (POP3Handler) Service() string { return "pop3" }
-func (IMAPHandler) Service() string { return "imap" }
-
-func (h SMTPHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "smtp"}.GenerateHeartbeat(svc)
-}
-func (h SMTPHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h SMTPHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-func (h POP3Handler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "pop3"}.GenerateHeartbeat(svc)
-}
-func (h POP3Handler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h POP3Handler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-func (h IMAPHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "imap"}.GenerateHeartbeat(svc)
-}
-func (h IMAPHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h IMAPHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-// Remote-access handlers (VNC/RDP imply a server/host offering GUI access).
-type VNCHandler struct{}
-type RDPHandler struct{}
-
-func (VNCHandler) Service() string { return "vnc" }
-func (RDPHandler) Service() string { return "rdp" }
-
-func (h VNCHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "vnc"}.GenerateHeartbeat(svc)
-}
-func (h VNCHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h VNCHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-func (h RDPHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "rdp"}.GenerateHeartbeat(svc)
-}
-func (h RDPHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h RDPHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-// Directory & file-share handlers.
-type LDAPHandler struct{}
-type SMBHandler struct{}
-
-func (LDAPHandler) Service() string { return "ldap" }
-func (SMBHandler) Service() string  { return "smb" }
-
-func (h LDAPHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "ldap"}.GenerateHeartbeat(svc)
-}
-func (h LDAPHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h LDAPHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-func (h SMBHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return serverServiceHandler{name: "smb"}.GenerateHeartbeat(svc)
-}
-func (h SMBHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return serverServiceHandler{}.Collect(ctx, svc)
-}
-func (h SMBHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	serverServiceHandler{}.EnrichDevice(svc, d)
-}
-
-// NOTE: HTTPSHandler used to live here as a type-only stub (no cert
-// collection). It moved to handler/tls_collect.go where it now performs the
-// full certificate chain grab via probe.CollectCertChain. Do NOT re-add an
-// HTTPSHandler type here — it would collide with the one in tls_collect.go.

--- a/internal/service/scannerv2/handler/services_test.go
+++ b/internal/service/scannerv2/handler/services_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. A commercial license is available for use cases
+// the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/service/scannerv2"
+)
+
+// TestServerHandlers_AllNamesRegistered verifies every name in
+// serverServiceNames produces a registered handler whose Service() returns that
+// name. This guards the data-driven registration (#158) against a name list /
+// dispatch mismatch.
+func TestServerHandlers_AllNamesRegistered(t *testing.T) {
+	handlers := newServerHandlers()
+	seen := make(map[string]bool, len(handlers))
+	for _, h := range handlers {
+		name := h.Service()
+		require.NotEmpty(t, name, "server handler must have a non-empty service name")
+		require.False(t, seen[name], "duplicate server handler for %q", name)
+		seen[name] = true
+
+		// Every server handler assigns inferred_type=server and generates a TCP
+		// heartbeat — assert the dispatch behavior is consistent across names.
+		sh, ok := h.(serverServiceHandler)
+		require.True(t, ok, "expected serverServiceHandler for %q", name)
+		require.Equal(t, name, sh.name)
+
+		svc := scannerv2.ServiceContext{
+			IP:       "10.0.0.1",
+			Identity: scannerv2.ServiceIdentity{Port: 3306},
+			Device: scannerv2.DeviceRef{
+				Fields: map[string]string{}, // pre-init so enrich mutates this map
+			},
+		}
+		hb := sh.GenerateHeartbeat(svc)
+		require.NotNil(t, hb)
+		require.Equal(t, "tcp", hb.Method)
+		require.Equal(t, "10.0.0.1:3306", hb.Target)
+
+		sh.EnrichDevice(svc, nil)
+		require.Equal(t, "server", svc.Device.Fields["inferred_type"])
+	}
+	// Sanity: the canonical set hasn't shrunk (a deletion without updating this
+	// count would silently drop a handler).
+	require.Len(t, handlers, len(serverServiceNames))
+}
+
+// TestTLSCollectHandlers_AllNamesRegistered verifies every name in
+// tlsCollectNames produces a registered handler whose Service() returns that
+// name. Guards the data-driven registration (#158).
+func TestTLSCollectHandlers_AllNamesRegistered(t *testing.T) {
+	handlers := newTLSCollectHandlers()
+	seen := make(map[string]bool, len(handlers))
+	for _, h := range handlers {
+		name := h.Service()
+		require.NotEmpty(t, name, "TLS handler must have a non-empty service name")
+		require.False(t, seen[name], "duplicate TLS handler for %q", name)
+		seen[name] = true
+
+		th, ok := h.(tlsCollectHandler)
+		require.True(t, ok, "expected tlsCollectHandler for %q", name)
+		require.Equal(t, name, th.name)
+
+		// Heartbeat is TCP on the service port; enrich assigns server type.
+		svc := scannerv2.ServiceContext{
+			IP:       "10.0.0.2",
+			Identity: scannerv2.ServiceIdentity{Port: 443},
+			Device: scannerv2.DeviceRef{
+				Fields: map[string]string{},
+			},
+		}
+		hb := th.GenerateHeartbeat(svc)
+		require.NotNil(t, hb)
+		require.Equal(t, "tcp", hb.Method)
+
+		th.EnrichDevice(svc, nil)
+		require.Equal(t, "server", svc.Device.Fields["inferred_type"])
+	}
+	require.Len(t, handlers, len(tlsCollectNames))
+}
+
+// TestDefaultHandlers_NoServiceNameCollisions asserts no two handlers in the
+// default set claim the same Service() name — a collision would silently shadow
+// one handler in the registry.
+func TestDefaultHandlers_NoServiceNameCollisions(t *testing.T) {
+	all := DefaultHandlers()
+	seen := make(map[string]bool, len(all))
+	for _, h := range all {
+		name := h.Service()
+		require.False(t, seen[name], "service name %q registered by two handlers", name)
+		seen[name] = true
+	}
+}

--- a/internal/service/scannerv2/handler/tls_collect.go
+++ b/internal/service/scannerv2/handler/tls_collect.go
@@ -3,9 +3,8 @@
 // Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later. A commercial license is available for use cases
+// the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 
 package handler
 
@@ -18,7 +17,7 @@ import (
 )
 
 // This file adds TLS-cert-collection handlers for every TLS-wrapped service a
-// classifier can identify. Each handler's Collect() performs a full-certificate
+// classifier can identify. The handler's Collect() performs a full-certificate
 // chain grab (leaf + issuers) via probe.CollectCertChain and returns it as a
 // TLSCertCollected payload. The orchestrator detects that payload type and
 // persists it via Repository.RecordTLSCerts — handlers themselves never touch
@@ -31,19 +30,24 @@ import (
 // covers the additional case of TLS-discovered-on-a-non-default-port and the
 // full-chain persistence for every case.
 //
-// Server-type assignment + TCP heartbeat reuse the existing
-// serverServiceHandler so we don't diverge from how https/smtps/etc are typed.
+// Data-driven registration (#158): a SINGLE tlsCollectHandler type,
+// parameterized by name, replaces 8 named stub types (HTTPSHandler,
+// LDAPSHandler, SMTPSHandler, …). Adding a new TLS-wrapped service is now one
+// entry in tlsCollectNames, not a new type + constructor + 4 method stubs.
 
-// tlsCollectHandler is the shared implementation embedded by every TLS-wrapped
-// service handler. The per-service types just delegate to it.
+// tlsCollectHandler is the ONE handler for every TLS-wrapped service. Service()
+// returns the name (the dispatch key); Collect grabs the cert chain; heartbeat
+// and enrich reuse the server-class behavior.
 type tlsCollectHandler struct {
 	name string // service name, e.g. "https", "ldaps"
 }
 
-// collectCerts is the shared body: dial the service port, grab the cert chain,
-// wrap it as TLSCertCollected. Returns nil data (and nil error) when the
-// identity has no usable port, so the orchestrator skips persistence cleanly.
-func (h tlsCollectHandler) collectCerts(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
+func (h tlsCollectHandler) Service() string { return h.name }
+
+// Collect dials the service port, grabs the cert chain, and wraps it as
+// TLSCertCollected. Returns nil data (and nil error) when the identity has no
+// usable port, so the orchestrator skips persistence cleanly.
+func (h tlsCollectHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
 	port := svc.Identity.Port
 	if port <= 0 {
 		return nil, nil, nil
@@ -59,146 +63,43 @@ func (h tlsCollectHandler) collectCerts(ctx context.Context, svc scannerv2.Servi
 	}, nil, nil
 }
 
-// heartbeat delegates to serverServiceHandler's TCP heartbeat — these are all
-// server-class services and the port is alive if the handshake succeeded.
-func (h tlsCollectHandler) heartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
+// GenerateHeartbeat delegates to a TCP heartbeat — these are all server-class
+// services and the port is alive if the handshake succeeded.
+func (h tlsCollectHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
 	return &scannerv2.HeartbeatSpec{
 		Method: "tcp",
 		Target: fmt.Sprintf("%s:%d", svc.IP, svc.Identity.Port),
 	}
 }
 
-// enrich delegates to the server-type assignment so hosts with only TLS-wrapped
-// services still get inferred_type=server.
-func (h tlsCollectHandler) enrich(svc scannerv2.ServiceContext, _ scannerv2.CollectedData) {
+// EnrichDevice assigns the server type so hosts with only TLS-wrapped services
+// still get inferred_type=server.
+func (h tlsCollectHandler) EnrichDevice(svc scannerv2.ServiceContext, _ scannerv2.CollectedData) {
 	preserveExisting(svc, "inferred_type", "server")
 }
 
-// ---- Per-service handler types ----
-//
-// One struct per service name; each implements the 4-method ServiceHandler
-// interface by delegating to tlsCollectHandler. Naming follows the service
-// strings emitted by the classifiers (see classify/web_tls.go for "https" and
-// classify/mail_remote.go's MiscClassifier for the rest).
-
-// HTTPSHandler — emitted by TLSClassifier for any TLS handshake.
-type HTTPSHandler struct{ tlsCollectHandler }
-
-func NewHTTPSHandler() HTTPSHandler  { return HTTPSHandler{tlsCollectHandler{name: "https"}} }
-func (HTTPSHandler) Service() string { return "https" }
-func (h HTTPSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h HTTPSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h HTTPSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
+// tlsCollectNames is the complete list of TLS-wrapped service names a
+// classifier can emit. "https" is emitted by TLSClassifier for any TLS
+// handshake; the rest are port-shape matches from MiscClassifier. Naming
+// follows the service strings emitted by the classifiers (see
+// classify/web_tls.go and classify/mail_remote.go).
+var tlsCollectNames = []string{
+	"https",
+	"ldaps",   // 636
+	"smtps",   // 465
+	"imaps",   // 993
+	"pop3s",   // 995
+	"ftps",    // 990 (control); ftps-data (989) shares the same TLS shape.
+	"ircs",    // 994
+	"telnets", // 992
 }
 
-// LDAPSHhandler — MiscClassifier port-shape for 636.
-type LDAPSHandler struct{ tlsCollectHandler }
-
-func NewLDAPSHandler() LDAPSHandler  { return LDAPSHandler{tlsCollectHandler{name: "ldaps"}} }
-func (LDAPSHandler) Service() string { return "ldaps" }
-func (h LDAPSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h LDAPSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h LDAPSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// SMTPSHhandler — 465.
-type SMTPSHandler struct{ tlsCollectHandler }
-
-func NewSMTPSHandler() SMTPSHandler  { return SMTPSHandler{tlsCollectHandler{name: "smtps"}} }
-func (SMTPSHandler) Service() string { return "smtps" }
-func (h SMTPSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h SMTPSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h SMTPSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// IMAPSHhandler — 993.
-type IMAPSHandler struct{ tlsCollectHandler }
-
-func NewIMAPSHandler() IMAPSHandler  { return IMAPSHandler{tlsCollectHandler{name: "imaps"}} }
-func (IMAPSHandler) Service() string { return "imaps" }
-func (h IMAPSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h IMAPSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h IMAPSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// POP3SHhandler — 995.
-type POP3SHandler struct{ tlsCollectHandler }
-
-func NewPOP3SHandler() POP3SHandler  { return POP3SHandler{tlsCollectHandler{name: "pop3s"}} }
-func (POP3SHandler) Service() string { return "pop3s" }
-func (h POP3SHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h POP3SHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h POP3SHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// FTPSHhandler — 990 (control). ftps-data (989) is rarely used standalone and
-// shares the same TLS shape, so it's covered by the same handler mapping
-// below.
-type FTPSHandler struct{ tlsCollectHandler }
-
-func NewFTPSHandler() FTPSHandler   { return FTPSHandler{tlsCollectHandler{name: "ftps"}} }
-func (FTPSHandler) Service() string { return "ftps" }
-func (h FTPSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h FTPSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h FTPSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// IRCSSHandler — 994.
-type IRCSSHandler struct{ tlsCollectHandler }
-
-func NewIRCSSHandler() IRCSSHandler  { return IRCSSHandler{tlsCollectHandler{name: "ircs"}} }
-func (IRCSSHandler) Service() string { return "ircs" }
-func (h IRCSSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h IRCSSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h IRCSSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
-}
-
-// TelnetSSHandler — 992.
-type TelnetSSHandler struct{ tlsCollectHandler }
-
-func NewTelnetSSHandler() TelnetSSHandler { return TelnetSSHandler{tlsCollectHandler{name: "telnets"}} }
-func (TelnetSSHandler) Service() string   { return "telnets" }
-func (h TelnetSSHandler) GenerateHeartbeat(svc scannerv2.ServiceContext) *scannerv2.HeartbeatSpec {
-	return h.heartbeat(svc)
-}
-func (h TelnetSSHandler) Collect(ctx context.Context, svc scannerv2.ServiceContext) (scannerv2.CollectedData, []scannerv2.Trigger, error) {
-	return h.collectCerts(ctx, svc)
-}
-func (h TelnetSSHandler) EnrichDevice(svc scannerv2.ServiceContext, d scannerv2.CollectedData) {
-	h.enrich(svc, d)
+// newTLSCollectHandlers returns one tlsCollectHandler per name in
+// tlsCollectNames, ready to register.
+func newTLSCollectHandlers() []scannerv2.ServiceHandler {
+	handlers := make([]scannerv2.ServiceHandler, len(tlsCollectNames))
+	for i, name := range tlsCollectNames {
+		handlers[i] = tlsCollectHandler{name: name}
+	}
+	return handlers
 }


### PR DESCRIPTION
## Summary

坍缩 handler 样板代码（P2 tech-debt #158）—— server-class 和 TLS-wrapped 两大家族从具名类型 + N×4 方法 stub 改为**单一类型 + name 切片**数据驱动注册。

**services.go**：13 个具名 server 类型（MySQL/Redis/PostgreSQL/MongoDB/MSSQL/Memcached/SMTP/POP3/IMAP/VNC/RDP/LDAP/SMB）→ 单个 `serverServiceHandler`（加 `Service()` 方法）+ `serverServiceNames` 切片 + `newServerHandlers()` 循环注册。

**tls_collect.go**：8 个具名 TLS 类型（HTTPS/LDAPS/SMTPS/IMAPS/POP3S/FTPS/IRCS/TelnetS）→ 单个 `tlsCollectHandler`（已有内部方法 `collectCerts`/`heartbeat`/`enrich` 提升为接口方法）+ `tlsCollectNames` 切片。

**registry.go**：`DefaultHandlers()` 改为 `append(newServerHandlers()...)` + `append(newTLSCollectHandlers()...)`。

**不动**：bespoke handler（SSH/HTTP/Prometheus/NodeExporter/RTSP/ONVIF/SNMP/Camera）—— 这些有真实 per-protocol `Collect` 逻辑。

## 结果
- **净删 251 行**（-345 +94）
- **handlers 数量不变**：29（8 bespoke + 13 server + 8 TLS）
- **AGENTS.md "add a protocol" 对齐**：server/TLS 家族 = 一行 name，不是新类型 + 4 stub
- 新增协议承诺现在成真

## Test
- [x] `TestServerHandlers_AllNamesRegistered`（13 server name 全注册 + heartbeat/enrich 一致）
- [x] `TestTLSCollectHandlers_AllNamesRegistered`（8 TLS name 全注册）
- [x] `TestDefaultHandlers_NoServiceNameCollisions`（29 handler 无 name 碰撞）
- [x] `go test -race ./...` 全绿
- [x] `gofmt` + `goimports` + `go vet` clean

Closes #158