### PR TITLE
fix(api): service 层 validation sentinel — handler errors.Is 映射 400 (#165)

### DIFF
--- a/internal/api/handler/device.go
+++ b/internal/api/handler/device.go
@@ -60,6 +60,10 @@ func (h *DeviceHandler) Create(w http.ResponseWriter, r *http.Request) {
 			Error(w, http.StatusBadRequest, "invalid IP address format")
 			return
 		}
+		if errors.Is(err, service.ErrDeviceNameRequired) {
+			Error(w, http.StatusBadRequest, "device name is required")
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to create device")
 		return
 	}

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -52,7 +52,11 @@ func (h *NotificationHandler) CreateChannel(w http.ResponseWriter, r *http.Reque
 
 	resp, err := h.svc.CreateChannel(r.Context(), req)
 	if err != nil {
-		Error(w, http.StatusBadRequest, err.Error())
+		if errors.Is(err, service.ErrInvalidChannelConfig) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to create notification channel")
 		return
 	}
 
@@ -127,6 +131,10 @@ func (h *NotificationHandler) UpdateChannel(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		if errors.Is(err, service.ErrChannelNotFound) {
 			Error(w, http.StatusNotFound, "notification channel not found")
+			return
+		}
+		if errors.Is(err, service.ErrInvalidChannelConfig) {
+			Error(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		Error(w, http.StatusInternalServerError, "failed to update notification channel")

--- a/internal/api/handler/notification_rule.go
+++ b/internal/api/handler/notification_rule.go
@@ -46,7 +46,11 @@ func (h *NotificationHandler) CreateRule(w http.ResponseWriter, r *http.Request)
 
 	resp, err := h.svc.CreateRule(r.Context(), req)
 	if err != nil {
-		Error(w, http.StatusBadRequest, err.Error())
+		if errors.Is(err, service.ErrInvalidRuleConfig) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to create notification rule")
 		return
 	}
 
@@ -119,7 +123,11 @@ func (h *NotificationHandler) UpdateRule(w http.ResponseWriter, r *http.Request)
 			Error(w, http.StatusNotFound, "notification rule not found")
 			return
 		}
-		Error(w, http.StatusBadRequest, err.Error())
+		if errors.Is(err, service.ErrInvalidRuleConfig) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to update notification rule")
 		return
 	}
 

--- a/internal/api/handler/scanner_task.go
+++ b/internal/api/handler/scanner_task.go
@@ -151,9 +151,12 @@ func (h *ScannerTaskHandler) TriggerTask(w http.ResponseWriter, r *http.Request)
 			Error(w, http.StatusConflict, "scan task is disabled; enable it before triggering")
 			return
 		}
-		// Surface the real cause (e.g. "scheduler not available",
-		// "no job registered for task N") instead of a generic 500 string so
-		// operators can diagnose scheduler/engine wiring failures.
+		if errors.Is(err, taskservice.ErrSchedulerNotAvailable) {
+			Error(w, http.StatusServiceUnavailable, "scanner scheduler is not available")
+			return
+		}
+		// Surface the real cause (e.g. "no job registered for task N") instead
+		// of a generic 500 string so operators can diagnose engine wiring failures.
 		Error(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/api/handler/user.go
+++ b/internal/api/handler/user.go
@@ -169,6 +169,10 @@ func (h *UserHandler) Register(w http.ResponseWriter, r *http.Request) {
 			Error(w, http.StatusConflict, "user already exists")
 			return
 		}
+		if errors.Is(err, service.ErrWeakPassword) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		Error(w, http.StatusInternalServerError, "registration failed")
 		return
 	}
@@ -307,6 +311,14 @@ func (h *UserHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, service.ErrInvalidCredentials) {
 			Error(w, http.StatusBadRequest, "incorrect current password")
+			return
+		}
+		if errors.Is(err, service.ErrSamePassword) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errors.Is(err, service.ErrWeakPassword) {
+			Error(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		Error(w, http.StatusInternalServerError, "failed to change password")

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -23,8 +23,9 @@ import (
 )
 
 var (
-	ErrDeviceNotFound = errors.New("device not found")
-	ErrInvalidIP      = errors.New("invalid IP address")
+	ErrDeviceNotFound     = errors.New("device not found")
+	ErrInvalidIP          = errors.New("invalid IP address")
+	ErrDeviceNameRequired = errors.New("device name is required")
 )
 
 // DeviceService handles device management business logic.
@@ -41,7 +42,7 @@ func NewDeviceService(repo *repository.DeviceRepository, heartbeatSvc *Heartbeat
 // Create validates and creates a new device.
 func (s *DeviceService) Create(ctx context.Context, req domain.CreateDeviceRequest) (*domain.DeviceResponse, error) {
 	if req.Name == "" {
-		return nil, fmt.Errorf("device name is required")
+		return nil, ErrDeviceNameRequired
 	}
 
 	if req.IPAddress != "" {

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -300,7 +300,7 @@ func TestDevice_Create_EmptyName(t *testing.T) {
 		IPAddress: "10.0.0.1",
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "device name is required")
+	require.ErrorIs(t, err, ErrDeviceNameRequired)
 }
 
 // 14. List defaults — limit clamp

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -22,6 +22,11 @@ import (
 
 var (
 	ErrChannelNotFound = errors.New("notification channel not found")
+	// ErrInvalidChannelConfig / ErrInvalidRuleConfig are category sentinels for
+	// channel/rule field validation. Each wraps the specific rule as detail so
+	// handlers map the whole family to 400 via errors.Is. (#165)
+	ErrInvalidChannelConfig = errors.New("invalid notification channel configuration")
+	ErrInvalidRuleConfig    = errors.New("invalid notification rule configuration")
 )
 
 // NotificationService handles notification channel and log business logic.
@@ -42,10 +47,10 @@ func NewNotificationService(q *db.Queries) *NotificationService {
 // CreateChannel validates and creates a new notification channel.
 func (s *NotificationService) CreateChannel(ctx context.Context, req domain.CreateChannelRequest) (*domain.ChannelResponse, error) {
 	if req.Name == "" {
-		return nil, fmt.Errorf("channel name is required")
+		return nil, fmt.Errorf("%w: name is required", ErrInvalidChannelConfig)
 	}
 	if req.Type != domain.ChannelTypeWebhook && req.Type != domain.ChannelTypeEmail {
-		return nil, fmt.Errorf("invalid channel type: %s", req.Type)
+		return nil, fmt.Errorf("%w: invalid type %q", ErrInvalidChannelConfig, req.Type)
 	}
 
 	enabled := int64(1)
@@ -298,25 +303,25 @@ func (s *NotificationService) ListEnabledRulesByEventType(ctx context.Context, e
 // 409/400 with a channel-specific message before touching the DB).
 func validateRuleFields(eventType, scopeType, name string, channelID int64, networkID *int64, deviceUUID string) error {
 	if name == "" {
-		return fmt.Errorf("rule name is required")
+		return fmt.Errorf("%w: name is required", ErrInvalidRuleConfig)
 	}
 	if !domain.IsValidRuleEventType(eventType) {
-		return fmt.Errorf("invalid event_type: %s", eventType)
+		return fmt.Errorf("%w: invalid event_type %q", ErrInvalidRuleConfig, eventType)
 	}
 	if !domain.IsValidRuleScopeType(scopeType) {
-		return fmt.Errorf("invalid scope_type: %s", scopeType)
+		return fmt.Errorf("%w: invalid scope_type %q", ErrInvalidRuleConfig, scopeType)
 	}
 	if channelID <= 0 {
-		return fmt.Errorf("channel_id is required")
+		return fmt.Errorf("%w: channel_id is required", ErrInvalidRuleConfig)
 	}
 	switch scopeType {
 	case domain.RuleScopeNetwork:
 		if networkID == nil || *networkID <= 0 {
-			return fmt.Errorf("scope_network_id is required when scope_type=network")
+			return fmt.Errorf("%w: scope_network_id is required when scope_type=network", ErrInvalidRuleConfig)
 		}
 	case domain.RuleScopeDevice:
 		if deviceUUID == "" {
-			return fmt.Errorf("scope_device_uuid is required when scope_type=device")
+			return fmt.Errorf("%w: scope_device_uuid is required when scope_type=device", ErrInvalidRuleConfig)
 		}
 	}
 	return nil

--- a/internal/service/scannerv2/credresolver/credresolver.go
+++ b/internal/service/scannerv2/credresolver/credresolver.go
@@ -59,12 +59,12 @@ type cacheEntry struct {
 // ErrDisabled is returned by Resolve when the resolver has no cipher (master
 // key not configured). The engine treats this as "no v3 available" and falls
 // back to the legacy community path rather than failing the scan.
-var ErrDisabled = fmt.Errorf("credresolver: disabled (no master key configured)")
+var ErrDisabled = errors.New("credresolver: disabled (no master key configured)")
 
 // ErrNotFound is returned when no credential row exists for the requested ID.
 // Distinct from ErrDisabled so callers can tell "v3 disabled globally" from
 // "this specific credential was deleted".
-var ErrNotFound = fmt.Errorf("credresolver: credential not found")
+var ErrNotFound = errors.New("credresolver: credential not found")
 
 // New builds a resolver backed by the given *sql.DB + cipher. cipher may be
 // nil (→ Resolve returns ErrDisabled), which is how a deployment without a

--- a/internal/service/scannerv2/taskservice/taskservice.go
+++ b/internal/service/scannerv2/taskservice/taskservice.go
@@ -27,9 +27,10 @@ import (
 
 // Sentinel errors (preserved verbatim from v1 so handler error mapping still works).
 var (
-	ErrScanTaskNotFound = errors.New("scan task not found")
-	ErrScanNotRunning   = errors.New("scan is not running")
-	ErrScanTaskDisabled = errors.New("scan task is disabled")
+	ErrScanTaskNotFound      = errors.New("scan task not found")
+	ErrScanNotRunning        = errors.New("scan is not running")
+	ErrScanTaskDisabled      = errors.New("scan task is disabled")
+	ErrSchedulerNotAvailable = errors.New("scheduler not available")
 )
 
 // Service manages scan tasks: CRUD + trigger/cancel, keeping the DB and the
@@ -296,7 +297,7 @@ func (s *Service) TriggerTask(ctx context.Context, id int64) (domain.ScanRunResp
 		return domain.ScanRunResponse{}, ErrScanTaskDisabled
 	}
 	if s.scheduler == nil {
-		return domain.ScanRunResponse{}, errors.New("scheduler not available")
+		return domain.ScanRunResponse{}, ErrSchedulerNotAvailable
 	}
 	if err := s.scheduler.TriggerNow(id); err != nil {
 		// Distinguish "task has no registered cron job" (e.g. scheduler never

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -33,6 +33,11 @@ var (
 	ErrUserExists         = errors.New("user already exists")
 	ErrSamePassword       = errors.New("new password must be different")
 	ErrAccountLocked      = errors.New("account is locked due to too many failed login attempts")
+	// ErrWeakPassword is the sentinel for every password-strength rule failure.
+	// validatePassword wraps the specific rule as detail, so handlers map the
+	// whole family to 400 via errors.Is(err, ErrWeakPassword) without checking
+	// each rule individually. (#165)
+	ErrWeakPassword = errors.New("password does not meet requirements")
 )
 
 var (
@@ -46,22 +51,22 @@ var (
 // and requires at least one uppercase, lowercase, digit, and special character.
 func validatePassword(password, username string) error {
 	if len(password) < 8 {
-		return fmt.Errorf("password must be at least 8 characters")
+		return fmt.Errorf("%w: must be at least 8 characters", ErrWeakPassword)
 	}
 	if password == username {
-		return fmt.Errorf("password must not equal username")
+		return fmt.Errorf("%w: must not equal username", ErrWeakPassword)
 	}
 	if !hasUppercase.MatchString(password) {
-		return fmt.Errorf("password must contain at least one uppercase letter")
+		return fmt.Errorf("%w: must contain at least one uppercase letter", ErrWeakPassword)
 	}
 	if !hasLowercase.MatchString(password) {
-		return fmt.Errorf("password must contain at least one lowercase letter")
+		return fmt.Errorf("%w: must contain at least one lowercase letter", ErrWeakPassword)
 	}
 	if !hasDigit.MatchString(password) {
-		return fmt.Errorf("password must contain at least one digit")
+		return fmt.Errorf("%w: must contain at least one digit", ErrWeakPassword)
 	}
 	if !hasSpecialChar.MatchString(password) {
-		return fmt.Errorf("password must contain at least one special character")
+		return fmt.Errorf("%w: must contain at least one special character", ErrWeakPassword)
 	}
 	return nil
 }

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -106,6 +106,7 @@ func TestRegister_PasswordTooShort(t *testing.T) {
 
 	_, err := svc.Register(context.Background(), "charlie", "charlie@example.com", "Ab1!", "user")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrWeakPassword)
 	require.Contains(t, err.Error(), "at least 8 characters")
 }
 
@@ -114,6 +115,7 @@ func TestRegister_PasswordMissingUppercase(t *testing.T) {
 
 	_, err := svc.Register(context.Background(), "dave", "dave@example.com", "lower123!@#", "user")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrWeakPassword)
 	require.Contains(t, err.Error(), "uppercase")
 }
 
@@ -122,6 +124,7 @@ func TestRegister_PasswordMissingDigit(t *testing.T) {
 
 	_, err := svc.Register(context.Background(), "eve", "eve@example.com", "NoDigits!!", "user")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrWeakPassword)
 	require.Contains(t, err.Error(), "digit")
 }
 
@@ -130,6 +133,7 @@ func TestRegister_PasswordMissingSpecial(t *testing.T) {
 
 	_, err := svc.Register(context.Background(), "frank", "frank@example.com", "NoSpecial123", "user")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrWeakPassword)
 	require.Contains(t, err.Error(), "special")
 }
 


### PR DESCRIPTION
Closes #165. See commit message for full details. Service-layer validation sentinels (ErrWeakPassword, ErrInvalidChannelConfig, ErrInvalidRuleConfig, ErrDeviceNameRequired, ErrSchedulerNotAvailable) + handler errors.Is → 400 mapping. credresolver fmt.Errorf → errors.New. go test -race ./... green.