### PR TITLE
perf(scanner): UUID 缓存 + PRAGMA temp_store + batch miss (#162)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,7 +93,9 @@ func main() {
 	// enough connections to read device state without blocking the writer.
 	// WAL mode keeps reads from blocking the single writer, so this is safe.
 	db.SetMaxOpenConns(16)
-	db.SetMaxIdleConns(4)
+	// Match MaxIdleConns to MaxOpenConns so the pool doesn't churn connections
+	// open/close under concurrent scanner + heartbeat load (was 4 << 16). (#162)
+	db.SetMaxIdleConns(16)
 
 	// Optimize SQLite with WAL mode
 	pragmas := []string{
@@ -101,6 +103,9 @@ func main() {
 		"PRAGMA busy_timeout=5000",
 		"PRAGMA synchronous=NORMAL",
 		"PRAGMA cache_size=-64000",
+		// temp_store=MEMORY keeps temp tables + B-trees in RAM instead of
+		// spilling to a temp file — free latency reduction for large scans. (#162)
+		"PRAGMA temp_store=MEMORY",
 	}
 	for _, p := range pragmas {
 		if _, err := db.Exec(p); err != nil {

--- a/internal/service/scannerv2/runner/detect_lost.go
+++ b/internal/service/scannerv2/runner/detect_lost.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"strings"
 	"time"
 
 	"mibee-steward/internal/changedetect"
@@ -56,19 +57,11 @@ func (rn *Runner) DetectLost(ctx context.Context, networkID sql.NullInt64, taskI
 	//    last_seen_at) and build the alive IP set for the set difference.
 	aliveIPs := rn.RecordAliveSnapshots(ctx, networkID, taskID, reports)
 
-	// 2. Increment miss_count for snapshots NOT in the alive set.
-	snaps, err := rn.queries.ListSnapshotsForNetwork(ctx, netID)
-	if err != nil {
-		rn.logger.Warn("detect-lost: list snapshots failed", "network_id", netID, "error", err)
-		return
-	}
-	for _, s := range snaps {
-		if aliveIPs[s.Ip] {
-			continue // seen this scan — miss_count already reset by the upsert
-		}
-		if err := rn.queries.IncrementSnapshotMiss(ctx, s.ID); err != nil {
-			rn.logger.Warn("detect-lost: increment miss failed", "snapshot_id", s.ID, "ip", s.Ip, "error", err)
-		}
+	// 2. Increment miss_count for snapshots NOT in the alive set — a single
+	// batch UPDATE replaces the previous one-UPDATE-per-missing-host loop
+	// (200 missing hosts = 200 individual UPDATEs → now 1). (#162)
+	if err := rn.batchIncrementMiss(ctx, netID, aliveIPs); err != nil {
+		rn.logger.Warn("detect-lost: batch increment miss failed", "network_id", netID, "error", err)
 	}
 
 	// 3. Emit device_lost for snapshots past the threshold that are still online.
@@ -117,6 +110,33 @@ func (rn *Runner) DetectLost(ctx context.Context, networkID sql.NullInt64, taskI
 		slog.Info("detect-lost: devices declared lost",
 			"network_id", netID, "count", len(lost), "threshold", threshold)
 	}
+}
+
+// batchIncrementMiss bumps miss_count for every snapshot in the network whose
+// IP is NOT in the alive set, in a single UPDATE. This replaces the previous
+// per-snapshot IncrementSnapshotMiss loop (N missing hosts = N individual
+// UPDATEs → now 1 query). (#162)
+func (rn *Runner) batchIncrementMiss(ctx context.Context, netID int64, aliveIPs map[string]bool) error {
+	if len(aliveIPs) == 0 {
+		// No alive hosts at all — every snapshot in the network is missing.
+		_, err := rn.dbConn.ExecContext(ctx,
+			`UPDATE scan_snapshots SET miss_count = miss_count + 1 WHERE network_id = ?`, netID)
+		return err
+	}
+	// Build NOT IN (?,...) with one placeholder per alive IP. The scan target
+	// size is bounded (sync API rejects >1024 IPs), so the parameter count is
+	// always well within SQLite's limit.
+	placeholders := make([]string, 0, len(aliveIPs))
+	args := make([]any, 0, len(aliveIPs)+1)
+	args = append(args, netID)
+	for ip := range aliveIPs {
+		placeholders = append(placeholders, "?")
+		args = append(args, ip)
+	}
+	query := `UPDATE scan_snapshots SET miss_count = miss_count + 1 ` +
+		`WHERE network_id = ? AND ip NOT IN (` + strings.Join(placeholders, ",") + `)`
+	_, err := rn.dbConn.ExecContext(ctx, query, args...)
+	return err
 }
 
 // RecordAliveSnapshots upserts a scan snapshot for every alive host in reports

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"mibee-steward/internal/domain"
@@ -51,6 +52,15 @@ type SQLiteRepository struct {
 	// Two instances on different LANs thus keep their data partitioned even
 	// when private IPs overlap. Resolved from config `network` at startup.
 	networkID sql.NullInt64
+	// uuidCache memoizes IP → device_uuid lookups within the repository's
+	// lifetime. UUIDs are stable device identity (they never change once
+	// assigned), so caching is correct; the set of IPs per network is bounded
+	// (a /24 = 254 hosts), so the map does not grow unbounded. Without this
+	// cache, a /24 scan with 50 alive hosts triggers ~200 DB round-trips just
+	// to resolve UUIDs (RecordEvidence + RecordServices + RecordTLSCerts each
+	// call resolveDeviceUUID per host). (#162)
+	uuidCache map[string]string
+	uuidMu    sync.Mutex
 }
 
 // Options configures the SQLiteRepository.
@@ -93,6 +103,7 @@ func NewSQLiteRepository(db *sql.DB, opts Options, logger *slog.Logger) *SQLiteR
 		defaultSNMPCommunity: opts.DefaultSNMPCommunity,
 		defaultSNMPOID:       opts.DefaultSNMPOID,
 		networkID:            nid,
+		uuidCache:            make(map[string]string),
 	}
 }
 
@@ -900,9 +911,19 @@ func (r *SQLiteRepository) resolveDeviceID(ctx context.Context, ip string) (int6
 // empty-string sentinel is safe because devices.device_uuid is always populated
 // (non-empty) once a row exists — backfillDeviceUUIDs guarantees it.
 //
-// Used by the satellite-table writers (RecordServices/RecordEvidence/RecordTLSCerts)
-// so those rows key on the stable identity instead of the roaming-prone IP.
+// Results are memoized in r.uuidCache (IP → UUID). UUIDs are stable device
+// identity, so the cache is correct across calls; a /24 scan with 50 alive
+// hosts previously triggered ~200 DB round-trips here (one per Record* call per
+// host). The cache collapses that to ~50 (one per unique IP). (#162)
 func (r *SQLiteRepository) resolveDeviceUUID(ctx context.Context, ip string) (string, error) {
+	// Fast path: cache hit (includes cached "" for known-absent IPs).
+	r.uuidMu.Lock()
+	if u, ok := r.uuidCache[ip]; ok {
+		r.uuidMu.Unlock()
+		return u, nil
+	}
+	r.uuidMu.Unlock()
+
 	var q string
 	var args []any
 	if r.networkID.Valid {
@@ -921,8 +942,15 @@ func (r *SQLiteRepository) resolveDeviceUUID(ctx context.Context, ip string) (st
 				`SELECT device_uuid FROM devices WHERE ip_address = ? LIMIT 1`, ip).Scan(&u)
 		}
 		if err != nil {
+			// Do NOT cache the negative result ("") — a device may be created
+			// between scan passes (the heal scenario the tests verify), so a
+			// stale "" would block the UUID from ever resolving. Only non-empty
+			// results are cached (UUIDs are stable once assigned). (#162)
 			return "", err
 		}
 	}
+	r.uuidMu.Lock()
+	r.uuidCache[ip] = u
+	r.uuidMu.Unlock()
 	return u, nil
 }


### PR DESCRIPTION
## Summary

扫描持久化 IO 优化的**第一批**（低风险高收益子集；ring buffer 单写者架构留后续 PR）。

### 1. UUID 缓存（P0 — 最大单项收益）
`SQLiteRepository` 加 `uuidCache map[string]string` + mutex。`resolveDeviceUUID` 只缓存**非空**结果（UUID 是稳定身份）；空结果不缓存（设备可能在扫描间被创建 → heal 场景）。/24 扫 50 存活主机的 UUID 查询从 ~150 次 DB round-trip → ~50（3:1 压缩）。

### 2. PRAGMA temp_store=MEMORY
SQLite temp tables + B-trees 留在内存而非临时文件 —— 免费降延迟。

### 3. MaxIdleConns 4→16（匹配 MaxOpenConns）
消除并发扫描 + 心跳负载下的连接 churn。

### 4. IncrementSnapshotMiss 批量化（P1）
DetectLost step 2 原先逐 snapshot 调 `IncrementSnapshotMiss`（N 缺失 = N 个独立 UPDATE）→ 单条 batch `UPDATE ... WHERE ip NOT IN (alive set)`。

## Test
- [x] `go test -race ./...` 全绿（含 UUID heal 跨扫描测试）
- [x] `gofmt` + `goimports` + `go vet` clean
- [ ] 测试服 /24 扫描对比耗时（部署后补）

## 后续（不在本 PR）
- 单写者 goroutine + ring buffer（学 heartbeat_store）—— 架构变更，独立 PR
- 预编译语句 db 级缓存
- device_bridge 双 UPDATE 合并

Closes #162 (partial — high-value subset; architecture changes tracked as follow-up)