### PR TITLE
fix(web): DeviceEditModal confirmDiscard + Modal 文档决策 (#170)

### DIFF
--- a/web/src/lib/components/DeviceEditModal.svelte
+++ b/web/src/lib/components/DeviceEditModal.svelte
@@ -56,6 +56,17 @@
 	// form mode is stable across re-renders even if the caller updates `device`.
 	let editing = $state<Device | null>(null);
 
+	// Snapshot of form state captured after the modal hydrates; formDirty
+	// ($derived) detects unsaved edits so the Modal warns before discarding
+	// (Esc / backdrop / X). #170 — same pattern as the list-page modals (#151).
+	let formSnapshot = $state('');
+	function snapshotForm(): string {
+		return JSON.stringify([formName, formType, formBrand, formModel, formLocation,
+			formPurpose, formIpAddress, formMacAddress, formSerialNumber,
+			formPurchaseDate, formWarrantyExpiry, formTags]);
+	}
+	const formDirty = $derived(open && snapshotForm() !== formSnapshot);
+
 	function resetForm() {
 		formName = '';
 		formType = 'pc';
@@ -99,6 +110,9 @@
 			} else {
 				resetForm();
 			}
+			// Capture the baseline after hydration so formDirty reflects only
+			// edits the user makes AFTER the form is populated. #170
+			formSnapshot = snapshotForm();
 		}
 	});
 
@@ -160,7 +174,7 @@
 	}
 </script>
 
-<Modal bind:open title={editing ? m['devices.Edit Device']() : m['devices.Create Device']()} maxWidth="42rem" onClose={resetForm}>
+<Modal bind:open title={editing ? m['devices.Edit Device']() : m['devices.Create Device']()} maxWidth="42rem" onClose={resetForm} confirmDiscard={() => formDirty}>
 	{#if formError}
 		<div class="mb-4 px-4 py-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
 			{formError}


### PR DESCRIPTION
## Summary

#170 审计结论：**大部分条目已由前序 PR 解决**。本 PR 补唯一缺口 + 文档化决策。

| AC 条目 | 状态 |
|---------|------|
| tab URL 同步（?tab=xxx）| ✅ 已存在（hydrateTabFromUrl + history.replaceState）|
| 双提交防护 | ✅ 已存在（所有 submit 按钮 disabled={loading}）|
| 脏状态守卫（5 modal）| ✅ #151 已覆盖 scan-tasks/networks/users/notifications |
| **DeviceEditModal 脏状态守卫** | ❌ → ✅ **本 PR 补** |
| Modal back-on-mobile | 📝 文档化决策（acceptable trade-off）|

### DeviceEditModal confirmDiscard
`DeviceEditModal`（设备列表页 + 设备详情页共用的 create/edit 组件）是 #151 漏的唯一 modal。加 snapshot-based `formDirty` + `confirmDiscard={() => formDirty}`，与其它 5 个 modal 一致。快照在 `$effect` hydrate 表单后捕获，确保只检测用户编辑（不把 hydrate 本身误判为 dirty）。

### Modal back-on-mobile 文档化
评估 history pushState 让移动端 back 关 modal —— SPA + adapter-static 下脆弱，决定不做。记入 `web/AGENTS.md` lessons learned。

## Test
- [x] `npm test` 191 passed
- [x] `npm run build` clean
- [ ] 浏览器实测（部署后补）

Closes #170