### PR TITLE
refactor: 解散 internal/repository/ — repo 类型并入 service (#161)

### DIFF
--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -18,7 +18,6 @@ import (
 	"mibee-steward/internal/api/handler"
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/config"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/testutil"
 )
@@ -140,10 +139,10 @@ func setupCSRFTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 
 	expiry := 1 * time.Hour
 	userSvc := service.NewUserService(db, cfg.Auth.JWTSecret, expiry)
-	auditRepo := repository.NewAuditRepository(db)
+	auditRepo := service.NewAuditRepository(db)
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, nil)
 
-	deviceRepo := repository.NewDeviceRepository(db)
+	deviceRepo := service.NewDeviceRepository(db)
 	deviceSvc := service.NewDeviceService(deviceRepo, nil)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc)
 
@@ -267,7 +266,7 @@ func setupRateLimitTestServer(t *testing.T) *httptest.Server {
 
 	expiry := 1 * time.Hour
 	userSvc := service.NewUserService(db, cfg.Auth.JWTSecret, expiry)
-	auditRepo := repository.NewAuditRepository(db)
+	auditRepo := service.NewAuditRepository(db)
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, nil)
 
 	// Rate limiter matching production config: 10 req/min with burst 10

--- a/internal/api/handler/document.go
+++ b/internal/api/handler/document.go
@@ -23,7 +23,6 @@ import (
 
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 )
 
@@ -31,11 +30,11 @@ import (
 type DocumentHandler struct {
 	svc       *service.DocumentService
 	uploadDir string
-	auditRepo *repository.AuditRepository
+	auditRepo *service.AuditRepository
 }
 
 // NewDocumentHandler creates a new DocumentHandler.
-func NewDocumentHandler(svc *service.DocumentService, uploadDir string, auditRepo *repository.AuditRepository) *DocumentHandler {
+func NewDocumentHandler(svc *service.DocumentService, uploadDir string, auditRepo *service.AuditRepository) *DocumentHandler {
 	return &DocumentHandler{svc: svc, uploadDir: uploadDir, auditRepo: auditRepo}
 }
 
@@ -84,7 +83,7 @@ func (h *DocumentHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "file.upload",
 			ResourceType: "document",
@@ -158,7 +157,7 @@ func (h *DocumentHandler) Download(w http.ResponseWriter, r *http.Request) {
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "file.download",
 			ResourceType: "document",
@@ -236,7 +235,7 @@ func (h *DocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "file.delete",
 			ResourceType: "document",

--- a/internal/api/handler/handler_extended_test.go
+++ b/internal/api/handler/handler_extended_test.go
@@ -16,7 +16,6 @@ import (
 	"mibee-steward/internal/api/handler"
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/config"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 )
 
@@ -38,7 +37,7 @@ func setupExtendedTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 	maxFileSize := cfg.Storage.MaxFileSize
 	uploadSvc := service.NewUploadService(uploadPath, maxFileSize)
 	docSvc := service.NewDocumentService(db, uploadSvc)
-	auditRepo := repository.NewAuditRepository(db)
+	auditRepo := service.NewAuditRepository(db)
 	docHandler := handler.NewDocumentHandler(docSvc, uploadPath, auditRepo)
 
 	// HeartbeatService needs its dedicated store; use a temp file.
@@ -51,7 +50,7 @@ func setupExtendedTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 	heartbeatSvc := service.NewHeartbeatService(db, hbStore, cfg)
 	heartbeatHandler := handler.NewHeartbeatHandler(heartbeatSvc)
 
-	deviceRepo := repository.NewDeviceRepository(db)
+	deviceRepo := service.NewDeviceRepository(db)
 	deviceSvc := service.NewDeviceService(deviceRepo, nil)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc)
 

--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -21,7 +21,6 @@ import (
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/config"
 	sqldb "mibee-steward/internal/db"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
 	"mibee-steward/internal/testutil"
@@ -59,11 +58,11 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 
 	// User service and handler
 	userSvc := service.NewUserService(db, cfg.Auth.JWTSecret, expiry)
-	auditRepo := repository.NewAuditRepository(db)
+	auditRepo := service.NewAuditRepository(db)
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, nil)
 
 	// Device handler
-	deviceRepo := repository.NewDeviceRepository(db)
+	deviceRepo := service.NewDeviceRepository(db)
 	deviceSvc := service.NewDeviceService(deviceRepo, nil)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc)
 

--- a/internal/api/handler/link.go
+++ b/internal/api/handler/link.go
@@ -20,19 +20,19 @@ import (
 
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/db"
-	"mibee-steward/internal/repository"
+	"mibee-steward/internal/service"
 )
 
 // LinkHandler handles device-document linking endpoints.
 type LinkHandler struct {
 	queries   *db.Queries
-	auditRepo *repository.AuditRepository // may be nil → auditing skipped
+	auditRepo *service.AuditRepository // may be nil → auditing skipped
 }
 
 // NewLinkHandler creates a new LinkHandler. auditRepo is optional; when set,
 // link/unlink actions are recorded in the audit log for parity with other admin
 // write operations.
-func NewLinkHandler(dbConn db.DBTX, auditRepo *repository.AuditRepository) *LinkHandler {
+func NewLinkHandler(dbConn db.DBTX, auditRepo *service.AuditRepository) *LinkHandler {
 	return &LinkHandler{queries: db.New(dbConn), auditRepo: auditRepo}
 }
 
@@ -108,7 +108,7 @@ func (h *LinkHandler) auditLink(r *http.Request, action string, deviceID, docID 
 		return
 	}
 	// Log is best-effort and returns nothing; a write failure is logged inside.
-	h.auditRepo.Log(r.Context(), repository.AuditLog{
+	h.auditRepo.Log(r.Context(), service.AuditLog{
 		UserID:       &userID,
 		Action:       action,
 		ResourceType: "device",

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -19,7 +19,6 @@ import (
 
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
 )
@@ -28,11 +27,11 @@ import (
 type NotificationHandler struct {
 	svc        *service.NotificationService
 	dispatcher *notification.Dispatcher
-	auditRepo  *repository.AuditRepository
+	auditRepo  *service.AuditRepository
 }
 
 // NewNotificationHandler creates a new NotificationHandler.
-func NewNotificationHandler(svc *service.NotificationService, dispatcher *notification.Dispatcher, auditRepo *repository.AuditRepository) *NotificationHandler {
+func NewNotificationHandler(svc *service.NotificationService, dispatcher *notification.Dispatcher, auditRepo *service.AuditRepository) *NotificationHandler {
 	return &NotificationHandler{
 		svc:        svc,
 		dispatcher: dispatcher,
@@ -62,7 +61,7 @@ func (h *NotificationHandler) CreateChannel(w http.ResponseWriter, r *http.Reque
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.channel.create",
 			ResourceType: "notification_channel",
@@ -143,7 +142,7 @@ func (h *NotificationHandler) UpdateChannel(w http.ResponseWriter, r *http.Reque
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.channel.update",
 			ResourceType: "notification_channel",
@@ -185,7 +184,7 @@ func (h *NotificationHandler) SetChannelEnabled(w http.ResponseWriter, r *http.R
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.channel.enable",
 			ResourceType: "notification_channel",
@@ -213,7 +212,7 @@ func (h *NotificationHandler) DeleteChannel(w http.ResponseWriter, r *http.Reque
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.channel.delete",
 			ResourceType: "notification_channel",

--- a/internal/api/handler/notification_rule.go
+++ b/internal/api/handler/notification_rule.go
@@ -16,7 +16,6 @@ import (
 
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 )
 
@@ -56,7 +55,7 @@ func (h *NotificationHandler) CreateRule(w http.ResponseWriter, r *http.Request)
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.rule.create",
 			ResourceType: "notification_rule",
@@ -133,7 +132,7 @@ func (h *NotificationHandler) UpdateRule(w http.ResponseWriter, r *http.Request)
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.rule.update",
 			ResourceType: "notification_rule",
@@ -170,7 +169,7 @@ func (h *NotificationHandler) SetRuleEnabled(w http.ResponseWriter, r *http.Requ
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.rule.enable",
 			ResourceType: "notification_rule",
@@ -196,7 +195,7 @@ func (h *NotificationHandler) DeleteRule(w http.ResponseWriter, r *http.Request)
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.notification.rule.delete",
 			ResourceType: "notification_rule",

--- a/internal/api/handler/sd.go
+++ b/internal/api/handler/sd.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"mibee-steward/internal/db"
-	"mibee-steward/internal/repository"
+	"mibee-steward/internal/service"
 )
 
 // SDTarget represents a single Prometheus HTTP Service Discovery target.
@@ -29,11 +29,11 @@ type SDTarget struct {
 // SDHandler serves Prometheus HTTP Service Discovery endpoints.
 type SDHandler struct {
 	queries    *db.Queries
-	systemRepo *repository.DeviceSystemRepository
+	systemRepo *service.DeviceSystemRepository
 }
 
 // NewSDHandler creates a new SDHandler.
-func NewSDHandler(dbtx db.DBTX, systemRepo *repository.DeviceSystemRepository) *SDHandler {
+func NewSDHandler(dbtx db.DBTX, systemRepo *service.DeviceSystemRepository) *SDHandler {
 	return &SDHandler{queries: db.New(dbtx), systemRepo: systemRepo}
 }
 

--- a/internal/api/handler/totp.go
+++ b/internal/api/handler/totp.go
@@ -19,7 +19,6 @@ import (
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 )
 
@@ -28,11 +27,11 @@ type TOTPHandler struct {
 	svc       *service.TOTPService
 	userSvc   *service.UserService
 	cfg       *config.Config
-	auditRepo *repository.AuditRepository
+	auditRepo *service.AuditRepository
 }
 
 // NewTOTPHandler creates a new TOTPHandler.
-func NewTOTPHandler(svc *service.TOTPService, userSvc *service.UserService, cfg *config.Config, auditRepo *repository.AuditRepository) *TOTPHandler {
+func NewTOTPHandler(svc *service.TOTPService, userSvc *service.UserService, cfg *config.Config, auditRepo *service.AuditRepository) *TOTPHandler {
 	return &TOTPHandler{svc: svc, userSvc: userSvc, cfg: cfg, auditRepo: auditRepo}
 }
 
@@ -203,7 +202,7 @@ func (h *TOTPHandler) Verify(w http.ResponseWriter, r *http.Request) {
 
 	// Audit log
 	userID := req.UserID
-	h.auditRepo.Log(r.Context(), repository.AuditLog{
+	h.auditRepo.Log(r.Context(), service.AuditLog{
 		UserID:       &userID,
 		Action:       "auth.login.2fa.success",
 		ResourceType: "user",

--- a/internal/api/handler/user.go
+++ b/internal/api/handler/user.go
@@ -24,7 +24,6 @@ import (
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 )
 
@@ -32,12 +31,12 @@ import (
 type UserHandler struct {
 	svc       *service.UserService
 	cfg       *config.Config
-	auditRepo *repository.AuditRepository
+	auditRepo *service.AuditRepository
 	blacklist *service.TokenBlacklist
 }
 
 // NewUserHandler creates a new UserHandler.
-func NewUserHandler(svc *service.UserService, cfg *config.Config, auditRepo *repository.AuditRepository, blacklist *service.TokenBlacklist) *UserHandler {
+func NewUserHandler(svc *service.UserService, cfg *config.Config, auditRepo *service.AuditRepository, blacklist *service.TokenBlacklist) *UserHandler {
 	return &UserHandler{svc: svc, cfg: cfg, auditRepo: auditRepo, blacklist: blacklist}
 }
 
@@ -79,7 +78,7 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, service.ErrInvalidCredentials) {
 			slog.Warn("login failed", "username", req.Username, "ip", r.RemoteAddr, "reason", "invalid credentials")
-			h.auditRepo.Log(r.Context(), repository.AuditLog{
+			h.auditRepo.Log(r.Context(), service.AuditLog{
 				Action:       "auth.login.failure",
 				ResourceType: "user",
 				IPAddress:    r.RemoteAddr,
@@ -91,7 +90,7 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 		}
 		if errors.Is(err, service.ErrAccountLocked) {
 			slog.Warn("login failed", "username", req.Username, "ip", r.RemoteAddr, "reason", "account locked")
-			h.auditRepo.Log(r.Context(), repository.AuditLog{
+			h.auditRepo.Log(r.Context(), service.AuditLog{
 				Action:       "auth.login.failure",
 				ResourceType: "user",
 				IPAddress:    r.RemoteAddr,
@@ -102,7 +101,7 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		slog.Warn("login failed", "username", req.Username, "ip", r.RemoteAddr, "reason", err.Error())
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			Action:       "auth.login.failure",
 			ResourceType: "user",
 			IPAddress:    r.RemoteAddr,
@@ -121,7 +120,7 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.auditRepo.Log(r.Context(), repository.AuditLog{
+	h.auditRepo.Log(r.Context(), service.AuditLog{
 		UserID:       &userID,
 		Action:       "auth.login.success",
 		ResourceType: "user",
@@ -178,7 +177,7 @@ func (h *UserHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "admin.user.create",
 			ResourceType: "user",
@@ -213,7 +212,7 @@ func (h *UserHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	userID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &userID,
 			Action:       "auth.logout",
 			ResourceType: "user",
@@ -418,7 +417,7 @@ func (h *UserHandler) AdminResetPassword(w http.ResponseWriter, r *http.Request)
 
 	adminID, _, ok := middleware.GetUserFromContext(r)
 	if ok {
-		h.auditRepo.Log(r.Context(), repository.AuditLog{
+		h.auditRepo.Log(r.Context(), service.AuditLog{
 			UserID:       &adminID,
 			Action:       "admin.user.reset_password",
 			ResourceType: "user",

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -28,7 +28,6 @@ import (
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/crypto"
 	"mibee-steward/internal/db"
-	"mibee-steward/internal/repository"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
 	scannerv2cleanup "mibee-steward/internal/service/scannerv2/cleanup"
@@ -66,7 +65,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// User service and handler
 	userSvc := service.NewUserService(dbConn, cfg.Auth.JWTSecret, expiry)
 	// Audit logging
-	auditRepo := repository.NewAuditRepository(dbConn)
+	auditRepo := service.NewAuditRepository(dbConn)
 
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, tokenBlacklist)
 
@@ -160,7 +159,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	exportHandler := handler.NewExportHandler(service.NewExportService(db.New(dbConn), hbStore.Queries()))
 
 	// Device routes
-	deviceRepo := repository.NewDeviceRepository(dbConn)
+	deviceRepo := service.NewDeviceRepository(dbConn)
 	deviceSvc := service.NewDeviceService(deviceRepo, heartbeatSvc)
 	deviceHandler := handler.NewDeviceHandler(deviceSvc)
 	r.Route("/api/v1/devices", func(r chi.Router) {
@@ -600,7 +599,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	})
 
 	// Device system routes
-	deviceSystemRepo := repository.NewDeviceSystemRepository(dbConn)
+	deviceSystemRepo := service.NewDeviceSystemRepository(dbConn)
 	deviceSystemSvc := service.NewDeviceSystemService(deviceSystemRepo)
 	deviceSystemHandler := handler.NewDeviceSystemHandler(deviceSystemSvc)
 	r.Route("/api/v1/devices/{id}/systems", func(r chi.Router) {

--- a/internal/service/audit_repo.go
+++ b/internal/service/audit_repo.go
@@ -7,7 +7,7 @@
 // those terms; see LICENSE for the full text. A commercial license is available
 // for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/batch.go
+++ b/internal/service/batch.go
@@ -18,7 +18,6 @@ import (
 
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 )
 
 var (
@@ -31,11 +30,11 @@ var (
 // BatchService handles batch operations for devices and users.
 type BatchService struct {
 	db    *sql.DB
-	audit *repository.AuditRepository
+	audit *AuditRepository
 }
 
 // NewBatchService creates a new BatchService.
-func NewBatchService(db *sql.DB, audit *repository.AuditRepository) *BatchService {
+func NewBatchService(db *sql.DB, audit *AuditRepository) *BatchService {
 	return &BatchService{db: db, audit: audit}
 }
 
@@ -72,7 +71,7 @@ func (s *BatchService) DeleteDevices(ctx context.Context, ids []int64, userID in
 	for i, id := range ids {
 		idStrs[i] = fmt.Sprintf("%d", id)
 	}
-	s.audit.Log(ctx, repository.AuditLog{
+	s.audit.Log(ctx, AuditLog{
 		UserID:       &userID,
 		Action:       "admin.device.batch_delete",
 		ResourceType: "device",
@@ -141,7 +140,7 @@ func (s *BatchService) UpdateDeviceStatuses(ctx context.Context, ids []int64, st
 	for i, id := range ids {
 		idStrs[i] = fmt.Sprintf("%d", id)
 	}
-	s.audit.Log(ctx, repository.AuditLog{
+	s.audit.Log(ctx, AuditLog{
 		UserID:       &userID,
 		Action:       "admin.device.batch_update_status",
 		ResourceType: "device",
@@ -192,7 +191,7 @@ func (s *BatchService) DeleteUsers(ctx context.Context, ids []int64, currentUser
 	for i, id := range ids {
 		idStrs[i] = fmt.Sprintf("%d", id)
 	}
-	s.audit.Log(ctx, repository.AuditLog{
+	s.audit.Log(ctx, AuditLog{
 		UserID:       &currentUserID,
 		Action:       "admin.user.batch_delete",
 		ResourceType: "user",

--- a/internal/service/batch_test.go
+++ b/internal/service/batch_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"mibee-steward/internal/repository"
 )
 
 // setupBatchTestDB creates an in-memory SQLite DB with schema for batch tests.
@@ -131,7 +129,7 @@ func TestBatchService_DeleteDevices_EmptyIDs(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	deleted, err := svc.DeleteDevices(context.Background(), nil, 1)
@@ -143,7 +141,7 @@ func TestBatchService_DeleteDevices_Single(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -164,7 +162,7 @@ func TestBatchService_DeleteDevices_Multiple(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -185,7 +183,7 @@ func TestBatchService_DeleteDevices_NonexistentIDs(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	deleted, err := svc.DeleteDevices(context.Background(), []int64{9999, 10000}, 99)
@@ -197,7 +195,7 @@ func TestBatchService_DeleteDevices_Mixed(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -214,7 +212,7 @@ func TestBatchService_DeleteDevices_AuditLog(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -235,7 +233,7 @@ func TestBatchService_UpdateDeviceStatuses_EmptyIDs(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	updated, err := svc.UpdateDeviceStatuses(context.Background(), nil, "online", 1)
@@ -247,7 +245,7 @@ func TestBatchService_UpdateDeviceStatuses_InvalidStatus(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	updated, err := svc.UpdateDeviceStatuses(context.Background(), []int64{1}, "invalid", 1)
@@ -259,7 +257,7 @@ func TestBatchService_UpdateDeviceStatuses_Success(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -282,7 +280,7 @@ func TestBatchService_UpdateDeviceStatuses_AllValidStatuses(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -302,7 +300,7 @@ func TestBatchService_UpdateDeviceStatuses_AuditLog(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -321,7 +319,7 @@ func TestBatchService_DeleteUsers_EmptyIDs(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	deleted, err := svc.DeleteUsers(context.Background(), nil, 1)
@@ -333,7 +331,7 @@ func TestBatchService_DeleteUsers_SelfDelete(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 
 	deleted, err := svc.DeleteUsers(context.Background(), []int64{1, 2, 1}, 1)
@@ -345,7 +343,7 @@ func TestBatchService_DeleteUsers_Success(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 
@@ -367,7 +365,7 @@ func TestBatchService_DeleteUsers_AuditLog(t *testing.T) {
 	d := setupBatchTestDB(t)
 	defer d.Close()
 
-	auditRepo := repository.NewAuditRepository(d)
+	auditRepo := NewAuditRepository(d)
 	svc := NewBatchService(d, auditRepo)
 	ctx := context.Background()
 

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -19,7 +19,6 @@ import (
 
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 )
 
 var (
@@ -30,12 +29,12 @@ var (
 
 // DeviceService handles device management business logic.
 type DeviceService struct {
-	repo         *repository.DeviceRepository
+	repo         *DeviceRepository
 	heartbeatSvc *HeartbeatService
 }
 
 // NewDeviceService creates a new DeviceService.
-func NewDeviceService(repo *repository.DeviceRepository, heartbeatSvc *HeartbeatService) *DeviceService {
+func NewDeviceService(repo *DeviceRepository, heartbeatSvc *HeartbeatService) *DeviceService {
 	return &DeviceService{repo: repo, heartbeatSvc: heartbeatSvc}
 }
 
@@ -347,7 +346,7 @@ func toDeviceResponse(d db.Device) domain.DeviceResponse {
 // toDeviceResponseWithNetwork extends toDeviceResponse with the joined network
 // name (available on the list path via LEFT JOIN networks). NetworkID is set
 // from the device row regardless; NetworkName only when the join resolved one.
-func toDeviceResponseWithNetwork(dw repository.DeviceWithNetwork) domain.DeviceResponse {
+func toDeviceResponseWithNetwork(dw DeviceWithNetwork) domain.DeviceResponse {
 	resp := toDeviceResponse(dw.Device)
 	resp.NetworkName = dw.NetworkName
 	return resp

--- a/internal/service/device_attributes_repo_test.go
+++ b/internal/service/device_attributes_repo_test.go
@@ -1,4 +1,4 @@
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/device_list_sort_repo_test.go
+++ b/internal/service/device_list_sort_repo_test.go
@@ -1,4 +1,4 @@
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/device_repo.go
+++ b/internal/service/device_repo.go
@@ -7,7 +7,7 @@
 // those terms; see LICENSE for the full text. A commercial license is available
 // for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/device_system.go
+++ b/internal/service/device_system.go
@@ -18,7 +18,6 @@ import (
 
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 )
 
 var (
@@ -30,11 +29,11 @@ var (
 
 // DeviceSystemService handles device system management business logic.
 type DeviceSystemService struct {
-	repo *repository.DeviceSystemRepository
+	repo *DeviceSystemRepository
 }
 
 // NewDeviceSystemService creates a new DeviceSystemService.
-func NewDeviceSystemService(repo *repository.DeviceSystemRepository) *DeviceSystemService {
+func NewDeviceSystemService(repo *DeviceSystemRepository) *DeviceSystemService {
 	return &DeviceSystemService{repo: repo}
 }
 

--- a/internal/service/device_system_repo.go
+++ b/internal/service/device_system_repo.go
@@ -7,7 +7,7 @@
 // those terms; see LICENSE for the full text. A commercial license is available
 // for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
 
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/device_system_repo_test.go
+++ b/internal/service/device_system_repo_test.go
@@ -1,4 +1,4 @@
-package repository
+package service
 
 import (
 	"context"

--- a/internal/service/device_system_test.go
+++ b/internal/service/device_system_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
@@ -93,7 +92,7 @@ func setupDeviceSystemService(t *testing.T) (*DeviceSystemService, *sql.DB, int6
 	).Scan(&deviceID)
 	require.NoError(t, err)
 
-	repo := repository.NewDeviceSystemRepository(db)
+	repo := NewDeviceSystemRepository(db)
 	svc := NewDeviceSystemService(repo)
 	return svc, db, deviceID
 }

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
@@ -70,7 +69,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *sql.DB) {
 	`)
 	require.NoError(t, err)
 
-	repo := repository.NewDeviceRepository(db)
+	repo := NewDeviceRepository(db)
 	svc := NewDeviceService(repo, nil)
 	return svc, db
 }

--- a/internal/service/totp.go
+++ b/internal/service/totp.go
@@ -26,7 +26,6 @@ import (
 
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
-	"mibee-steward/internal/repository"
 )
 
 // TOTPIssuer is the issuer name used in TOTP URIs.
@@ -45,11 +44,11 @@ var (
 type TOTPService struct {
 	queries   *db.Queries
 	userDB    db.DBTX
-	auditRepo *repository.AuditRepository
+	auditRepo *AuditRepository
 }
 
 // NewTOTPService creates a new TOTPService.
-func NewTOTPService(dbConn db.DBTX, auditRepo *repository.AuditRepository) *TOTPService {
+func NewTOTPService(dbConn db.DBTX, auditRepo *AuditRepository) *TOTPService {
 	return &TOTPService{
 		queries:   db.New(dbConn),
 		userDB:    dbConn,
@@ -133,7 +132,7 @@ func (s *TOTPService) Enable(ctx context.Context, userID int64, code string) err
 
 	// Audit log
 	if s.auditRepo != nil {
-		s.auditRepo.Log(ctx, repository.AuditLog{
+		s.auditRepo.Log(ctx, AuditLog{
 			UserID:       &userID,
 			Action:       "admin.user.2fa.enable",
 			ResourceType: "user",
@@ -221,7 +220,7 @@ func (s *TOTPService) Disable(ctx context.Context, userID int64, password string
 
 	// Audit log
 	if s.auditRepo != nil {
-		s.auditRepo.Log(ctx, repository.AuditLog{
+		s.auditRepo.Log(ctx, AuditLog{
 			UserID:       &userID,
 			Action:       "admin.user.2fa.disable",
 			ResourceType: "user",


### PR DESCRIPTION
Closes #161. 纯包移动 + 引用更新，无逻辑变更。3 个 repo 类型 (DeviceRepository/DeviceSystemRepository/AuditRepository) + 测试移入 internal/service/。go test -race ./... 全绿。