### PR TITLE
fix(web): devices 页事件委托加键盘处理 — a11y 无需 cell snippet (#174 #167)

### DIFF
--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -886,6 +886,23 @@ interface AddDevicesResponse {
 			openDelete(device);
 		}
 	}
+
+	// Keyboard equivalent for the event-delegation wrapper. The rendered
+	// <button>/<input> elements are natively focusable + Enter/Space fires a
+	// click that bubbles to handleTableClick — but the wrapper div itself also
+	// needs to forward Enter/Space so keyboard-only users can activate actions
+	// without a mouse. (#167 / #174 — devices page uses real <button> elements
+	// via {@html} render, unlike the 8 pages migrated to cell snippets; this
+	// keyboard handler closes the remaining a11y gap without the cell snippet
+	// that triggered the Svelte 5 flush stall.)
+	function handleTableKeydown(e: KeyboardEvent) {
+		if (e.key !== 'Enter' && e.key !== ' ') return;
+		const target = e.target as HTMLElement;
+		const interactive = target.closest('[data-action]') as HTMLElement | null;
+		if (!interactive) return;
+		e.preventDefault();
+		handleTableClick({ target: interactive } as unknown as MouseEvent);
+	}
 </script>
 
 <div class="p-6">
@@ -1276,8 +1293,9 @@ interface AddDevicesResponse {
 	{#if loading}
 		<PageSkeleton type="table" />
 	{:else}
-		<!-- Device table with expandable heartbeat rows -->
-		<div onclick={handleTableClick}>
+		<!-- Device table with expandable heartbeat rows.
+		     svelte-ignore a11y_no_static_element_interactions -- event delegation wrapper; keyboard handled by onkeydown + native <button> focus -->
+		<div onclick={handleTableClick} onkeydown={handleTableKeydown}>
 			<DataTable
 				{columns}
 				rows={devices as unknown as Record<string, unknown>[]}


### PR DESCRIPTION
Closes #174. Closes #167. Devices 页交互元素已是原生 <button>/<input>（{@html} render），只需给事件委托 wrapper 加 onkeydown（Enter/Space → handleTableClick）即可满足键盘可达性，绕过 Svelte 5 flush stall（不使用 cell snippet）。npm test 191 passed, npm run build clean。