### PR TITLE
fix(dashboard): 离线设备名退化为 IP 时取当前 IP (#197)

### DIFF
--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -123,6 +123,20 @@
 	let draggedId: string | null = $state(null);
 	let refreshTimers: ReturnType<typeof setInterval>[] = [];
 
+	// ipv4OrV6 matches a bare IPv4 (a.b.c.d) or IPv6 literal. Used to detect
+	// when a device's stored name has degenerated to an IP (common after a DHCP
+	// roam: a scanner first discovered the host at .170 and recorded that IP as
+	// the name, then DHCP reassigned .167 — the name field did not follow the
+	// roam). In that case we show the CURRENT ip_address instead, so the device
+	// list name, IP column, and search link all agree (#197).
+	const IPV4_OR_V6 = /^(\d{1,3}\.){3}\d{1,3}$|^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$/;
+	function displayName(dev: OverviewDevice): string {
+		// User-set names are always honored; a degenerated IP name should not
+		// override the live ip_address (which is what the search link uses).
+		if (dev.name && !IPV4_OR_V6.test(dev.name)) return dev.name;
+		return dev.ip_address;
+	}
+
 	function getCSSVar(name: string, fallback: string): string {
 		return getComputedStyle(document.documentElement)
 			.getPropertyValue(name)
@@ -969,8 +983,10 @@
 								<a href="/devices?search={dev.ip_address}" class="flex items-center justify-between px-2 py-2 hover:bg-surface-2 rounded transition-colors">
 									<div class="flex items-center gap-2 min-w-0">
 										<span class="inline-block w-2 h-2 rounded-full bg-error shrink-0"></span>
-										<span class="text-sm truncate">{dev.name || dev.ip_address}</span>
-										<span class="text-xs text-muted font-mono truncate">{dev.ip_address}</span>
+										<span class="text-sm truncate">{displayName(dev)}</span>
+										{#if displayName(dev) !== dev.ip_address}
+											<span class="text-xs text-muted font-mono truncate">{dev.ip_address}</span>
+										{/if}
 									</div>
 									<span class="text-xs text-muted shrink-0 ml-2">{dev.type || '-'}</span>
 								</a>


### PR DESCRIPTION
## 背景

Closes #197。仪表盘「离线设备」列表显示名（\`192.168.63.170\`）与 IP 列/搜索链接（\`192.168.63.167\`）不一致。

## 根因

Scanner 首次发现设备时把当时的 IP 存成 \`name\`，DHCP 漫游后（\`.170\`→\`.167\`）\`name\` 字段没跟随更新 → 显示名停留在旧 IP，与当前 \`ip_address\` 不一致。

## 修复

前端启发式 \`displayName(dev)\`（\`web/src/routes/dashboard/+page.svelte\`）：
- 当 \`name\` 看起来是 IP（IPv4 \`a.b.c.d\` 或 IPv6）→ 用当前 \`ip_address\` 作显示名
- 用户设的真实名字（非 IP）始终被尊重

附带：当 \`displayName(dev) === dev.ip_address\` 时，隐藏重复的 IP 列（原 name + ip_address 并排，退化场景会重复显示同一 IP 两次）。

## 设计取舍

**为何只修前端**：后端 \`name\` 字段的更新策略是产品决策 —— scanner 是否该自动覆盖一个 IP 式的 name？这涉及"何时该覆盖用户可见的显示名"。P3 小问题用前端启发式（"IP 式 name 不可信，取当前 IP"）足够，不动后端 \`name\` 持久化逻辑。

## 验证

- ✅ \`npm run build\`（svelte + TS）通过
- ✅ \`npm test\`（191 vitest）全绿

## ⚠️ 需浏览器验证

test env dashboard 确认：离线设备名/IP 一致、用户设名的设备仍显示真实名字。