### PR TITLE
refactor(device_bridge): 身份写入吸收进 Repository 接口 (#159 PR 2/2)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -138,6 +138,7 @@ func main() {
 	// networkID=0 here — the agent's LOCAL shadow devices get NULL network_id;
 	// the center tags its copies with the agent's network from the token.
 	scanRunner := scannerv2runner.New(engine, queries, dbConn, nil, 0, slog.Default())
+	scanRunner.SetRepo(engine.Repository) // device-identity upsert for the agent's LOCAL shadow devices
 	scanRunner.SetReportSink(reporter.Report)
 	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)
 

--- a/internal/api/handler/agent_report_test.go
+++ b/internal/api/handler/agent_report_test.go
@@ -19,6 +19,7 @@ import (
 	sqldb "mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
 	scannerv2runner "mibee-steward/internal/service/scannerv2/runner"
+	"mibee-steward/internal/service/scannerv2/store"
 	"mibee-steward/internal/testutil"
 )
 
@@ -54,6 +55,7 @@ func setupAgentIngestServer(t *testing.T) (srv *httptest.Server, db *sql.DB, tok
 	// engine/heartbeat are nil — ApplyReport only needs the device-bridge path,
 	// which uses dbConn directly (heartbeat seeding no-ops when heartbeat is nil).
 	rn := scannerv2runner.New(nil, queries, db, nil, 0, nil)
+	rn.SetRepo(store.NewSQLiteRepository(db, store.Options{}, nil)) // agent reports carry a per-call networkID
 	agentReportHandler := handler.NewAgentReportHandler(rn, queries, db)
 
 	r := chi.NewMux()
@@ -292,6 +294,7 @@ func TestAgentReport_BackfillNetworkCIDR(t *testing.T) {
 	require.NoError(t, err)
 
 	rn := scannerv2runner.New(nil, queries, dbConn, nil, 0, nil)
+	rn.SetRepo(store.NewSQLiteRepository(dbConn, store.Options{}, nil))
 	h := handler.NewAgentReportHandler(rn, queries, dbConn)
 	r := chi.NewMux()
 	r.Use(chimw.RequestID)

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -265,6 +265,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Runner: connects the engine to run/result persistence + the device bridge.
 	scanRunner := scannerv2runner.New(v2Engine, scanQueries, dbConn, heartbeatSvc, networkID, slog.Default())
+	scanRunner.SetRepo(v2Engine.Repository)                // device-identity upsert (ResolveDeviceIdentity / ApplyDeviceIdentity)
 	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)
 
 	// Change detection (Phase 3): the center records device_added/changed/lost

--- a/internal/service/scannerv2/orchestrator_test.go
+++ b/internal/service/scannerv2/orchestrator_test.go
@@ -2,6 +2,7 @@ package scannerv2
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"reflect"
 	"sort"
@@ -136,6 +137,18 @@ func (r *recordRepo) EnrichDeviceByMAC(_ context.Context, _ string, _ map[string
 func (r *recordRepo) RecordTLSCerts(_ context.Context, ip string, certs []TLSCertRecord) error {
 	r.tlsCerts[ip] = append(r.tlsCerts[ip], certs...)
 	return nil
+}
+
+// ResolveDeviceIdentity / ApplyDeviceIdentity are no-ops in the orchestrator
+// test double — the orchestrator never calls them (identity upsert is the
+// runner's job via applyDeviceBridge). The stubs exist only to satisfy the
+// expanded Repository interface.
+func (r *recordRepo) ResolveDeviceIdentity(_ context.Context, _, _ string, _ sql.NullInt64) (IdentityResolution, error) {
+	return IdentityResolution{IsNew: true}, nil
+}
+
+func (r *recordRepo) ApplyDeviceIdentity(_ context.Context, _ IdentityWrite) (int64, error) {
+	return 0, nil
 }
 
 func TestOrchestrator_GatherClassifyDispatch(t *testing.T) {

--- a/internal/service/scannerv2/repository.go
+++ b/internal/service/scannerv2/repository.go
@@ -9,7 +9,10 @@
 
 package scannerv2
 
-import "context"
+import (
+	"context"
+	"database/sql"
+)
 
 // Repository is the ④ Persistence abstraction. The orchestrator and handlers
 // depend only on this interface, never on sqlc types or *sql.DB. The concrete
@@ -57,6 +60,90 @@ type Repository interface {
 	// Best-effort like the other Record methods: persistence failures are
 	// logged but never abort a scan.
 	RecordTLSCerts(ctx context.Context, ip string, certs []TLSCertRecord) error
+
+	// ResolveDeviceIdentity decides which devices row a scan should update, or
+	// whether a new row must be created. It is the read-only half of the
+	// MAC-primary identity upsert (the single authoritative writer for device
+	// identity, runner.applyDeviceBridge). Identity is MAC-first across ALL
+	// networks (a roaming device stays one asset), falling back to (ip,
+	// network_id) when no MAC is known. It also detects two special cases the
+	// caller must handle in ApplyDeviceIdentity:
+	//   - Roamed: the MAC-matched device moved to a NEW free IP (DHCP renewal).
+	//     The caller relocates the row's ip_address to the scanned IP.
+	//   - ReplacedID: a different physical device now occupies the scanned IP
+	//     (router/asset swap). The IP-holder becomes the update target and the
+	//     prior MAC-matched row (ReplacedID) is superseded (marked offline).
+	//
+	// networkID is per-call: a center ingesting many agents' networks resolves
+	// each against the agent's own network, not the center's. This method MUST
+	// NOT mutate — the caller applies type stickiness between resolve and write
+	// (see IdentityWrite), then calls ApplyDeviceIdentity to commit.
+	ResolveDeviceIdentity(ctx context.Context, mac, ip string, networkID sql.NullInt64) (IdentityResolution, error)
+
+	// ApplyDeviceIdentity commits the identity upsert for a resolved device: it
+	// creates a new row (in.IsNew) or updates the resolved row (normal rescan,
+	// device replacement when ReplacedID != 0, or IP roaming when Roamed). It
+	// also stamps status=online, last_seen, offline_since=NULL, last_scanned_at,
+	// and the mac/network — the liveness + freshness bookkeeping that belongs
+	// with the identity write. Returns the device ID of the affected row.
+	//
+	// The caller (runner.applyDeviceBridge) computes the report-derived fields
+	// (name, open_ports/services/scan_attributes JSON, tags, …) and the
+	// stickiness-adjusted Type BEFORE calling this, so the implementation is a
+	// thin SQL layer with no classification logic. in.TargetID MUST be the value
+	// returned by ResolveDeviceIdentity (0 when IsNew).
+	ApplyDeviceIdentity(ctx context.Context, in IdentityWrite) (deviceID int64, err error)
+}
+
+// IdentityResolution is the read-only result of ResolveDeviceIdentity. It tells
+// the caller which existing row to update (TargetID) and which special handling
+// applies (Roamed / ReplacedID), or that no row exists yet (IsNew).
+type IdentityResolution struct {
+	// TargetID is the devices.id to update. 0 when IsNew (no existing row).
+	TargetID int64
+	// ReplacedID is the id of a row superseded by a device replacement (a
+	// different physical device took over the scanned IP). The implementation
+	// marks it offline; 0 means no replacement.
+	ReplacedID int64
+	// Roamed is true when the MAC-matched device moved to a NEW free IP (DHCP
+	// renewal/re-lease). The caller relocates ip_address to the scanned IP.
+	Roamed bool
+	// IsNew is true when no existing row matches → the caller must create one.
+	IsNew bool
+}
+
+// IdentityWrite is the input to ApplyDeviceIdentity. It carries the identity
+// resolution result (TargetID/IsNew/ReplacedID/Roamed) plus the pre-computed
+// field values to persist. The runner derives the JSON blobs (OpenPortsJSON,
+// ScanAttributesJSON, …) from the HostReport BEFORE calling ApplyDeviceIdentity,
+// so the store stays a thin SQL layer.
+type IdentityWrite struct {
+	// Resolution (from ResolveDeviceIdentity).
+	TargetID   int64 // 0 when IsNew
+	IsNew      bool
+	ReplacedID int64 // device replacement (router/asset swap); 0 = none
+	Roamed     bool
+
+	// Origin.
+	IP        string
+	MAC       string
+	NetworkID sql.NullInt64
+
+	// Identity + classification fields to persist.
+	Name        string
+	Type        string
+	Brand       string
+	Description string
+	Location    string
+
+	// Scan-derived JSON blobs (pre-computed by the runner).
+	OpenPortsJSON        string
+	DetectedServicesJSON string
+	PrometheusURL        string
+	NodeExporterURL      string
+	ScanAttributesJSON   string
+	TagsJSON             string
+	RTTMs                int64
 }
 
 // NoopRepository is a Repository that does nothing. It is the default when no
@@ -70,6 +157,17 @@ func (NoopRepository) RecordHeartbeats(context.Context, string, []HeartbeatSpec)
 func (NoopRepository) RecordNeighbors(context.Context, string, []NeighborSpec) error      { return nil }
 func (NoopRepository) EnrichDeviceByMAC(context.Context, string, map[string]string) error { return nil }
 func (NoopRepository) RecordTLSCerts(context.Context, string, []TLSCertRecord) error      { return nil }
+
+// ResolveDeviceIdentity reports "new device" for every call — a Noop repository
+// holds no rows, so identity resolution always signals create.
+func (NoopRepository) ResolveDeviceIdentity(context.Context, string, string, sql.NullInt64) (IdentityResolution, error) {
+	return IdentityResolution{IsNew: true}, nil
+}
+
+// ApplyDeviceIdentity is a no-op; returns 0 (no row created) and nil.
+func (NoopRepository) ApplyDeviceIdentity(context.Context, IdentityWrite) (int64, error) {
+	return 0, nil
+}
 
 // Compile-time check that NoopRepository satisfies Repository.
 var _ Repository = NoopRepository{}

--- a/internal/service/scannerv2/runner/change_detect_test.go
+++ b/internal/service/scannerv2/runner/change_detect_test.go
@@ -11,6 +11,7 @@ import (
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/store"
 	"mibee-steward/internal/testutil"
 )
 
@@ -30,6 +31,10 @@ func setupChangeDetectDB(t *testing.T) (*Runner, *db.Queries, *sql.DB) {
 
 	rn := New(nil, queries, conn, nil, 0, nil)
 	rn.networkID = nid
+	// Wire the identity repository (applyDeviceBridge delegates ResolveDeviceIdentity
+	// / ApplyDeviceIdentity to it). NetworkID is baked into the repo so identity
+	// resolution tags devices with the seeded network.
+	rn.SetRepo(store.NewSQLiteRepository(conn, store.Options{NetworkID: net.ID}, nil))
 	recorder := changedetect.NewDBRecorder(queries, nil, 0, nil)
 	rn.SetChangeRecorder(recorder)
 	return rn, queries, conn

--- a/internal/service/scannerv2/runner/device_bridge.go
+++ b/internal/service/scannerv2/runner/device_bridge.go
@@ -15,9 +15,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/domain"
@@ -143,11 +140,18 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 	// router's MAC was first seen on a transient DHCP ip (.100), then the device
 	// took over the gateway ip (.1) which a prior router still occupied.
 	mac := reportMAC(rep)
-	existingID, replacedID, roamed, err := rn.resolveDeviceIdentity(ctx, mac, rep.IP, networkID)
+	res, err := rn.repo.ResolveDeviceIdentity(ctx, mac, rep.IP, networkID)
+	if err != nil {
+		// A genuine lookup error (not the "no rows" sentinel, which ResolveDeviceIdentity
+		// surfaces as res.IsNew). Can't decide identity safely — bail without writing.
+		rn.logger.Warn("device bridge: lookup failed", "ip", rep.IP, "mac", mac, "error", err)
+		return false, false
+	}
 
-	switch err {
-	case sql.ErrNoRows:
-		devID, derr := rn.createDevice(ctx, inferredType, inferredBrand, inferredDescr, inferredLoc, rep, mac, networkID)
+	if res.IsNew {
+		iw := rn.buildIdentityWrite(rep, mac, inferredType, inferredBrand, inferredDescr, inferredLoc, networkID)
+		iw.IsNew = true
+		devID, derr := rn.repo.ApplyDeviceIdentity(ctx, iw)
 		if derr != nil {
 			rn.logger.Warn("device bridge: create device failed", "ip", rep.IP, "mac", mac, "error", derr)
 			return false, false
@@ -179,178 +183,121 @@ func (rn *Runner) applyDeviceBridge(ctx context.Context, rep scannerv2.HostRepor
 			}
 		}
 		return true, false
+	}
 
-	case nil:
-		// Change detection: capture the BEFORE snapshot before any UPDATE
-		// mutates the row. Read the full device row (the identity SELECT above
-		// only fetched id). In a replacement the before-snapshot is the OLD
-		// device's identity — exactly what we want the device_changed diff to
-		// record (e.g. name NanoPiR4S → GL-MT3000).
-		before := rn.snapshotDevice(ctx, existingID)
-		// Evidence stickiness (type only upgrades, never downgrades). A protocol-
-		// derived type (SNMP sysObjectID, RTSP/ONVIF) is authoritative and must
-		// NOT be reverted to a heuristic/"other" verdict on a later scan where the
-		// probe timed out — that re-derivation is the other↔router type-flap root
-		// cause. Trust ranking: protocol > heuristic > unknown. Only apply on a
-		// normal re-scan (replacedID==0); a device replacement force-overwrites
-		// identity (the new device's type wins), so stickiness must not hold there.
-		if replacedID == 0 && before != nil {
-			inferredType, typeSource = applyTypeStickiness(before, inferredType, typeSource)
-			rep.Device.Fields["inferred_type"] = inferredType
-			rep.Device.Fields["inferred_type_source"] = typeSource
-		}
-		// Pick the UPDATE variant: replacement force-overwrites identity fields
-		// (name/type/brand/...) because a new physical device took over the ip;
-		// a normal re-scan only fills empty/unknown fields (richer earlier scans
-		// win over shallower new ones).
-		updateSQL := buildExistingUpdate()
-		if replacedID != 0 {
-			updateSQL = buildReplacementUpdate()
-		}
-		if _, uerr := rn.dbConn.ExecContext(ctx, updateSQL,
-			existingUpdateArgs(existingID, inferredType, inferredBrand, inferredDescr, inferredLoc, rep, mac)...); uerr != nil {
-			rn.logger.Warn("device bridge: update device failed", "ip", rep.IP, "mac", mac, "error", uerr)
-		}
-		// Always set status=online for alive hosts (matches v1). Also refresh
-		// last_seen (online freshness) and stamp mac/network when newly resolved
-		// (a re-scan may have filled a previously-empty MAC after an ARP walk).
-		// In a device-replacement scenario (replacedID != 0) the target is the
-		// ip-holder whose OWN mac differs from the scanned one — overwrite it so
-		// the row reflects the device that now physically occupies that ip.
-		now := time.Now().UTC()
-		if replacedID != 0 {
-			// Replacement: force-overwrite mac on the ip-holder (it now belongs to
-			// the scanned device), and mark the prior mac-matched row offline.
-			_, _ = rn.dbConn.ExecContext(ctx, `
-				UPDATE devices SET status='online',
-				    mac_address = ?,
-				    last_seen = ?,
-				    offline_since=NULL,
-				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
-				mac, now, now, now, existingID)
-			_, _ = rn.dbConn.ExecContext(ctx,
-				`UPDATE devices SET status='offline',
-				    offline_since = CASE WHEN status != 'offline' THEN ? ELSE offline_since END,
-				    updated_at=? WHERE id=?`,
-				now, now, replacedID)
-			rn.logger.Warn("device bridge: device replaced (router/asset swap detected)",
-				"ip", rep.IP, "scanned_mac", mac, "replaced_device_id", replacedID,
-				"target_device_id", existingID,
-				"action", "ip-holder updated with new mac; prior mac-matched row marked offline")
-		} else {
-			// Normal re-scan of an existing alive device. When the device ROAMED
-			// (same MAC, new free IP — DHCP renewal), relocate ip_address to the
-			// scanned IP so the registry reflects its current address. The prior
-			// behavior of never relocating left devices stuck on stale IPs (a NAS
-			// that renewed its lease showed an IP days out of date). The before
-			// snapshot (read at :186) still holds the old IP, so the DiffIdentity
-			// check below catches ip_address as a change → emits device_changed,
-			// recording the relocation as the identity event it is.
-			ipClause := "ip_address = ip_address"
-			if roamed {
-				ipClause = "ip_address = ?"
-			}
-			_, err = rn.dbConn.ExecContext(ctx, `
-				UPDATE devices SET status='online',
-				    `+ipClause+`,
-				    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
-				    last_seen = ?,
-				    offline_since=NULL,
-				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
-				argsForRoamUpdate(roamed, rep.IP, mac, now, existingID)...)
-			if err != nil && roamed {
-				// The roam UPDATE can fail the (ip_address, network_id) unique
-				// constraint when a mac='' placeholder row occupies the target IP
-				// (the device-split scenario). Rather than silently swallowing the
-				// error (the prior bug — the roam was lost and the device stayed on
-				// its stale IP), evict the placeholder then retry. The placeholder
-				// is a mac-less stale discovery at this IP; the real device (with
-				// this MAC) is taking over, so removing it is correct.
-				rn.logger.Warn("device bridge: roam update failed, evicting ip-holder placeholder and retrying",
-					"ip", rep.IP, "device_id", existingID, "error", err)
-				if netClause, netArg := networkClause(networkID); netClause != "" {
-					_, _ = rn.dbConn.ExecContext(ctx,
-						`DELETE FROM devices WHERE ip_address = ? AND `+netClause+` AND mac_address = '' AND id != ?`,
-						append([]any{rep.IP}, append(netArg, existingID)...)...)
+	// Existing device: capture the BEFORE snapshot, apply type stickiness, then
+	// delegate the identity upsert (existing-field UPDATE + status/mac/last_seen
+	// stamping + roam relocation / replacement) to the repository.
+	existingID := res.TargetID
+	// In a replacement the before-snapshot is the OLD device's identity — exactly
+	// what we want the device_changed diff to record (e.g. name NanoPiR4S → GL-MT3000).
+	before := rn.snapshotDevice(ctx, existingID)
+	// Evidence stickiness (type only upgrades, never downgrades). A protocol-
+	// derived type (SNMP sysObjectID, RTSP/ONVIF) is authoritative and must
+	// NOT be reverted to a heuristic/"other" verdict on a later scan where the
+	// probe timed out — that re-derivation is the other↔router type-flap root
+	// cause. Trust ranking: protocol > heuristic > unknown. Only apply on a
+	// normal re-scan (ReplacedID==0); a device replacement force-overwrites
+	// identity (the new device's type wins), so stickiness must not hold there.
+	if res.ReplacedID == 0 && before != nil {
+		inferredType, typeSource = applyTypeStickiness(before, inferredType, typeSource)
+		rep.Device.Fields["inferred_type"] = inferredType
+		rep.Device.Fields["inferred_type_source"] = typeSource
+	}
+	iw := rn.buildIdentityWrite(rep, mac, inferredType, inferredBrand, inferredDescr, inferredLoc, networkID)
+	iw.TargetID = res.TargetID
+	iw.ReplacedID = res.ReplacedID
+	iw.Roamed = res.Roamed
+	if _, uerr := rn.repo.ApplyDeviceIdentity(ctx, iw); uerr != nil {
+		rn.logger.Warn("device bridge: update device failed", "ip", rep.IP, "mac", mac, "error", uerr)
+	}
+	// Change detection: re-read the AFTER snapshot and apply the TIERED
+	// model. Two separate judgments, so liveness and identity never conflate:
+	//   (a) device_recovered — a status flip offline→online. This is the
+	//       symmetric counterpart of device_lost. It fires ONLY on the
+	//       recovery transition (a scan revives a device DetectLost/lease
+	//       sweeper had marked offline), NOT on every rescan of a healthy
+	//       device (those have before.status==online already).
+	//   (b) device_changed — an IDENTITY field changed (name/type/brand/
+	//       model/mac/ip). status is deliberately excluded from this gate
+	//       (it is a liveness signal, owned by device_lost/recovered); so is
+	//       classification-field wobble (open_ports/services/scan_attributes)
+	//       which is recorded in before/after_data but doesn't trip the gate.
+	// This replaces the old all-fields Diff that fired a device_changed on
+	// every status flip — the root cause of the 70k+ noise-row storm.
+	changed := false
+	if before != nil {
+		after := rn.snapshotDevice(ctx, existingID)
+		if after != nil {
+			// (a) Recovery: offline→online. Emit device_recovered (not
+			// device_changed). before was captured ABOVE the ApplyDeviceIdentity
+			// call, so before.Status is the faithful pre-recovery value.
+			if before.Status == "offline" && after.Status == "online" {
+				var nidPtr *int64
+				if networkID.Valid {
+					v := networkID.Int64
+					nidPtr = &v
 				}
-				_, err = rn.dbConn.ExecContext(ctx, `
-					UPDATE devices SET status='online', ip_address = ?,
-					    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
-					    last_seen = ?,
-					    offline_since=NULL,
-					    last_scanned_at = ?, updated_at = ? WHERE id=?`,
-					rep.IP, mac, mac, now, now, now, existingID)
-				if err != nil {
-					rn.logger.Warn("device bridge: roam retry failed", "ip", rep.IP, "device_id", existingID, "error", err)
+				rn.recordDeviceRecovered(ctx, existingID, nidPtr, agentID, before)
+				changed = true
+			}
+			// (b) Identity change: only identity-tier fields gate device_changed.
+			if diff := changedetect.DiffIdentity(*before, *after); diff != nil {
+				rn.recordDeviceChanged(ctx, existingID, networkID, agentID, *before, *after, diff)
+				changed = true
+			}
+		}
+	}
+	// Clear the heartbeat service's failure counter for this device: the
+	// scan just proved it's alive, so a stale counter from a prior flapping
+	// window must not pull it back to offline on the next heartbeat tick.
+	if rn.heartbeat != nil {
+		rn.heartbeat.ResetFailures(existingID)
+		// Backfill heartbeat configs for pre-existing devices that were
+		// discovered before the "always seed at least ICMP" fallback existed.
+		// These hosts have been scanned repeatedly but never got a config
+		// (because no service was identified on any scan), so they show
+		// "no heartbeat" forever. Only act when the device has ZERO configs
+		// to avoid duplicating configs on devices that already have some.
+		if !rn.deviceHasHeartbeatConfig(ctx, existingID) {
+			if len(rep.Heartbeats) > 0 {
+				if herr := rn.heartbeat.CreateConfigs(ctx, existingID, rep.Heartbeats); herr != nil {
+					rn.logger.Warn("device bridge: backfill heartbeats failed", "ip", rep.IP, "error", herr)
+				}
+			} else {
+				if herr := rn.heartbeat.CreateDefaultConfig(ctx, existingID, rep.IP); herr != nil {
+					rn.logger.Warn("device bridge: backfill ICMP fallback heartbeat failed", "ip", rep.IP, "error", herr)
 				}
 			}
 		}
-		// Change detection: re-read the AFTER snapshot and apply the TIERED
-		// model. Two separate judgments, so liveness and identity never conflate:
-		//   (a) device_recovered — a status flip offline→online. This is the
-		//       symmetric counterpart of device_lost. It fires ONLY on the
-		//       recovery transition (a scan revives a device DetectLost/lease
-		//       sweeper had marked offline), NOT on every rescan of a healthy
-		//       device (those have before.status==online already).
-		//   (b) device_changed — an IDENTITY field changed (name/type/brand/
-		//       model/mac/ip). status is deliberately excluded from this gate
-		//       (it is a liveness signal, owned by device_lost/recovered); so is
-		//       classification-field wobble (open_ports/services/scan_attributes)
-		//       which is recorded in before/after_data but doesn't trip the gate.
-		// This replaces the old all-fields Diff that fired a device_changed on
-		// every status flip — the root cause of the 70k+ noise-row storm.
-		changed := false
-		if before != nil {
-			after := rn.snapshotDevice(ctx, existingID)
-			if after != nil {
-				// (a) Recovery: offline→online. Emit device_recovered (not
-				// device_changed). The before snapshot was captured at :186
-				// BEFORE the status UPDATE, so before.Status is the faithful
-				// pre-recovery value.
-				if before.Status == "offline" && after.Status == "online" {
-					var nidPtr *int64
-					if networkID.Valid {
-						v := networkID.Int64
-						nidPtr = &v
-					}
-					rn.recordDeviceRecovered(ctx, existingID, nidPtr, agentID, before)
-					changed = true
-				}
-				// (b) Identity change: only identity-tier fields gate device_changed.
-				if diff := changedetect.DiffIdentity(*before, *after); diff != nil {
-					rn.recordDeviceChanged(ctx, existingID, networkID, agentID, *before, *after, diff)
-					changed = true
-				}
-			}
-		}
-		// Clear the heartbeat service's failure counter for this device: the
-		// scan just proved it's alive, so a stale counter from a prior flapping
-		// window must not pull it back to offline on the next heartbeat tick.
-		if rn.heartbeat != nil {
-			rn.heartbeat.ResetFailures(existingID)
-			// Backfill heartbeat configs for pre-existing devices that were
-			// discovered before the "always seed at least ICMP" fallback existed.
-			// These hosts have been scanned repeatedly but never got a config
-			// (because no service was identified on any scan), so they show
-			// "no heartbeat" forever. Only act when the device has ZERO configs
-			// to avoid duplicating configs on devices that already have some.
-			if !rn.deviceHasHeartbeatConfig(ctx, existingID) {
-				if len(rep.Heartbeats) > 0 {
-					if herr := rn.heartbeat.CreateConfigs(ctx, existingID, rep.Heartbeats); herr != nil {
-						rn.logger.Warn("device bridge: backfill heartbeats failed", "ip", rep.IP, "error", herr)
-					}
-				} else {
-					if herr := rn.heartbeat.CreateDefaultConfig(ctx, existingID, rep.IP); herr != nil {
-						rn.logger.Warn("device bridge: backfill ICMP fallback heartbeat failed", "ip", rep.IP, "error", herr)
-					}
-				}
-			}
-		}
-		return false, changed
+	}
+	return false, changed
+}
 
-	default:
-		rn.logger.Warn("device bridge: lookup failed", "ip", rep.IP, "mac", mac, "error", err)
-		return false, false
+// buildIdentityWrite assembles the IdentityWrite input for ApplyDeviceIdentity
+// from a HostReport, computing the report-derived fields the store persists
+// (display name, open_ports/detected_services JSON, scan_attributes, tags). The
+// resolution fields (IsNew / TargetID / ReplacedID / Roamed) are left zero for
+// the caller to set from ResolveDeviceIdentity's result. This replaces the
+// former createDevice + existingUpdateArgs derivation that lived inline here.
+func (rn *Runner) buildIdentityWrite(rep scannerv2.HostReport, mac, devType, brand, descr, location string, networkID sql.NullInt64) scannerv2.IdentityWrite {
+	ports, services := deviceScanInfoJSON(rep)
+	return scannerv2.IdentityWrite{
+		IP:                   rep.IP,
+		MAC:                  mac,
+		NetworkID:            networkID,
+		Name:                 deviceDisplayName(rep),
+		Type:                 devType,
+		Brand:                brand,
+		Description:          descr,
+		Location:             location,
+		OpenPortsJSON:        ports,
+		DetectedServicesJSON: services,
+		PrometheusURL:        rep.Device.Fields["prometheus_url"],
+		NodeExporterURL:      rep.Device.Fields["node_exporter_url"],
+		ScanAttributesJSON:   marshalScanAttributes(buildScanAttributes(rep)),
+		TagsJSON:             buildDeviceTags(devType, brand, rep),
+		RTTMs:                rep.RTTMs,
 	}
 }
 
@@ -364,29 +311,6 @@ func (rn *Runner) snapshotDevice(ctx context.Context, deviceID int64) *changedet
 	}
 	s := changedetect.SnapshotFromDevice(d)
 	return &s
-}
-
-// networkClause returns a SQL fragment + arg for a network_id condition matching
-// the resolveDeviceIdentity pattern: "network_id = ?" when valid, or
-// "network_id IS NULL" when not (empty fragment + nil arg means "no constraint").
-func networkClause(networkID sql.NullInt64) (string, []any) {
-	if networkID.Valid {
-		return "network_id = ?", []any{networkID.Int64}
-	}
-	return "network_id IS NULL", nil
-}
-
-// argsForRoamUpdate builds the positional args for the normal-rescan status
-// UPDATE. When roamed is true the SQL has an extra `ip_address = ?` clause (the
-// scanned IP comes first); otherwise ip_address is left unchanged (the SQL uses
-// `ip_address = ip_address` with no placeholder for it).
-func argsForRoamUpdate(roamed bool, ip, mac string, now time.Time, existingID int64) []any {
-	if roamed {
-		// order matches: ip_address=?, mac_address CASE ?/?, last_seen=?, last_scanned_at=?, updated_at=?, id=?
-		return []any{ip, mac, mac, now, now, now, existingID}
-	}
-	// order matches: mac_address CASE ?/?, last_seen=?, last_scanned_at=?, updated_at=?, id=?
-	return []any{mac, mac, now, now, now, existingID}
 }
 
 // applyTypeStickiness enforces "type only upgrades, never downgrades" against
@@ -493,103 +417,6 @@ func (rn *Runner) recordDeviceChanged(ctx context.Context, deviceID int64, netwo
 	})
 }
 
-// resolveDeviceIdentity decides which existing devices row a scan should update,
-// or whether a new row must be created. It returns:
-//   - targetID: the devices.id to update (valid when err == nil)
-//   - replacedID: id of a row superseded by a device replacement (0 when none)
-//   - roamed: true when the MAC-matched device moved to a NEW free IP (DHCP
-//     roaming). The caller must relocate the row's ip_address to the scanned ip
-//     so the registry reflects the device's current address (the prior behavior
-//     of NOT relocating left devices stuck on stale IPs — a real-world bug where
-//     a NAS that renewed its DHCP lease showed an IP days out of date).
-//   - err: sql.ErrNoRows means "create a new row".
-func (rn *Runner) resolveDeviceIdentity(ctx context.Context, mac, ip string, networkID sql.NullInt64) (targetID int64, replacedID int64, roamed bool, err error) {
-	if mac == "" {
-		// No MAC → identity is (ip, network_id).
-		if networkID.Valid {
-			err = rn.dbConn.QueryRowContext(ctx,
-				`SELECT id FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`,
-				ip, networkID.Int64).Scan(&targetID)
-		} else {
-			err = rn.dbConn.QueryRowContext(ctx,
-				`SELECT id FROM devices WHERE ip_address = ? AND network_id IS NULL LIMIT 1`,
-				ip).Scan(&targetID)
-		}
-		return targetID, 0, false, err
-	}
-
-	// MAC present → global identity lookup.
-	err = rn.dbConn.QueryRowContext(ctx,
-		`SELECT id FROM devices WHERE mac_address = ? LIMIT 1`, mac).Scan(&targetID)
-	if err == sql.ErrNoRows {
-		// MAC not seen before. Fall back to (ip, network_id) with empty mac so a
-		// device first seen MAC-less gets its mac filled on this scan.
-		if networkID.Valid {
-			err = rn.dbConn.QueryRowContext(ctx,
-				`SELECT id FROM devices WHERE ip_address = ? AND network_id = ? AND mac_address = '' LIMIT 1`,
-				ip, networkID.Int64).Scan(&targetID)
-		} else {
-			err = rn.dbConn.QueryRowContext(ctx,
-				`SELECT id FROM devices WHERE ip_address = ? AND network_id IS NULL AND mac_address = '' LIMIT 1`,
-				ip).Scan(&targetID)
-		}
-		return targetID, 0, false, err
-	}
-	if err != nil {
-		return 0, 0, false, err
-	}
-
-	// MAC matched a row. Check whether it sits on the scanned ip; if so, this is
-	// the normal update path (no replacement).
-	var macRowIP string
-	var macRowMAC string
-	if qerr := rn.dbConn.QueryRowContext(ctx,
-		`SELECT ip_address, mac_address FROM devices WHERE id = ?`, targetID).Scan(&macRowIP, &macRowMAC); qerr != nil {
-		// Failing to read the row's ip is unexpected; proceed with the plain match.
-		return targetID, 0, false, nil
-	}
-	if macRowIP == ip {
-		return targetID, 0, false, nil // same ip — normal update, nothing replaced.
-	}
-
-	// MAC matched a device on a DIFFERENT ip than the one being scanned. Check
-	// whether the scanned ip is held by another device with its own different
-	// mac: that signals a device replacement (the new device took over an ip a
-	// prior device occupied).
-	var ipHolderID int64
-	var ipHolderMAC string
-	var ipLookErr error
-	if networkID.Valid {
-		ipLookErr = rn.dbConn.QueryRowContext(ctx,
-			`SELECT id, mac_address FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`,
-			ip, networkID.Int64).Scan(&ipHolderID, &ipHolderMAC)
-	} else {
-		ipLookErr = rn.dbConn.QueryRowContext(ctx,
-			`SELECT id, mac_address FROM devices WHERE ip_address = ? AND network_id IS NULL LIMIT 1`,
-			ip).Scan(&ipHolderID, &ipHolderMAC)
-	}
-	if ipLookErr == sql.ErrNoRows {
-		// Scanned ip is free → roaming: the MAC-matched device moved to a new IP
-		// (DHCP renewal/re-lease). Keep it as one asset (targetID), but signal
-		// roamed=true so the caller relocates ip_address to the scanned ip. The
-		// old behavior of NOT relocating left devices stuck on stale IPs.
-		return targetID, 0, true, nil
-	}
-	if ipLookErr != nil {
-		// Lookup error → don't speculate; fall back to the plain MAC match.
-		return targetID, 0, false, nil
-	}
-	// Replacement requires the ip-holder to have its OWN mac differing from the
-	// scanned one. An empty-mac ip-holder is a MAC-less placeholder (rule 2):
-	// leave it to be filled, do not treat as a replacement conflict.
-	if ipHolderMAC == "" || ipHolderMAC == mac {
-		return targetID, 0, false, nil
-	}
-	// Device replacement: the ip-holder becomes the target, the MAC-matched row
-	// (the prior asset now sitting on a stale ip) is superseded.
-	return ipHolderID, targetID, false, nil
-}
-
 // reportMAC extracts and canonicalizes the MAC from a HostReport. It checks the
 // device Fields first (handler-enriched), then falls back to mac-kind evidence
 // (ARP/router-ARP probe output). Returns "" when no MAC was observed.
@@ -646,130 +473,6 @@ func deviceDisplayName(rep scannerv2.HostReport) string {
 		return h
 	}
 	return rep.IP
-}
-
-// createDevice inserts a new device row derived from the report. networkID is
-// the per-call origin network (the agent's network on the center ingestion
-// path, the instance's own network on the local scan path).
-func (rn *Runner) createDevice(ctx context.Context, devType, brand, descr, location string, rep scannerv2.HostReport, mac string, networkID sql.NullInt64) (int64, error) {
-	name := deviceDisplayName(rep)
-	if devType == "" {
-		devType = "other"
-	}
-	ports, services := deviceScanInfoJSON(rep)
-	promURL := rep.Device.Fields["prometheus_url"]
-	neURL := rep.Device.Fields["node_exporter_url"]
-	tags := buildDeviceTags(devType, brand, rep)
-	scanAttrs := marshalScanAttributes(buildScanAttributes(rep))
-	now := time.Now().UTC()
-	res, err := rn.dbConn.ExecContext(ctx, `
-		INSERT INTO devices (device_uuid, name, type, brand, ip_address, mac_address,
-		                     status, scan_source, description, location,
-		                     open_ports, detected_services, prometheus_url, node_exporter_url,
-		                     scan_attributes, network_id, first_seen, last_seen,
-		                     tags, last_scan_rtt_ms, last_scanned_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?,
-		        'online', 'scanner_v2', ?, ?,
-		        ?, ?, ?, ?,
-		        ?, ?, ?, ?,
-		        ?, ?, ?, ?, ?)`,
-		uuid.NewString(), name, devType, brand, rep.IP, mac,
-		descr, location,
-		ports, services, promURL, neURL,
-		scanAttrs, networkID, now, now,
-		tags, rep.RTTMs, now, now, now)
-	if err != nil {
-		return 0, err
-	}
-	id, _ := res.LastInsertId()
-	return id, nil
-}
-
-// buildExistingUpdate returns the static UPDATE statement for an existing
-// device. The positional args are assembled separately in existingUpdateArgs.
-//
-// scan_attributes uses json_patch (not a blind overwrite) so a SHALLOW scan
-// can't erase fields a DEEPER earlier scan (or passive discovery) collected:
-// json_patch(old, new) keeps old's keys that new omits. Because every field on
-// ScanAttributes is `omitempty`, a scan that didn't collect (say) a hostname
-// emits a JSON object WITHOUT a hostname key, and the patch preserves the prior
-// value. Slice fields (open_ports/detected_services) are still whole-replaced
-// when present — they reflect "what THIS scan saw open", not a union across
-// scans (a port that closed should drop off). Issue #20.
-func buildExistingUpdate() string {
-	return `
-		UPDATE devices SET
-		    name = CASE WHEN (name = '' OR name = ip_address) THEN ? ELSE name END,
-		    type = CASE WHEN (type = '' OR type = 'unknown' OR type = 'other') AND ? != '' THEN ? ELSE type END,
-		    brand = CASE WHEN (brand = '' OR brand = 'unknown') AND ? != '' THEN ? ELSE brand END,
-		    description = CASE WHEN (description = '' OR description = 'unknown') AND ? != '' THEN ? ELSE description END,
-		    location = CASE WHEN (location = '' OR location = 'unknown') AND ? != '' THEN ? ELSE location END,
-		    open_ports = ?,
-		    detected_services = ?,
-		    prometheus_url = CASE WHEN ? != '' THEN ? ELSE prometheus_url END,
-		    node_exporter_url = CASE WHEN ? != '' THEN ? ELSE node_exporter_url END,
-		    scan_attributes = json_patch(scan_attributes, ?),
-		    last_scan_rtt_ms = ?,
-		    last_scanned_at = ?,
-		    updated_at = ?
-		WHERE id = ?`
-}
-
-// buildReplacementUpdate returns the UPDATE for the device-REPLACEMENT case (a
-// different physical device now occupies this ip). Unlike buildExistingUpdate it
-// FORCE-OVERWRITES name/type/brand/description/location — the CASE "only fill
-// empty/unknown" guards that protect a re-scan from clobbering a richer earlier
-// scan would be WRONG here: this is a brand-new device, so its identity fields
-// must fully replace the prior device's. The before/after change-detection diff
-// captures the old→new values as a device_changed event (that is where the
-// historical "what it was" lives), so the device row itself always reflects the
-// current truth.
-//
-// Shares the SAME positional arg order as buildExistingUpdate, so it reuses
-// existingUpdateArgs.
-func buildReplacementUpdate() string {
-	return `
-		UPDATE devices SET
-		    name = ?,
-		    type = CASE WHEN ? != '' THEN ? ELSE type END,
-		    brand = CASE WHEN ? != '' THEN ? ELSE brand END,
-		    description = CASE WHEN ? != '' THEN ? ELSE description END,
-		    location = CASE WHEN ? != '' THEN ? ELSE location END,
-		    open_ports = ?,
-		    detected_services = ?,
-		    prometheus_url = CASE WHEN ? != '' THEN ? ELSE prometheus_url END,
-		    node_exporter_url = CASE WHEN ? != '' THEN ? ELSE node_exporter_url END,
-		    scan_attributes = json_patch(scan_attributes, ?),
-		    last_scan_rtt_ms = ?,
-		    last_scanned_at = ?,
-		    updated_at = ?
-		WHERE id = ?`
-}
-
-// existingUpdateArgs builds the positional args matching buildExistingUpdate's
-// placeholder order. (MAC/network_id/last_seen are stamped in a separate UPDATE
-// in applyDeviceBridge so the identity fields update on every scan, not just
-// when the CASE-when-empty conditions in this statement happen to fire.)
-//
-// The SAME arg order also matches buildReplacementUpdate — both statements share
-// the placeholder layout for the columns they have in common.
-func existingUpdateArgs(id int64, inferredType, brand, descr, location string, rep scannerv2.HostReport, _ string) []any {
-	ports, services := deviceScanInfoJSON(rep)
-	promURL := rep.Device.Fields["prometheus_url"]
-	neURL := rep.Device.Fields["node_exporter_url"]
-	scanAttrs := marshalScanAttributes(buildScanAttributes(rep))
-	now := time.Now().UTC()
-	return []any{
-		deviceDisplayName(rep), inferredType, inferredType,
-		brand, brand,
-		descr, descr,
-		location, location,
-		ports, services,
-		promURL, promURL,
-		neURL, neURL,
-		scanAttrs,
-		rep.RTTMs, now, now, id,
-	}
 }
 
 // deviceScanInfoJSON returns the open_ports + detected_services JSON for the

--- a/internal/service/scannerv2/runner/device_bridge_baseline_test.go
+++ b/internal/service/scannerv2/runner/device_bridge_baseline_test.go
@@ -188,7 +188,8 @@ func TestApplyDeviceBridge_NullNetworkID(t *testing.T) {
 	queries := db.New(conn)
 	// Runner with NO network (mirrors standalone pre-network-config startup).
 	rn := New(nil, queries, conn, nil, 0, nil)
-	rn.networkID = sql.NullInt64{} // explicit: NULL network
+	rn.networkID = sql.NullInt64{}                                    // explicit: NULL network
+	rn.SetRepo(store.NewSQLiteRepository(conn, store.Options{}, nil)) // NULL-network identity repo
 	rn.SetChangeRecorder(changedetect.NewDBRecorder(queries, nil, 0, nil))
 	ctx := context.Background()
 

--- a/internal/service/scannerv2/runner/device_type_test.go
+++ b/internal/service/scannerv2/runner/device_type_test.go
@@ -20,6 +20,7 @@ import (
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/store"
 	"mibee-steward/internal/testutil"
 )
 
@@ -277,6 +278,7 @@ func setupTypeTestDB(t *testing.T) (*Runner, *db.Queries, *sql.DB) {
 
 	rn := New(nil, queries, conn, nil, 0, nil)
 	rn.networkID = nid
+	rn.SetRepo(store.NewSQLiteRepository(conn, store.Options{NetworkID: net.ID}, nil))
 	rn.SetChangeRecorder(changedetect.NewDBRecorder(queries, nil, 0, nil))
 	return rn, queries, conn
 }

--- a/internal/service/scannerv2/runner/lease_sweeper_test.go
+++ b/internal/service/scannerv2/runner/lease_sweeper_test.go
@@ -12,6 +12,7 @@ import (
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/store"
 	"mibee-steward/internal/testutil"
 )
 
@@ -36,6 +37,10 @@ func setupLeaseTestDB(t *testing.T) (*Runner, *db.Queries, *sql.DB, int64, int64
 	require.NoError(t, err)
 
 	rn := New(nil, queries, conn, nil, 0, nil)
+	// Identity repo: the lease tests drive applyDeviceBridge with a per-call
+	// networkID (center or agent), so the repo's own NetworkID is unused by the
+	// identity methods (they take the per-call value).
+	rn.SetRepo(store.NewSQLiteRepository(conn, store.Options{}, nil))
 	recorder := changedetect.NewDBRecorder(queries, nil, 0, nil)
 	rn.SetChangeRecorder(recorder)
 	return rn, queries, conn, centerNet.ID, agentNet.ID

--- a/internal/service/scannerv2/runner/runner.go
+++ b/internal/service/scannerv2/runner/runner.go
@@ -77,6 +77,12 @@ type Runner struct {
 	// applyDeviceBridge (and device_lost from detectLost). nil on the agent
 	// (change detection is a center concern). See internal/changedetect.
 	changeRecorder changedetect.ChangeRecorder
+	// repo is the scannerv2.Repository used by applyDeviceBridge for device
+	// identity resolution + upsert (ResolveDeviceIdentity / ApplyDeviceIdentity).
+	// Injected via SetRepo (mirrors SetChangeRecorder). May be NoopRepository in
+	// tests that don't exercise identity. dbConn remains for the non-identity
+	// raw-SQL paths (detect_lost, lease sweeper, topology, subnets).
+	repo scannerv2.Repository
 	// lostThreshold is the number of consecutive scans a device must be absent
 	// from the alive set before being declared "lost" by DetectLost. Default 2
 	// (single missed scans must not flap a device offline). Configurable via
@@ -100,6 +106,14 @@ func (rn *Runner) SetReportSink(s ReportSink) { rn.reportSink = s }
 // change_log + pushes Watcher subscribers). nil clears it (agent mode, where
 // change detection is deferred to the center). Must be called before Run.
 func (rn *Runner) SetChangeRecorder(r changedetect.ChangeRecorder) { rn.changeRecorder = r }
+
+// SetRepo wires the scannerv2.Repository used by applyDeviceBridge for device
+// identity resolution + upsert (the single authoritative identity writer). Must
+// be called before any scan/ApplyReport; not safe to swap concurrently with a
+// running scan. Tests construct the runner with New(nil, ...) and MUST call
+// SetRepo before exercising applyDeviceBridge (the engine is nil there, so the
+// repo can't be inferred from it).
+func (rn *Runner) SetRepo(r scannerv2.Repository) { rn.repo = r }
 
 // New constructs a Runner. engine may be nil (the runner will log and no-op on
 // each Run), letting the scheduler stay alive even if the engine failed to init.

--- a/internal/service/scannerv2/runner/scan_attributes_merge_test.go
+++ b/internal/service/scannerv2/runner/scan_attributes_merge_test.go
@@ -19,6 +19,7 @@ import (
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/store"
 	"mibee-steward/internal/testutil"
 )
 
@@ -35,6 +36,7 @@ func setupScanAttrsTestDB(t *testing.T) (*Runner, *sql.DB) {
 	nid := sql.NullInt64{Int64: net.ID, Valid: true}
 	rn := New(nil, queries, conn, nil, 0, nil)
 	rn.networkID = nid
+	rn.SetRepo(store.NewSQLiteRepository(conn, store.Options{NetworkID: net.ID}, nil))
 	rn.SetChangeRecorder(changedetect.NewDBRecorder(queries, nil, 0, nil))
 	return rn, conn
 }

--- a/internal/service/scannerv2/store/identity_test.go
+++ b/internal/service/scannerv2/store/identity_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise ResolveDeviceIdentity directly against *SQLiteRepository
+// — the interface-level contract for the device-identity resolver (#159). They
+// lock the MAC-primary / (ip, network_id) fallback / roam / replacement rules
+// WITHOUT going through runner.applyDeviceBridge, so a future second Repository
+// implementation (the distributed伏笔) can be validated against the same
+// contract. The runner-level behavior is covered by the characterization tests
+// in runner/device_bridge_baseline_test.go.
+
+// resolveRepo builds a repo over a fresh in-memory DB and seeds a network row,
+// returning the repo, the network's NullInt64, the underlying db (for seeding),
+// and a context.
+func resolveRepo(t *testing.T, networkID int64) (*SQLiteRepository, sql.NullInt64, *sql.DB, context.Context) {
+	t.Helper()
+	repo, ctx := newRepo(t, Options{NetworkID: networkID})
+	var nid sql.NullInt64
+	if networkID > 0 {
+		if _, err := repo.db.Exec(`INSERT INTO networks (id, name, cidr, site, created_at, updated_at)
+			VALUES (?, 'n', '10.0.0.0/24', 's', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`, networkID); err != nil {
+			t.Fatalf("seed network: %v", err)
+		}
+		nid = sql.NullInt64{Int64: networkID, Valid: true}
+	}
+	return repo, nid, repo.db, ctx
+}
+
+func TestResolveDeviceIdentity_NoMAC_NewRow(t *testing.T) {
+	repo, nid, _, ctx := resolveRepo(t, 1)
+	res, err := repo.ResolveDeviceIdentity(ctx, "", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.True(t, res.IsNew, "no MAC and no existing (ip,network) row → IsNew")
+	require.Zero(t, res.TargetID)
+}
+
+func TestResolveDeviceIdentity_NoMAC_MatchesByIPNetwork(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	id := seedDeviceRow(t, db, "10.0.0.5", "", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.False(t, res.IsNew)
+	require.Equal(t, id, res.TargetID, "no MAC → identity is (ip, network_id)")
+	require.Zero(t, res.ReplacedID)
+	require.False(t, res.Roamed)
+}
+
+func TestResolveDeviceIdentity_MACMatch_SameIP_NormalUpdate(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	id := seedDeviceRow(t, db, "10.0.0.5", "aa:bb:cc:dd:ee:01", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:01", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.Equal(t, id, res.TargetID)
+	require.False(t, res.Roamed, "same IP → normal update, not a roam")
+	require.Zero(t, res.ReplacedID)
+}
+
+func TestResolveDeviceIdentity_MACMatch_NewFreeIP_IsRoam(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	// Device known at .5 by MAC; scans now see it at .9 (free IP) → DHCP roam.
+	id := seedDeviceRow(t, db, "10.0.0.5", "aa:bb:cc:dd:ee:01", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:01", "10.0.0.9", nid)
+	require.NoError(t, err)
+	require.Equal(t, id, res.TargetID)
+	require.True(t, res.Roamed, "MAC matched a device whose old IP is now free → roam")
+	require.Zero(t, res.ReplacedID)
+}
+
+func TestResolveDeviceIdentity_MACMatch_DifferentMACHoldsIP_IsReplacement(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	// Prior asset known by MAC-A at .100 (a stale/transient IP).
+	priorID := seedDeviceRow(t, db, "10.0.0.100", "aa:bb:cc:dd:ee:01", nid)
+	// A different device (MAC-B) now occupies the scanned IP .5.
+	holderID := seedDeviceRow(t, db, "10.0.0.5", "bb:bb:bb:bb:bb:02", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:01", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.Equal(t, holderID, res.TargetID, "the IP-holder becomes the update target")
+	require.Equal(t, priorID, res.ReplacedID, "the prior MAC-matched row is superseded")
+	require.False(t, res.Roamed)
+}
+
+func TestResolveDeviceIdentity_MACMatch_EmptyMACHolder_NotReplacement(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	// Device known by MAC-A at .100 (a different IP than the scan target).
+	id := seedDeviceRow(t, db, "10.0.0.100", "aa:bb:cc:dd:ee:01", nid)
+	// The scanned IP .5 is held by a MAC-less placeholder (a stale mac-less
+	// discovery). This is NOT a replacement — the placeholder should be filled,
+	// not treated as a conflict.
+	seedDeviceRow(t, db, "10.0.0.5", "", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:01", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.Equal(t, id, res.TargetID, "MAC match wins; empty-mac holder is not a replacement")
+	require.Zero(t, res.ReplacedID)
+}
+
+func TestResolveDeviceIdentity_MACUnseen_FallsBackToIPEmptyMAC(t *testing.T) {
+	repo, nid, db, ctx := resolveRepo(t, 1)
+	// A MAC-less placeholder exists at .5; a later scan with a fresh MAC for .5
+	// must match the placeholder (so its mac gets filled), not be flagged IsNew.
+	id := seedDeviceRow(t, db, "10.0.0.5", "", nid)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:09", "10.0.0.5", nid)
+	require.NoError(t, err)
+	require.False(t, res.IsNew)
+	require.Equal(t, id, res.TargetID, "unseen MAC falls back to (ip, network_id, mac='')")
+}
+
+func TestResolveDeviceIdentity_NullNetwork_Branches(t *testing.T) {
+	// Legacy single-instance path: networkID invalid → the network_id IS NULL
+	// branches. A device with NULL network_id must resolve; a device on a
+	// non-zero network must NOT match (cross-network isolation).
+	repo, _, db, ctx := resolveRepo(t, 0) // NetworkID 0 → NULL network
+	nullNID := sql.NullInt64{}
+	id := seedDeviceRow(t, db, "172.16.0.5", "aa:bb:cc:dd:ee:0a", nullNID)
+	res, err := repo.ResolveDeviceIdentity(ctx, "aa:bb:cc:dd:ee:0a", "172.16.0.5", nullNID)
+	require.NoError(t, err)
+	require.Equal(t, id, res.TargetID, "NULL-network device resolves on the legacy path")
+
+	// A device on network 1 must NOT match a NULL-network resolve (isolation).
+	seedDeviceRow(t, db, "172.16.0.5", "cc:cc:cc:cc:cc:0c", sql.NullInt64{Int64: 1, Valid: true})
+	res, err = repo.ResolveDeviceIdentity(ctx, "", "172.16.0.5", nullNID)
+	require.NoError(t, err)
+	require.Equal(t, id, res.TargetID, "NULL-network resolve matches only NULL-network rows")
+}

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -33,6 +33,8 @@ import (
 	"mibee-steward/internal/domain"
 
 	"mibee-steward/internal/service/scannerv2"
+
+	"github.com/google/uuid"
 )
 
 // SQLiteRepository implements scannerv2.Repository against a *sql.DB.
@@ -460,6 +462,328 @@ func (r *SQLiteRepository) RecordDevice(ctx context.Context, ip string, d scanne
 	}
 
 	return tx.Commit()
+}
+
+// identityNetworkClause returns the SQL fragment + arg matching the
+// resolveDeviceIdentity / ApplyDeviceIdentity network scoping: "network_id = ?"
+// when the per-call network is valid, "network_id IS NULL" when not. Unlike
+// RecordDevice (which uses the repository's own r.networkID field), the identity
+// methods take a per-call networkID so a center ingesting many agents' networks
+// resolves each against the agent's own network.
+func identityNetworkClause(networkID sql.NullInt64) (string, []any) {
+	if networkID.Valid {
+		return "network_id = ?", []any{networkID.Int64}
+	}
+	return "network_id IS NULL", nil
+}
+
+// ResolveDeviceIdentity is the read-only half of the MAC-primary identity
+// upsert. It is the single authoritative resolver for which devices row a scan
+// should update (or whether a new row must be created), ported verbatim from the
+// former runner.resolveDeviceIdentity. See Repository.ResolveDeviceIdentity for
+// the contract; the IsNew field replaces the former sql.ErrNoRows sentinel so
+// callers switch on a value, not an error.
+//
+// networkID is per-call (the agent's network on the center ingestion path, the
+// instance's own network locally) — it is NOT r.networkID, so one center
+// repository can resolve identities across many networks.
+func (r *SQLiteRepository) ResolveDeviceIdentity(ctx context.Context, mac, ip string, networkID sql.NullInt64) (scannerv2.IdentityResolution, error) {
+	if mac == "" {
+		// No MAC → identity is (ip, network_id).
+		var targetID int64
+		var err error
+		if networkID.Valid {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT id FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`,
+				ip, networkID.Int64).Scan(&targetID)
+		} else {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT id FROM devices WHERE ip_address = ? AND network_id IS NULL LIMIT 1`,
+				ip).Scan(&targetID)
+		}
+		if err == sql.ErrNoRows {
+			return scannerv2.IdentityResolution{IsNew: true}, nil
+		}
+		if err != nil {
+			return scannerv2.IdentityResolution{}, err
+		}
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil
+	}
+
+	// MAC present → global identity lookup.
+	var targetID int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id FROM devices WHERE mac_address = ? LIMIT 1`, mac).Scan(&targetID)
+	if err == sql.ErrNoRows {
+		// MAC not seen before. Fall back to (ip, network_id) with empty mac so a
+		// device first seen MAC-less gets its mac filled on this scan.
+		if networkID.Valid {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT id FROM devices WHERE ip_address = ? AND network_id = ? AND mac_address = '' LIMIT 1`,
+				ip, networkID.Int64).Scan(&targetID)
+		} else {
+			err = r.db.QueryRowContext(ctx,
+				`SELECT id FROM devices WHERE ip_address = ? AND network_id IS NULL AND mac_address = '' LIMIT 1`,
+				ip).Scan(&targetID)
+		}
+		if err == sql.ErrNoRows {
+			return scannerv2.IdentityResolution{IsNew: true}, nil
+		}
+		if err != nil {
+			return scannerv2.IdentityResolution{}, err
+		}
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil
+	}
+	if err != nil {
+		return scannerv2.IdentityResolution{}, err
+	}
+
+	// MAC matched a row. Check whether it sits on the scanned ip; if so, this is
+	// the normal update path (no replacement).
+	var macRowIP string
+	var macRowMAC string
+	if qerr := r.db.QueryRowContext(ctx,
+		`SELECT ip_address, mac_address FROM devices WHERE id = ?`, targetID).Scan(&macRowIP, &macRowMAC); qerr != nil {
+		// Failing to read the row's ip is unexpected; proceed with the plain match.
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil
+	}
+	if macRowIP == ip {
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil // same ip — normal update.
+	}
+
+	// MAC matched a device on a DIFFERENT ip than the one being scanned. Check
+	// whether the scanned ip is held by another device with its own different
+	// mac: that signals a device replacement.
+	var ipHolderID int64
+	var ipHolderMAC string
+	var ipLookErr error
+	if networkID.Valid {
+		ipLookErr = r.db.QueryRowContext(ctx,
+			`SELECT id, mac_address FROM devices WHERE ip_address = ? AND network_id = ? LIMIT 1`,
+			ip, networkID.Int64).Scan(&ipHolderID, &ipHolderMAC)
+	} else {
+		ipLookErr = r.db.QueryRowContext(ctx,
+			`SELECT id, mac_address FROM devices WHERE ip_address = ? AND network_id IS NULL LIMIT 1`,
+			ip).Scan(&ipHolderID, &ipHolderMAC)
+	}
+	if ipLookErr == sql.ErrNoRows {
+		// Scanned ip is free → roaming: the MAC-matched device moved to a new IP.
+		return scannerv2.IdentityResolution{TargetID: targetID, Roamed: true}, nil
+	}
+	if ipLookErr != nil {
+		// Lookup error → don't speculate; fall back to the plain MAC match.
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil
+	}
+	// Replacement requires the ip-holder to have its OWN mac differing from the
+	// scanned one. An empty-mac ip-holder is a MAC-less placeholder: leave it to
+	// be filled, do not treat as a replacement conflict.
+	if ipHolderMAC == "" || ipHolderMAC == mac {
+		return scannerv2.IdentityResolution{TargetID: targetID}, nil
+	}
+	// Device replacement: the ip-holder becomes the target, the MAC-matched row
+	// (the prior asset now sitting on a stale ip) is superseded.
+	return scannerv2.IdentityResolution{TargetID: ipHolderID, ReplacedID: targetID}, nil
+}
+
+// existingIdentityUpdate is the static UPDATE for an existing device (normal
+// rescan). Ported verbatim from the former runner.buildExistingUpdate. Positional
+// args are assembled in identityUpdateArgs. scan_attributes uses json_patch (not a
+// blind overwrite) so a SHALLOW scan can't erase fields a DEEPER earlier scan
+// collected: json_patch(old, new) keeps old's keys that new omits.
+func existingIdentityUpdate() string {
+	return `
+		UPDATE devices SET
+		    name = CASE WHEN (name = '' OR name = ip_address) THEN ? ELSE name END,
+		    type = CASE WHEN (type = '' OR type = 'unknown' OR type = 'other') AND ? != '' THEN ? ELSE type END,
+		    brand = CASE WHEN (brand = '' OR brand = 'unknown') AND ? != '' THEN ? ELSE brand END,
+		    description = CASE WHEN (description = '' OR description = 'unknown') AND ? != '' THEN ? ELSE description END,
+		    location = CASE WHEN (location = '' OR location = 'unknown') AND ? != '' THEN ? ELSE location END,
+		    open_ports = ?,
+		    detected_services = ?,
+		    prometheus_url = CASE WHEN ? != '' THEN ? ELSE prometheus_url END,
+		    node_exporter_url = CASE WHEN ? != '' THEN ? ELSE node_exporter_url END,
+		    scan_attributes = json_patch(scan_attributes, ?),
+		    last_scan_rtt_ms = ?,
+		    last_scanned_at = ?,
+		    updated_at = ?
+		WHERE id = ?`
+}
+
+// replacementIdentityUpdate is the UPDATE for the device-REPLACEMENT case (a
+// different physical device now occupies this ip). FORCE-OVERWRITES
+// name/type/brand/description/location — the CASE "only fill empty/unknown"
+// guards that protect a re-scan would be WRONG here. Ported verbatim from the
+// former runner.buildReplacementUpdate. Shares the SAME positional arg order as
+// existingIdentityUpdate, so it reuses identityUpdateArgs.
+func replacementIdentityUpdate() string {
+	return `
+		UPDATE devices SET
+		    name = ?,
+		    type = CASE WHEN ? != '' THEN ? ELSE type END,
+		    brand = CASE WHEN ? != '' THEN ? ELSE brand END,
+		    description = CASE WHEN ? != '' THEN ? ELSE description END,
+		    location = CASE WHEN ? != '' THEN ? ELSE location END,
+		    open_ports = ?,
+		    detected_services = ?,
+		    prometheus_url = CASE WHEN ? != '' THEN ? ELSE prometheus_url END,
+		    node_exporter_url = CASE WHEN ? != '' THEN ? ELSE node_exporter_url END,
+		    scan_attributes = json_patch(scan_attributes, ?),
+		    last_scan_rtt_ms = ?,
+		    last_scanned_at = ?,
+		    updated_at = ?
+		WHERE id = ?`
+}
+
+// identityUpdateArgs builds the positional args matching both
+// existingIdentityUpdate and replacementIdentityUpdate (they share the same
+// placeholder layout for the columns they have in common). Values come from the
+// IdentityWrite (the runner pre-computes name/JSON blobs/type before calling).
+func identityUpdateArgs(in scannerv2.IdentityWrite, now time.Time) []any {
+	return []any{
+		in.Name, in.Type, in.Type,
+		in.Brand, in.Brand,
+		in.Description, in.Description,
+		in.Location, in.Location,
+		in.OpenPortsJSON, in.DetectedServicesJSON,
+		in.PrometheusURL, in.PrometheusURL,
+		in.NodeExporterURL, in.NodeExporterURL,
+		in.ScanAttributesJSON,
+		in.RTTMs, now, now, in.TargetID,
+	}
+}
+
+// ApplyDeviceIdentity commits the identity upsert. Ported verbatim from the
+// former runner.createDevice + the status/mac/roam/replacement UPDATE blocks of
+// runner.applyDeviceBridge: creates a new row (in.IsNew) or updates the resolved
+// row (normal rescan / replacement when ReplacedID != 0 / roam when Roamed),
+// then stamps status/mac/last_seen and runs the roam eviction-retry. No
+// transaction (mirrors the former best-effort, log-and-continue semantics). See
+// Repository.ApplyDeviceIdentity for the contract.
+func (r *SQLiteRepository) ApplyDeviceIdentity(ctx context.Context, in scannerv2.IdentityWrite) (int64, error) {
+	if in.IsNew {
+		return r.createDeviceIdentity(ctx, in)
+	}
+	return r.updateDeviceIdentity(ctx, in)
+}
+
+// createDeviceIdentity inserts a new device row. Ported verbatim from the former
+// runner.createDevice; the values arrive pre-computed in the IdentityWrite.
+func (r *SQLiteRepository) createDeviceIdentity(ctx context.Context, in scannerv2.IdentityWrite) (int64, error) {
+	devType := in.Type
+	if devType == "" {
+		devType = "other"
+	}
+	now := time.Now().UTC()
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO devices (device_uuid, name, type, brand, ip_address, mac_address,
+		                     status, scan_source, description, location,
+		                     open_ports, detected_services, prometheus_url, node_exporter_url,
+		                     scan_attributes, network_id, first_seen, last_seen,
+		                     tags, last_scan_rtt_ms, last_scanned_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?,
+		        'online', 'scanner_v2', ?, ?,
+		        ?, ?, ?, ?,
+		        ?, ?, ?, ?,
+		        ?, ?, ?, ?, ?)`,
+		uuid.NewString(), in.Name, devType, in.Brand, in.IP, in.MAC,
+		in.Description, in.Location,
+		in.OpenPortsJSON, in.DetectedServicesJSON, in.PrometheusURL, in.NodeExporterURL,
+		in.ScanAttributesJSON, in.NetworkID, now, now,
+		in.TagsJSON, in.RTTMs, now, now, now)
+	if err != nil {
+		return 0, err
+	}
+	id, _ := res.LastInsertId()
+	return id, nil
+}
+
+// updateDeviceIdentity updates an existing resolved row: the identity-field
+// UPDATE (existing vs replacement variant) followed by the status/mac/last_seen
+// stamping and roam eviction-retry. Ported verbatim from the former
+// runner.applyDeviceBridge existing-device branch.
+func (r *SQLiteRepository) updateDeviceIdentity(ctx context.Context, in scannerv2.IdentityWrite) (int64, error) {
+	// 1. Identity-field UPDATE (existing vs replacement variant).
+	updateSQL := existingIdentityUpdate()
+	if in.ReplacedID != 0 {
+		updateSQL = replacementIdentityUpdate()
+	}
+	now := time.Now().UTC()
+	if _, uerr := r.db.ExecContext(ctx, updateSQL, identityUpdateArgs(in, now)...); uerr != nil {
+		r.logger.Warn("device identity: update device failed", "ip", in.IP, "mac", in.MAC, "error", uerr)
+	}
+
+	// 2. Status/mac/last_seen stamping + roam relocation / replacement offline.
+	if in.ReplacedID != 0 {
+		// Replacement: force-overwrite mac on the ip-holder (it now belongs to the
+		// scanned device), and mark the prior mac-matched row offline.
+		_, _ = r.db.ExecContext(ctx, `
+			UPDATE devices SET status='online',
+			    mac_address = ?,
+			    last_seen = ?,
+			    offline_since=NULL,
+			    last_scanned_at = ?, updated_at = ? WHERE id=?`,
+			in.MAC, now, now, now, in.TargetID)
+		_, _ = r.db.ExecContext(ctx,
+			`UPDATE devices SET status='offline',
+			    offline_since = CASE WHEN status != 'offline' THEN ? ELSE offline_since END,
+			    updated_at=? WHERE id=?`,
+			now, now, in.ReplacedID)
+		r.logger.Warn("device identity: device replaced (router/asset swap detected)",
+			"ip", in.IP, "scanned_mac", in.MAC, "replaced_device_id", in.ReplacedID,
+			"target_device_id", in.TargetID,
+			"action", "ip-holder updated with new mac; prior mac-matched row marked offline")
+	} else {
+		// Normal re-scan. When the device ROAMED (same MAC, new free IP — DHCP
+		// renewal), relocate ip_address to the scanned IP.
+		ipClause := "ip_address = ip_address"
+		if in.Roamed {
+			ipClause = "ip_address = ?"
+		}
+		_, err := r.db.ExecContext(ctx, `
+			UPDATE devices SET status='online',
+			    `+ipClause+`,
+			    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
+			    last_seen = ?,
+			    offline_since=NULL,
+			    last_scanned_at = ?, updated_at = ? WHERE id=?`,
+			roamUpdateArgs(in.Roamed, in.IP, in.MAC, now, in.TargetID)...)
+		if err != nil && in.Roamed {
+			// The roam UPDATE can fail the (ip_address, network_id) unique constraint
+			// when a mac='' placeholder occupies the target IP. Evict the placeholder
+			// then retry (the real device with this MAC is taking over).
+			r.logger.Warn("device identity: roam update failed, evicting ip-holder placeholder and retrying",
+				"ip", in.IP, "device_id", in.TargetID, "error", err)
+			if netClause, netArg := identityNetworkClause(in.NetworkID); netClause != "" {
+				_, _ = r.db.ExecContext(ctx,
+					`DELETE FROM devices WHERE ip_address = ? AND `+netClause+` AND mac_address = '' AND id != ?`,
+					append([]any{in.IP}, append(netArg, in.TargetID)...)...)
+			}
+			_, err = r.db.ExecContext(ctx, `
+				UPDATE devices SET status='online', ip_address = ?,
+				    mac_address = CASE WHEN ? != '' AND mac_address = '' THEN ? ELSE mac_address END,
+				    last_seen = ?,
+				    offline_since=NULL,
+				    last_scanned_at = ?, updated_at = ? WHERE id=?`,
+				in.IP, in.MAC, in.MAC, now, now, now, in.TargetID)
+			if err != nil {
+				r.logger.Warn("device identity: roam retry failed", "ip", in.IP, "device_id", in.TargetID, "error", err)
+			}
+		}
+	}
+	return in.TargetID, nil
+}
+
+// roamUpdateArgs builds the positional args for the normal-rescan status UPDATE
+// (mirrors the former runner.argsForRoamUpdate). When roamed is true the SQL has
+// an extra `ip_address = ?` clause (the scanned IP comes first); otherwise
+// ip_address is left unchanged.
+func roamUpdateArgs(roamed bool, ip, mac string, now time.Time, existingID int64) []any {
+	if roamed {
+		// order: ip_address=?, mac CASE ?/?, last_seen=?, last_scanned_at=?, updated_at=?, id=?
+		return []any{ip, mac, mac, now, now, now, existingID}
+	}
+	// order: mac CASE ?/?, last_seen=?, last_scanned_at=?, updated_at=?, id=?
+	return []any{mac, mac, now, now, now, existingID}
 }
 
 // NormalizeMAC canonicalizes a MAC address for storage and lookup: lowercased


### PR DESCRIPTION
## 背景

Refs #159。这是 #159（消除 device_bridge.go 唯一的 off-seam 身份写入路径）的 **PR 2/2 —— 真正的迁移**。PR 1/2（#201）已用 6 个 characterization 测试锁住当前行为，本 PR 在该安全网上把 raw database/sql 身份逻辑迁到 `scannerv2.Repository` 接口后面，**行为零变化**。

## 改动

### 接口（`repository.go`）+2 方法
| 方法 | 职责 |
|---|---|
| `ResolveDeviceIdentity(mac, ip, networkID) IdentityResolution` | 只读解析：MAC-primary 跨网络 + (ip,network_id) 回退 + 漫游/替换检测。`IsNew` 取代 `sql.ErrNoRows` 哨兵 |
| `ApplyDeviceIdentity(IdentityWrite) deviceID` | 写入：新建（INSERT）/ 既有 / 替换 / 漫游 UPDATE，含 status/mac/last_seen 撞击 + 漫游占位驱逐重试 |

`networkID` 是**逐调用**参数（center 用单一 repo 摄入多 agent 网络），不走 repo 的字段。

### store 实现（`sqlite.go` +324 行）
SQL **逐字搬入**（`resolveDeviceIdentity` / `createDevice` 的 INSERT / `buildExistingUpdate`+`buildReplacementUpdate`+`existingUpdateArgs` / 漫游状态 UPDATE + 驱逐重试）。不重写、不加事务（保留原 best-effort 语义）。

### runner 改造（`device_bridge.go` −416 行）
- 新增 `repo` 字段 + `SetRepo()`（仿 `SetChangeRecorder`）。
- `applyDeviceBridge` 委托 repo；类型粘滞（`applyTypeStickiness`）留 runner（在 resolve 与 apply 间运行，依赖经 sqlc 读的 before-snapshot）。
- 删除迁出的 7 个函数；`buildIdentityWrite` 集中报告派生。
- **`dbConn` 字段保留**：detect_lost / lease_sweeper / topology / subnets / arp_topology 仍在用，超出 #159 身份写入范围。

### 布线
`routes.go` + `cmd/agent` 经 `engine.Repository` 调 `SetRepo`。agent 报告路径自动经新接口。`NoopRepository` + `recordRepo` 测试替身补 stub。

## 设计决策：2 方法（粘滞留 runner）
类型粘滞（纯 Go，依赖 before-snapshot）夹在 resolve 与 apply 之间运行 → store 保持薄纯 SQL 层，粘滞逻辑零移动 = 行为零风险。（备选 1 方法会把分类逻辑灌进 store。）

## 验收（对照 issue AC）
- [x] Repository 新增身份写入方法（Resolve + Apply）
- [x] device_bridge 委托，身份 SQL 不再经 dbConn（字段因其他文件保留）
- [x] 共享 helper 集中（MAC normalize/U/L bit 已在 store 包，network_id 随 SQL 入 store）
- [x] agent report 走同一方法（经 applyDeviceBridge 自动）
- [x] identity 测试断言接口；NoopRepository + recordRepo 补新方法
- [x] baseline 测试（PR 1/2）先捕获当前行为

## 测试
- baseline 6 测试 + 全部 identity 测试通过（仅构造处补 `SetRepo`，断言不变）。
- 新增 8 个**接口级**测试（`store/identity_test.go`）直接对 `*SQLiteRepository` 断言 resolve 契约 —— 为分布式第二实现铺路。
- `go test -race ./...` 29 包全绿；`gofmt`/`goimports`/`go vet` 干净。

## 部署烟测（192.168.63.101）
扫描 `192.168.63.1/24`：设备身份合并正确（12 camera、router GL-MT3000 `94:83:c4:29:97:3e`、NAS Synology/Apache），create/update 路径均无回归。唯一错误（`.41`/`.216`/`.155` 的 `CHECK constraint failed: type IN (...)`）在 PR 1/2 前的基线日志（Aug 09）里已存在 —— 属预存问题，本 PR 精确保留（同样的 ip/mac/错误）。

Refs #159.