### PR TITLE
test(routes): router ARP config 解析回归测试 (#171)

### DIFF
--- a/internal/api/routes/scanner_config_test.go
+++ b/internal/api/routes/scanner_config_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package routes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/config"
+)
+
+// These tests pin the config-resolution helpers that turn a koanf-loaded
+// config.ScannerConfig / config.DiscoveryConfig into the concrete values the
+// scanner engine consumes. They were previously untested (#171); a refactor of
+// the composition root (#157) or the router-ARP path could silently flip a
+// fallback (e.g. router_arp.community → snmp_community → "public") without a
+// guard here.
+
+func TestRouterCommunity_ResolutionOrder(t *testing.T) {
+	// Dedicated router_arp.community wins over everything.
+	require.Equal(t, "router-secret", routerCommunity(config.ScannerConfig{
+		SNMPCommunity: "global-secret",
+		RouterARP:     config.RouterARPConfig{Community: "router-secret"},
+	}))
+	// No router_arp.community → fall back to the global snmp_community.
+	require.Equal(t, "global-secret", routerCommunity(config.ScannerConfig{
+		SNMPCommunity: "global-secret",
+	}))
+	// Neither set → the documented "public" default.
+	require.Equal(t, "public", routerCommunity(config.ScannerConfig{}))
+}
+
+func TestRouterTimeout_DefaultAndOverride(t *testing.T) {
+	// Configured value > 0 is honored.
+	require.Equal(t, 9, routerTimeout(config.ScannerConfig{
+		RouterARP: config.RouterARPConfig{Timeout: 9},
+	}))
+	// Zero/unset → the documented 4s default.
+	require.Equal(t, 4, routerTimeout(config.ScannerConfig{}))
+	require.Equal(t, 4, routerTimeout(config.ScannerConfig{
+		RouterARP: config.RouterARPConfig{Timeout: 0},
+	}))
+}
+
+func TestRouterResidentSourcesOn(t *testing.T) {
+	// No resident source enabled → false.
+	require.False(t, routerResidentSourcesOn(config.DiscoveryConfig{}))
+	// Each source alone flips it true (OR semantics — any one resident reader
+	// means the router may see hosts the active sweep missed).
+	require.True(t, routerResidentSourcesOn(config.DiscoveryConfig{
+		ARPCache: config.DiscoverySourceToggle{Enabled: true},
+	}))
+	require.True(t, routerResidentSourcesOn(config.DiscoveryConfig{
+		DHCPLeases: config.DiscoverySourceToggle{Enabled: true},
+	}))
+	require.True(t, routerResidentSourcesOn(config.DiscoveryConfig{
+		Conntrack: config.DiscoverySourceToggle{Enabled: true},
+	}))
+}


### PR DESCRIPTION
## 背景
Refs #171（重构安全网）。#171 标记的"无覆盖"符号中，多数已在后续 PR 补上：runMigrations（#194）、device_bridge 身份合并（#201/#202 的 characterization + 接口测试）、NewEngine（`engine_test`）、store Record\*（`sqlite_test`）。本 PR 补齐剩余的命名缺口：**router ARP 配置解析**。

## 改动
`internal/api/routes/scanner_config_test.go`（package routes 内部测试，访问未导出 helper）锁住 3 个纯函数：

| 函数 | 锁定的行为 |
|---|---|
| `routerCommunity` | 解析顺序：`router_arp.community` > 全局 `snmp_community` > `"public"` |
| `routerTimeout` | `router_arp.timeout > 0` 用配置值，否则默认 `4`s |
| `routerResidentSourcesOn` | ARP cache / DHCP leases / conntrack 任一 `Enabled` 即 true（OR 语义） |

## 价值
这些是 composition root（`#157`）与 router-ARP 路径的关键解析点。纯函数但此前无测试 —— 一个 fallback 顺序的静默翻转（如 `router_arp.community` 不再优先于 `snmp_community`）不会被现有集成测试捕获，本 PR 守住该回归。

## 验证
`go test ./internal/api/routes/` 全绿；`gofmt`/`goimports`/`go vet` 干净。

## #171 状态
覆盖率报告 + 最低 15 包的优先级跟进清单见 #171 评论（本 PR 不试图一次关闭该 P3 issue，而是补齐命名的 router 配置缺口这一具体安全网）。

Refs #171.