### PR TITLE
test(taskservice): scheduler-coupled Trigger/Cancel 回归测试 (#171)

### DIFF
--- a/internal/service/scannerv2/taskservice/scheduler_test.go
+++ b/internal/service/scannerv2/taskservice/scheduler_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package taskservice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service/scannerv2/scheduler"
+	"mibee-steward/internal/testutil"
+)
+
+// These tests cover the scheduler-coupled TriggerTask / CancelTask paths that
+// the package doc promised ("exercised separately in the real-scheduler tests
+// below") but were never written (#171). The existing tests only covered the
+// nil-scheduler guards; these exercise a REAL scheduler with a no-op ScanFunc
+// so the with-scheduler behavior (trigger dispatch, disabled/not-found errors,
+// cancel-with-no-running-scan) is pinned.
+
+// setupSvcWithScheduler returns a taskservice backed by an in-memory DB and a
+// real scheduler whose ScanFunc is a no-op. The scheduler is started so
+// TriggerNow can dispatch; Stop is registered for teardown. The no-op ScanFunc
+// means triggering a task does not create a run row (the runner is the run
+// writer) — these tests assert the dispatch + error-mapping, not run creation.
+func setupSvcWithScheduler(t *testing.T) (*Service, *db.Queries) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	sched, err := scheduler.New(queries, conn,
+		func(context.Context, int64, string, time.Duration, int, int64) {}, // no-op scan
+		nil)
+	require.NoError(t, err)
+	sched.Start(context.Background())
+	t.Cleanup(sched.Stop)
+	return New(queries, sched), queries
+}
+
+// TestTriggerTask_WithScheduler_ReturnsTriggered verifies the happy path: an
+// enabled task with a registered cron job fires via the scheduler and
+// TriggerTask returns the synthetic "triggered" status (fire-and-forget).
+func TestTriggerTask_WithScheduler_ReturnsTriggered(t *testing.T) {
+	svc, _ := setupSvcWithScheduler(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateTask(ctx, validRequest())
+	require.NoError(t, err)
+
+	resp, err := svc.TriggerTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, resp.TaskID)
+	require.Equal(t, "triggered", resp.Status, "TriggerTask is fire-and-forget → synthetic triggered status")
+}
+
+// TestTriggerTask_DisabledTask verifies that a disabled task is rejected with
+// ErrScanTaskDisabled BEFORE the scheduler is touched (the enabled check is the
+// first guard after the lookup, so the dispatch never runs).
+func TestTriggerTask_DisabledTask(t *testing.T) {
+	svc, _ := setupSvcWithScheduler(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateTask(ctx, validRequest())
+	require.NoError(t, err)
+	// CreateTask defaults enabled=true (schema DEFAULT 1); disable via UpdateTask.
+	_, err = svc.UpdateTask(ctx, created.ID, domain.UpdateScanTaskRequest{Enabled: boolPtr(false)})
+	require.NoError(t, err)
+
+	_, err = svc.TriggerTask(ctx, created.ID)
+	require.ErrorIs(t, err, ErrScanTaskDisabled, "a disabled task must not be triggerable")
+}
+
+// TestTriggerTask_NotFound verifies the not-found path maps to ErrScanTaskNotFound.
+func TestTriggerTask_NotFound(t *testing.T) {
+	svc, _ := setupSvcWithScheduler(t)
+	_, err := svc.TriggerTask(context.Background(), 99999)
+	require.ErrorIs(t, err, ErrScanTaskNotFound)
+}
+
+// TestCancelTask_NoRunningScan verifies that cancelling a task with no in-flight
+// run maps the scheduler's "no running scan" error to ErrScanNotRunning (the
+// user-facing signal that there is nothing to cancel).
+func TestCancelTask_NoRunningScan(t *testing.T) {
+	svc, _ := setupSvcWithScheduler(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateTask(ctx, validRequest())
+	require.NoError(t, err)
+
+	err = svc.CancelTask(ctx, created.ID)
+	require.ErrorIs(t, err, ErrScanNotRunning, "no in-flight run → ErrScanNotRunning")
+}
+
+// boolPtr returns a pointer to b (helper for *bool request fields).
+func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## 背景
Refs #171（重构安全网），#204（cleanup retention）之后的下一批。

taskservice 包**文档承诺**"Trigger/Cancel 在下面的 real-scheduler 测试中覆盖"，但这些测试从未写 —— 现存测试只覆盖了 nil-scheduler 守卫（`TestTriggerTask_NilScheduler` / `TestCancelTask_NilScheduler`）。scheduler-coupled 的真实路径（trigger dispatch、disabled/not-found 错误、cancel 错误映射）此前无测试，这是 taskservice 覆盖率仅 27.3% 的主因。

## 改动
`internal/service/scannerv2/taskservice/scheduler_test.go` —— 用真实 scheduler（no-op `ScanFunc`）补 4 个测试：

| 测试 | 锁定的行为 |
|---|---|
| `TestTriggerTask_WithScheduler_ReturnsTriggered` | enabled task 经 scheduler.TriggerNow 派发 → 返回 `{Status:"triggered"}`（fire-and-forget） |
| `TestTriggerTask_DisabledTask` | disabled task → `ErrScanTaskDisabled`（enabled 检查先于 dispatch） |
| `TestTriggerTask_NotFound` | 不存在的 task → `ErrScanTaskNotFound` |
| `TestCancelTask_NoRunningScan` | 无在跑 run → `ErrScanNotRunning`（scheduler 的 no-running-scan 错误映射到用户可见信号） |

`setupSvcWithScheduler` 构造真实 scheduler + no-op ScanFunc；no-op 意味着触发不建 run 行（runner 才是 run 写入者）—— 测试断言 dispatch + 错误映射，不是 run 创建。

## 验证
`go test -race ./internal/service/scannerv2/taskservice/` 全绿；`gofmt`/`goimports`/`go vet` 干净。**taskservice 覆盖率 27.3% → 54.1%（+26.8pp）**。

## #171 进度
覆盖率报告见 #171 评论。已合并批次：#203（router 配置）、#204（cleanup retention）；本批补 taskservice scheduler 路径。

Refs #171.