### PR TITLE
test(middleware): 安全中间件回归测试 — auth/csrf/rbac (#171)

### DIFF
--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package middleware_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/middleware"
+	"mibee-steward/internal/service"
+)
+
+// These tests pin the JWT Authenticator (#171). It is the security gate every
+// browser/user route passes through: a VALID token injects user_id + role into
+// the request context (downstream RBAC then authorizes); a missing/invalid/
+// expired/revoked token is passed through ANONYMOUSLY (GetUserFromContext returns
+// !ok), and RequireAuth/RequireAdmin turn that into 401. A regression here is an
+// auth-bypass hole, so the anonymous-on-failure contract is the load-bearing
+// invariant to lock.
+
+// authProbe wraps Authenticator around a handler that echoes the resolved
+// identity ("uid=N role=R") or "anon" when no user is in context.
+func authProbe() http.Handler {
+	return middleware.Authenticator(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uid, role, ok := middleware.GetUserFromContext(r)
+		if !ok {
+			_, _ = w.Write([]byte("anon"))
+			return
+		}
+		fmt.Fprintf(w, "uid=%d role=%s", uid, role)
+	}))
+}
+
+func reqWithBearer(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+func reqWithCookie(name, token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if token != "" {
+		r.AddCookie(&http.Cookie{Name: name, Value: token})
+	}
+	return r
+}
+
+// useJWTAuth installs a fresh JWT authenticator for the test and returns a
+// cleanup restoring prior behavior. The Authenticator reads a package global.
+func useJWTAuth(t *testing.T) {
+	t.Helper()
+	middleware.SetJWTAuth("test-secret-please-rotate")
+}
+
+func issueToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	_, s, err := middleware.GetJWTAuth().Encode(claims)
+	require.NoError(t, err)
+	return s
+}
+
+func TestAuthenticator_ValidBearerTokenAuthenticates(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 42.0, "role": "user"})
+
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithBearer(tok))
+
+	require.Equal(t, "uid=42 role=user", rec.Body.String())
+}
+
+func TestAuthenticator_CookieTokenWorks(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 7.0, "role": "admin"})
+
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithCookie("token", tok))
+
+	require.Equal(t, "uid=7 role=admin", rec.Body.String())
+}
+
+// TestAuthenticator_CookiePreferredOverBearer pins extractToken's cookie-first
+// precedence: when both are present, the cookie wins. (The reverse — valid
+// bearer shadowed by an invalid cookie — is the auth-bypass case this guards.)
+func TestAuthenticator_CookiePreferredOverBearer(t *testing.T) {
+	useJWTAuth(t)
+	valid := issueToken(t, map[string]any{"user_id": 1.0, "role": "user"})
+
+	// Cookie carries the valid token; bearer carries garbage. Cookie wins → authed.
+	rec := httptest.NewRecorder()
+	r := reqWithCookie("token", valid)
+	r.Header.Set("Authorization", "Bearer not.a.jwt")
+	authProbe().ServeHTTP(rec, r)
+	require.Equal(t, "uid=1 role=user", rec.Body.String(), "cookie token must take precedence")
+}
+
+func TestAuthenticator_MissingTokenIsAnonymous(t *testing.T) {
+	useJWTAuth(t)
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithBearer(""))
+	require.Equal(t, "anon", rec.Body.String())
+}
+
+func TestAuthenticator_GarbageTokenIsAnonymous(t *testing.T) {
+	useJWTAuth(t)
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithBearer("garbage.not-a-jwt"))
+	require.Equal(t, "anon", rec.Body.String())
+}
+
+func TestAuthenticator_ExpiredTokenIsAnonymous(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{
+		"user_id": 1.0,
+		"role":    "user",
+		"exp":     time.Now().Add(-time.Hour).Unix(), // expired
+	})
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithBearer(tok))
+	require.Equal(t, "anon", rec.Body.String(), "expired token must not authenticate")
+}
+
+func TestAuthenticator_BlacklistedTokenIsAnonymous(t *testing.T) {
+	useJWTAuth(t)
+	const jti = "revoked-session-1"
+	tok := issueToken(t, map[string]any{"user_id": 1.0, "role": "user", "jti": jti})
+
+	bl := service.NewTokenBlacklist()
+	bl.Add(jti, time.Hour)
+	middleware.SetTokenBlacklist(bl)
+	t.Cleanup(func() { middleware.SetTokenBlacklist(nil) }) // don't leak into other tests
+
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, reqWithBearer(tok))
+	require.Equal(t, "anon", rec.Body.String(), "a blacklisted (revoked) token must not authenticate")
+}
+
+// TestAuthenticator_MalformedAuthHeaderIsAnonymous pins extractToken's
+// "Bearer <token>" parsing: a non-Bearer scheme (e.g. "Basic ...") yields no
+// token → anonymous, never a crash or accidental parse.
+func TestAuthenticator_MalformedAuthHeaderIsAnonymous(t *testing.T) {
+	useJWTAuth(t)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Basic dXNlcjpwYXNz") // not a Bearer
+	rec := httptest.NewRecorder()
+	authProbe().ServeHTTP(rec, r)
+	require.Equal(t, "anon", rec.Body.String())
+}
+
+func TestGetUserFromContext_EmptyContextNotOk(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, _, ok := middleware.GetUserFromContext(r)
+	require.False(t, ok)
+}

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/middleware"
+)
+
+// These tests pin the CSRF middleware (#171) — the cross-origin + double-submit
+// gate that every state-changing browser request must pass. A regression here is
+// a CSRF hole (an attacker site forcing authenticated state changes). The
+// load-bearing invariants:
+//   - safe methods (GET/HEAD/OPTIONS) pass and seed the csrf cookie,
+//   - a state-changing request from a CROSS origin is rejected (403),
+//   - a same-origin state change needs cookie token == X-CSRF-Token header,
+//   - non-browser clients (no Origin + no cookie/header) are allowed through.
+
+func csrfRequest(method, host, origin, referer, cookieVal, headerVal string) *http.Request {
+	r := httptest.NewRequest(method, "/", nil)
+	if host != "" {
+		r.Host = host
+	}
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	if referer != "" {
+		r.Header.Set("Referer", referer)
+	}
+	if cookieVal != "" {
+		r.AddCookie(&http.Cookie{Name: "csrf_token", Value: cookieVal})
+	}
+	if headerVal != "" {
+		r.Header.Set("X-CSRF-Token", headerVal)
+	}
+	return r
+}
+
+func TestCSRF_SafeMethodSeedsCookie(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec, csrfRequest(http.MethodGet, "example.com", "", "", "", ""))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// A GET with no existing csrf cookie must seed one for future state changes.
+	setCookie := rec.Header().Get("Set-Cookie")
+	require.Contains(t, setCookie, "csrf_token=", "GET must seed a csrf cookie")
+}
+
+func TestCSRF_POST_SameOriginMatchingTokenPasses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec,
+		csrfRequest(http.MethodPost, "example.com", "http://example.com", "", "tok", "tok"))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ok", rec.Body.String())
+}
+
+// TestCSRF_POST_CrossOriginRejected pins the Origin check: a POST whose Origin
+// does not match the request host is rejected before the token check even runs.
+func TestCSRF_POST_CrossOriginRejected(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec,
+		csrfRequest(http.MethodPost, "example.com", "http://evil.example", "", "tok", "tok"))
+
+	require.Equal(t, http.StatusForbidden, rec.Code, "cross-origin POST must be rejected")
+}
+
+// TestCSRF_POST_TokenMismatchRejected pins the double-submit check: even
+// same-origin, a cookie/header mismatch is rejected (an attacker can set a
+// cookie via a subdomain but cannot forge the matching header).
+func TestCSRF_POST_TokenMismatchRejected(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec,
+		csrfRequest(http.MethodPost, "example.com", "http://example.com", "", "cookie-tok", "header-tok"))
+
+	require.Equal(t, http.StatusForbidden, rec.Code, "cookie/header token mismatch must be rejected")
+}
+
+// TestCSRF_POST_NoOriginNoRefererPasses pins the non-browser-client carve-out:
+// a request with neither Origin nor Referer (a non-browser client with no CSRF
+// state) is allowed through. CSRF protects browsers, not API clients.
+func TestCSRF_POST_NoOriginNoRefererPasses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec,
+		csrfRequest(http.MethodPost, "example.com", "", "", "", ""))
+
+	require.Equal(t, http.StatusOK, rec.Code, "non-browser POST (no Origin/Referer) passes")
+}
+
+// TestCSRF_POST_NoOriginMismatchedRefererRejected pins the Referer fallback:
+// when Origin is absent, a Referer pointing elsewhere is rejected.
+func TestCSRF_POST_NoOriginMismatchedRefererRejected(t *testing.T) {
+	rec := httptest.NewRecorder()
+	middleware.CSRF(okHandler()).ServeHTTP(rec,
+		csrfRequest(http.MethodPost, "example.com", "", "http://evil.example/x", "", ""))
+
+	require.Equal(t, http.StatusForbidden, rec.Code, "mismatched Referer must be rejected")
+}

--- a/internal/api/middleware/rbac_test.go
+++ b/internal/api/middleware/rbac_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/middleware"
+)
+
+// These tests pin RequireAuth / RequireAdmin (#171) — the authorization gates
+// that turn the Authenticator's context (or lack of it) into 401/403. They wrap
+// Authenticator, so each is exercised end-to-end with a real signed JWT:
+//   - RequireAuth:  valid user → next;  no/invalid token → 401.
+//   - RequireAdmin: admin → next;  non-admin → 403;  no/invalid token → 401.
+// A regression here is a privilege-escalation or auth-bypass hole.
+
+// okHandler is the protected downstream handler; writing 200 "ok" proves the
+// gate passed the request through.
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+func TestRequireAuth_ValidTokenPasses(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 1.0, "role": "user"})
+
+	rec := httptest.NewRecorder()
+	middleware.RequireAuth(okHandler()).ServeHTTP(rec, reqWithBearer(tok))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ok", rec.Body.String())
+}
+
+func TestRequireAuth_MissingTokenReturns401(t *testing.T) {
+	useJWTAuth(t)
+	rec := httptest.NewRecorder()
+	middleware.RequireAuth(okHandler()).ServeHTTP(rec, reqWithBearer(""))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAuth_InvalidTokenReturns401(t *testing.T) {
+	useJWTAuth(t)
+	rec := httptest.NewRecorder()
+	middleware.RequireAuth(okHandler()).ServeHTTP(rec, reqWithBearer("garbage"))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAdmin_AdminPasses(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 1.0, "role": "admin"})
+
+	rec := httptest.NewRecorder()
+	middleware.RequireAdmin(okHandler()).ServeHTTP(rec, reqWithBearer(tok))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ok", rec.Body.String())
+}
+
+// TestRequireAdmin_NonAdminReturns403 pins the privilege boundary: an
+// authenticated but non-admin user is rejected with 403 (not 401 — they ARE
+// authenticated, just not authorized). This is the privilege-escalation guard.
+func TestRequireAdmin_NonAdminReturns403(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 2.0, "role": "user"})
+
+	rec := httptest.NewRecorder()
+	middleware.RequireAdmin(okHandler()).ServeHTTP(rec, reqWithBearer(tok))
+	require.Equal(t, http.StatusForbidden, rec.Code, "non-admin must get 403, not pass-through")
+}
+
+func TestRequireAdmin_MissingTokenReturns401(t *testing.T) {
+	useJWTAuth(t)
+	rec := httptest.NewRecorder()
+	middleware.RequireAdmin(okHandler()).ServeHTTP(rec, reqWithBearer(""))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/api/middleware/rbac_test.go
+++ b/internal/api/middleware/rbac_test.go
@@ -24,7 +24,7 @@ import (
 // okHandler is the protected downstream handler; writing 200 "ok" proves the
 // gate passed the request through.
 func okHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})


### PR DESCRIPTION
## 背景
Refs #171（重构安全网）。middleware 包已测 agent_auth / ratelimit / realip，但**三个安全关键中间件此前无测试**（包覆盖率仅 48.3%）。这些是回归即安全洞的路径 —— 认证绕过、CSRF、越权。

## 改动
三个测试文件，共 **21 个安全测试**：

### `auth_test.go`（9 测试 — JWT 网关）
| 测试 | 锁定 |
|---|---|
| ValidBearerTokenAuthenticates / CookieTokenWorks | 有效 token 注入 user_id+role |
| CookiePreferredOverBearer | cookie 优先于 bearer（防 bearer 绕过） |
| MissingToken / GarbageToken / ExpiredToken / MalformedAuthHeader | → 匿名透传（GetUserFromContext !ok） |
| BlacklistedTokenIsAnonymous | 黑名单（吊销）token → 匿名 |

**关键契约**：Authenticator 是 pass-through —— 有效 token 注入身份，无效 token 匿名透传，由下游 RequireAuth/RequireAdmin 转成 401。匿名-on-failure 是承载 invariant。

### `rbac_test.go`（6 测试 — 授权闸门，端到端真实签名 JWT）
| 测试 | 锁定 |
|---|---|
| RequireAuth ValidPasses / Missing/Invalid→401 | 认证闸门 |
| RequireAdmin AdminPasses / Missing→401 | 管理员闸门 |
| RequireAdmin **NonAdmin→403** | 特权边界（非 admin 得 403，非 401/透传） |

### `csrf_test.go`（6 测试 — 跨站+双重提交闸门）
| 测试 | 锁定 |
|---|---|
| SafeMethodSeedsCookie | GET 透传 + 种 csrf cookie |
| POST_SameOriginMatchingTokenPasses | 同源 + cookie==header → 通过 |
| POST_CrossOriginRejected | 跨源 → 403（Origin 检查先于 token） |
| POST_TokenMismatchRejected | cookie/header 不匹配 → 403（双重提交） |
| POST_NoOriginNoRefererPasses | 非浏览器客户端 → 通过 |
| POST_NoOriginMismatchedRefererRejected | Referer 不匹配 → 403 |

## 验证
`go test -race ./internal/api/middleware/` 全绿；`gofmt`/`goimports`/`go vet` 干净。**middleware 覆盖率 48.3% → 78.2%（+29.9pp）**。

## #171 进度
已合并批次：#203（router）、#204（cleanup）、#205（taskservice）；本批补 middleware 三大安全闸门。覆盖率报告见 #171 评论。

Refs #171.