### PR TITLE
test(web): login 页渲染测试 + svelteTesting 模式（首个 .svelte 渲染测试）(#171)

### DIFF
--- a/web/src/__tests__/login.page.test.ts
+++ b/web/src/__tests__/login.page.test.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+// Mock the modules with external behavior so the page module loads cleanly
+// under jsdom. A render-only test does not submit, so the spies are never
+// called — they exist only so the imports resolve without a real fetcher/router.
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$lib/api/client', () => ({
+	api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), del: vi.fn() },
+	ApiError: class ApiError extends Error {},
+	SessionExpiredError: class SessionExpiredError extends Error {}
+}));
+
+// login page must be imported AFTER the vi.mock calls so the mocks take effect.
+import Login from '../routes/login/+page.svelte';
+
+describe('Login page', () => {
+	it('mounts and renders the credential form (username + password)', () => {
+		const { container } = render(Login);
+
+		// The default login view shows a username (text) + password input.
+		expect(container.querySelector('input[type="text"]')).toBeTruthy();
+		expect(container.querySelector('input[type="password"]')).toBeTruthy();
+		// And a submit button to send the credentials.
+		expect(container.querySelector('button[type="submit"]')).toBeTruthy();
+	});
+
+	it('does not show the 2FA or force-password views on initial render', () => {
+		const { container } = render(Login);
+
+		// The 2FA code field (inputmode numeric, maxlength 6) is conditional —
+		// absent until a 2FA challenge is returned. Absence on mount is the
+		// contract that the default credential form is the initial view.
+		const twoFactorInput = container.querySelector('input[inputmode="numeric"][maxlength="6"]');
+		expect(twoFactorInput).toBeFalsy();
+	});
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,10 +11,17 @@
 
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
+	// svelteTesting() makes @testing-library/svelte's render() compile .svelte
+	// components for the CLIENT (not SSR) under jsdom — without it the sveltekit
+	// plugin emits the server build and render() fails with
+	// "lifecycle_function_unavailable: mount() is not available on the server".
+	// It only adds a client-compile condition for component rendering; the
+	// existing logic/utility tests don't render components and are unaffected.
+	plugins: [tailwindcss(), sveltekit(), svelteTesting()],
 	test: {
 		environment: 'jsdom',
 		include: ['src/**/*.test.ts'],


### PR DESCRIPTION
## 背景
Refs #171 最后一个 AC 项：前端组件渲染测试（设备列表/详情/登录/扫描）。此前 8 个 Vitest 文件全是逻辑/工具测试，**无任何 `.svelte` 页面渲染测试**。本 PR 建立渲染测试模式并落地首个页测试。

## 改动

### `vitest.config.ts` —— svelteTesting() 模式（关键 enabler）
`sveltekit()` 默认把 `.svelte` 编成 **SSR server build**，`render()` 会报 `lifecycle_function_unavailable: mount() is not available on the server`。加 `@testing-library/svelte/vite` 的 `svelteTesting()` 插件引入 client 编译条件，让 `render()` 走客户端 mount。**只影响组件渲染；既有 8 个逻辑测试不渲染组件，无影响。**

### `src/__tests__/login.page.test.ts`（2 测试，首个页渲染测试）
| 测试 | 锁定 |
|---|---|
| mounts 并渲染凭据表单 | 用户名(text) + 密码(password) + submit 三元素在 |
| 初始视图不显示 2FA | inputmode numeric maxlength 6 字段缺位 → 默认凭据表单是初始态 |

### mock 策略（可复用于 device list/detail/scan 后续页测试）
只 mock 有外部行为的模块：`$app/navigation`（goto）、`$lib/api/client`（api）。paraglide `m[]` 是真实生成模块可直接用；render-only 测试不 submit，故不触达 api/goto/auth。

## 验证
全前端套件 `npx vitest run` **9 文件 193 测试全绿**（既有无回归）。

## #171 进度
这是 #171 最后一个 AC 项的首个交付 —— 渲染测试模式建立 + login 页落地。device list/detail/scan 页可按同模式跟进（follow-up）。

Refs #171.