### PR TITLE
test(handler): user 管理安全路径测试（register/change-password/admin-reset/list）(#171)

### DIFF
--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -102,6 +102,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 	r.Route("/api/v1/users", func(r chi.Router) {
 		r.Use(middleware.RequireAdmin)
 		r.Get("/", userHandler.ListUsers)
+		r.Post("/{id}/reset-password", userHandler.AdminResetPassword)
 	})
 
 	// Device routes

--- a/internal/api/handler/user_test.go
+++ b/internal/api/handler/user_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler_test
+
+import (
+	"bytes"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// These tests extend the user/auth handler coverage (#171). handler_test.go
+// already covers Login (success/invalid/missing) + Profile; these pin the
+// UNTESTED security-critical user-management paths: admin-gated user creation,
+// self password change (with old-password verification), admin password reset,
+// and the ListUsers privilege boundary. A regression in any is a privilege or
+// account-takeover risk.
+
+// insertTestUser seeds a user row directly with the given role + password,
+// bypassing the service password policy so test fixtures aren't gated by
+// strength rules. Returns the new row id.
+func insertTestUser(t *testing.T, db *sql.DB, username, email, role, password string) int64 {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	res, err := db.Exec(
+		"INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+		username, email, string(hash), role,
+	)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+// loginStatus attempts a login and returns the HTTP status (no assertion), for
+// verifying a credential pair succeeds OR fails.
+func loginStatus(t *testing.T, server *httptest.Server, username, password string) int {
+	t.Helper()
+	body := `{"username":"` + username + `","password":"` + password + `"}`
+	resp, err := http.Post(server.URL+"/api/v1/auth/login", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// --- Register (admin-only) ---
+
+func TestUserRegister_AdminCreatesUserThenLogin(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+	admin := loginAsAdmin(t, server)
+
+	resp := authPost(t, server.URL+"/api/v1/auth/register", admin,
+		`{"username":"alice","email":"alice@test.com","password":"Alice@2026","role":"user"}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// The new user can authenticate with the admin-set password.
+	token := loginAs(t, server, "alice", "Alice@2026")
+	require.NotEmpty(t, token)
+}
+
+func TestUserRegister_DuplicateName_Conflict(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "bob", "bob@test.com", "user", "Bob@2026")
+	insertTestAdmin(t, db)
+	admin := loginAsAdmin(t, server)
+
+	resp := authPost(t, server.URL+"/api/v1/auth/register", admin,
+		`{"username":"bob","email":"bob2@test.com","password":"Bob@2026","role":"user"}`)
+	require.Equal(t, http.StatusConflict, resp.StatusCode, "duplicate username → 409")
+}
+
+// --- ChangePassword (self, old-password verified) ---
+
+func TestUserChangePassword_Success(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "carol", "carol@test.com", "user", "Carol@2026")
+	token := loginAs(t, server, "carol", "Carol@2026")
+
+	resp := authPut(t, server.URL+"/api/v1/auth/password", token,
+		`{"old_password":"Carol@2026","new_password":"Carol@2027!"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// New password authenticates; the old one no longer does.
+	require.NotEmpty(t, loginAs(t, server, "carol", "Carol@2027!"))
+	require.Equal(t, http.StatusUnauthorized,
+		loginStatus(t, server, "carol", "Carol@2026"), "old password must stop working")
+}
+
+func TestUserChangePassword_WrongOldPassword(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "dave", "dave@test.com", "user", "Dave@2026")
+	token := loginAs(t, server, "dave", "Dave@2026")
+
+	resp := authPut(t, server.URL+"/api/v1/auth/password", token,
+		`{"old_password":"totally-wrong","new_password":"Dave@2027!"}`)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "wrong old password → 400")
+
+	// Original password still works (the change was rejected).
+	require.NotEmpty(t, loginAs(t, server, "dave", "Dave@2026"))
+}
+
+// --- ListUsers privilege boundary ---
+
+func TestListUsers_RequiresAdmin(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "eve", "eve@test.com", "user", "Eve@2026")
+	insertTestAdmin(t, db)
+	userToken := loginAs(t, server, "eve", "Eve@2026")
+	adminToken := loginAsAdmin(t, server)
+
+	// A regular user is rejected by the RequireAdmin gate.
+	resp := authGet(t, server.URL+"/api/v1/users", userToken)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "non-admin listing users → 403")
+
+	// An admin gets the list.
+	resp = authGet(t, server.URL+"/api/v1/users", adminToken)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// --- AdminResetPassword (admin resets another user) ---
+
+func TestAdminResetPassword_SuccessThenLogin(t *testing.T) {
+	server, db := setupTestServer(t)
+	frankID := insertTestUser(t, db, "frank", "frank@test.com", "user", "Frank@2026")
+	insertTestAdmin(t, db)
+	admin := loginAsAdmin(t, server)
+
+	resp := authPost(t, server.URL+"/api/v1/users/"+strconv.FormatInt(frankID, 10)+"/reset-password", admin,
+		`{"new_password":"Frank@2027!"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The target user can now log in with the admin-reset password.
+	require.NotEmpty(t, loginAs(t, server, "frank", "Frank@2027!"))
+	// ... and the OLD password no longer works.
+	require.Equal(t, http.StatusUnauthorized,
+		loginStatus(t, server, "frank", "Frank@2026"))
+}
+
+func TestAdminResetPassword_NotFound(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestAdmin(t, db)
+	admin := loginAsAdmin(t, server)
+
+	resp := authPost(t, server.URL+"/api/v1/users/99999/reset-password", admin,
+		`{"new_password":"Any@2026"}`)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, "resetting a non-existent user → 404")
+}


### PR DESCRIPTION
## 背景
Refs #171。`user.go` handler 此前只测了 Login + Profile（`handler_test.go` 的集成测试），其余 **account-management 路径无测试** —— 回归即账号接管/越权风险。

## 改动
`user_test.go`（package `handler_test`，复用 `setupTestServer`/`loginAsAdmin` + 新增 `insertTestUser` fixture）—— 7 个集成测试覆盖未测的安全关键路径：

| 测试 | 锁定 |
|---|---|
| Register_AdminCreatesUserThenLogin | admin 建用户后该用户可登录 |
| Register_DuplicateName_Conflict | 重名→409 |
| **ChangePassword_Success** | 验旧密码：成功后新密码登录 / 旧密码作废 |
| ChangePassword_WrongOldPassword | 旧密码错→400，原密码仍有效 |
| **ListUsers_RequiresAdmin** | 非 admin→403，admin→200（特权边界） |
| **AdminResetPassword_SuccessThenLogin** | admin 重置后用户用新密码登录 / 旧密码作废 |
| AdminResetPassword_NotFound | 不存在用户→404 |

附带：`setupTestServer` 补挂 `POST /users/{id}/reset-password` 路由（既有 helper 的安全增量，不影响其他测试）。测试密码遵守服务层密码策略（≥8 + 大小写+数字+特殊字符）。

## 验证
`go test -race ./internal/api/handler/` 全绿（87s 全包 race）；`gofmt`/`goimports`/`go vet` 干净；**golangci-lint 0 issues**。handler 包覆盖率 **26.3% → 28.0%**。

## #171 进度
已合并批次 #203（router）/ #204（cleanup）/ #205（taskservice）/ #206（middleware 安全）/ #207（network handler 债务）/ #208（前端 login 渲染）。本批补 user 管理安全路径。

Refs #171.