### PR TITLE
test(handler): 2FA TOTP handler 测试（含 bypass guard）(#171)

### DIFF
--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -60,6 +60,10 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 	userSvc := service.NewUserService(db, cfg.Auth.JWTSecret, expiry)
 	auditRepo := service.NewAuditRepository(db)
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, nil)
+	// TOTP service + handler (wired into userSvc so the 2FA flow is exercisable).
+	totpSvc := service.NewTOTPService(db, auditRepo)
+	userSvc.SetTOTPService(totpSvc)
+	totpHandler := handler.NewTOTPHandler(totpSvc, userSvc, cfg, auditRepo)
 
 	// Device handler
 	deviceRepo := service.NewDeviceRepository(db)
@@ -97,6 +101,18 @@ func setupTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 
 	// Auth routes
 	r.Mount("/api/v1/auth", userHandler.Routes())
+
+	// 2FA routes (public verify + protected setup/enable/disable/status)
+	r.Route("/api/v1/auth/2fa", func(r chi.Router) {
+		r.Post("/verify", totpHandler.Verify)
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.RequireAuth)
+			r.Post("/setup", totpHandler.Setup)
+			r.Post("/enable", totpHandler.Enable)
+			r.Post("/disable", totpHandler.Disable)
+			r.Get("/status", totpHandler.Status)
+		})
+	})
 
 	// Admin-only user list
 	r.Route("/api/v1/users", func(r chi.Router) {

--- a/internal/api/handler/totp_test.go
+++ b/internal/api/handler/totp_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler_test
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the 2FA (TOTP) HTTP handler layer (#171). The TOTP *service*
+// (algorithm + storage) is covered by service/totp_test.go; the thin handler
+// layer (error→status mapping) was untested. The load-bearing security invariant
+// is the BYPASS GUARD: Verify with a wrong code MUST be rejected (422), never
+// accepted — a regression here is a 2FA bypass = account takeover.
+
+// setupAndEnable2FA seeds a user, logs in, runs the setup→enable flow with a
+// valid current code, and returns the secret + the user's id + login token.
+func setupAndEnable2FA(t *testing.T, server *httptest.Server, db *sql.DB, username, password string) (secret string, userID int64, token string) {
+	t.Helper()
+	userID = insertTestUser(t, db, username, username+"@test.com", "user", password)
+	token = loginAs(t, server, username, password)
+
+	// Setup → returns the TOTP secret + QR URL.
+	resp := authPost(t, server.URL+"/api/v1/auth/2fa/setup", token, `{}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var setup struct {
+		Secret string `json:"secret"`
+	}
+	decodeJSON(t, resp, &setup)
+	require.NotEmpty(t, setup.Secret, "setup must return a secret")
+
+	// Enable with a valid current code derived from that secret.
+	code, err := totp.GenerateCode(setup.Secret, time.Now())
+	require.NoError(t, err)
+	resp = authPost(t, server.URL+"/api/v1/auth/2fa/enable", token, `{"code":"`+code+`"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "enable with a valid code must succeed")
+	return setup.Secret, userID, token
+}
+
+func Test2FA_SetupReturnsSecret(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "ivan", "ivan@test.com", "user", "Ivan@2026")
+	token := loginAs(t, server, "ivan", "Ivan@2026")
+
+	resp := authPost(t, server.URL+"/api/v1/auth/2fa/setup", token, `{}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var setup struct {
+		Secret string `json:"secret"`
+	}
+	decodeJSON(t, resp, &setup)
+	require.NotEmpty(t, setup.Secret)
+}
+
+func Test2FA_EnableWithValidCode_StatusEnabled(t *testing.T) {
+	server, db := setupTestServer(t)
+	_, _, token := setupAndEnable2FA(t, server, db, "judy", "Judy@2026")
+
+	resp := authGet(t, server.URL+"/api/v1/auth/2fa/status", token)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var status struct {
+		Enabled bool `json:"enabled"`
+	}
+	decodeJSON(t, resp, &status)
+	require.True(t, status.Enabled, "status must report 2FA enabled after a valid enable")
+}
+
+// Test2FA_EnableWithInvalidCode_Rejected: a wrong code cannot enable 2FA (the
+// user must prove possession of the authenticator secret first).
+func Test2FA_EnableWithInvalidCode_Rejected(t *testing.T) {
+	server, db := setupTestServer(t)
+	insertTestUser(t, db, "kate", "kate@test.com", "user", "Kate@2026")
+	token := loginAs(t, server, "kate", "Kate@2026")
+
+	authPost(t, server.URL+"/api/v1/auth/2fa/setup", token, `{}`) // setup first
+	resp := authPost(t, server.URL+"/api/v1/auth/2fa/enable", token, `{"code":"000000"}`)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode, "an invalid code must not enable 2FA")
+}
+
+// Test2FA_VerifyValidCode_ReturnsToken: the public 2FA login step, given a valid
+// code for an enabled user, issues a session token (completes 2FA login).
+func Test2FA_VerifyValidCode_ReturnsToken(t *testing.T) {
+	server, db := setupTestServer(t)
+	secret, userID, _ := setupAndEnable2FA(t, server, db, "liam", "Liam@2026")
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	resp := authPost(t, server.URL+"/api/v1/auth/2fa/verify", "",
+		`{"user_id":`+itoaInt64(userID)+`,"code":"`+code+`"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	decodeJSON(t, resp, &body)
+	require.NotEmpty(t, body["token"], "a valid 2FA verify must issue a session token")
+}
+
+// Test2FA_VerifyInvalidCode_Rejected is the BYPASS GUARD: a wrong code at the
+// 2FA login step MUST be rejected (422), never accepted. This is the single
+// most security-critical assertion in the 2FA surface.
+func Test2FA_VerifyInvalidCode_Rejected(t *testing.T) {
+	server, db := setupTestServer(t)
+	_, userID, _ := setupAndEnable2FA(t, server, db, "mike", "Mike@2026")
+
+	resp := authPost(t, server.URL+"/api/v1/auth/2fa/verify", "",
+		`{"user_id":`+itoaInt64(userID)+`,"code":"000000"}`)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"a wrong 2FA code must be rejected with 422 — accepting it is a 2FA bypass")
+	// And critically, no token is issued.
+	var body map[string]any
+	decodeJSON(t, resp, &body)
+	require.Empty(t, body["token"], "no session token on a rejected 2FA verify")
+}
+
+// itoaInt64 formats an int64 for the verify request body.
+func itoaInt64(n int64) string { return strconv.FormatInt(n, 10) }


### PR DESCRIPTION
## 背景
Refs #171。`totp.go` 的 HTTP handler 层此前无测试（`service/totp_test.go` 测算法，不测 handler 的错误→状态映射）。2FA 回归即账号接管。

## 改动
`totp_test.go`（package `handler_test`，扩展 `setupTestServer` 接 TOTP + 用 `totp.GenerateCode` 生成有效码）—— 5 个集成测试覆盖 setup→enable→verify→status 全流程：

| 测试 | 锁定 |
|---|---|
| SetupReturnsSecret | setup→201 + 非空 secret |
| EnableWithValidCode_StatusEnabled | 有效码 enable→200，status 报 enabled |
| EnableWithInvalidCode_Rejected | 错误码不能 enable 2FA |
| VerifyValidCode_ReturnsToken | 公开 2FA 登录步骤，有效码→200 + 发 token |
| **VerifyInvalidCode_Rejected（bypass guard）** | 错误码→**422**，**不发 token** —— 接受错误码 = 2FA 绕过 = 账号接管 |

### 关键安全断言
**VerifyInvalidCode_Rejected** 是 2FA 面最关键的安全测试：错误码必须 422 拒绝 + 不发 token。一个把 422 变 200 的回归就是 2FA 绕过。

附带：`setupTestServer` 补 TOTP 接线（totpSvc + userSvc.SetTOTPService + totpHandler + /2fa 路由），既有测试无回归。

## 验证
`go test -race ./internal/api/handler/` 全绿（96s 全包 race）；`gofmt`/`goimports`/`go vet` 干净；**golangci-lint 0 issues**。handler 覆盖率 **28.0% → 29.7%**。

## #171 进度
至此 **#171 列出的全部安全关键 handler 路径已覆盖**：auth(JWT, #206)、RBAC(401/403, #206)、CSRF(#206)、user 管理(#209)、network(#207)、**2FA(本批)**。

Refs #171.