### PR TITLE
test(handler): scanner_task + audit handler 测试 (#171)

### DIFF
--- a/internal/api/handler/audit_test.go
+++ b/internal/api/handler/audit_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/service"
+	"mibee-steward/internal/testutil"
+)
+
+// These tests pin AuditHandler's List + Facets endpoints (#171): the audit-log
+// read path + query-filter parsing + the facet dropdown source. Audit is
+// admin-only in production (RequireAdmin); tested here directly (handler level)
+// to lock the filter→response shape independent of auth wiring.
+
+func setupAuditHandler(t *testing.T) (*AuditHandler, *sql.DB) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return NewAuditHandler(service.NewAuditService(conn)), conn
+}
+
+func seedAudit(t *testing.T, db *sql.DB, action, resourceType string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO audit_logs (action, resource_type, resource_id, ip_address, details) VALUES (?, ?, ?, ?, '{}')`,
+		action, resourceType, "1", "127.0.0.1")
+	require.NoError(t, err)
+}
+
+func TestAuditHandler_List_ReturnsLogs(t *testing.T) {
+	h, db := setupAuditHandler(t)
+	seedAudit(t, db, "user.login", "user")
+	seedAudit(t, db, "device.update", "device")
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/audit-logs?limit=10", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		AuditLogs []map[string]any `json:"audit_logs"`
+		Total     int              `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Equal(t, 2, resp.Total)
+	require.Len(t, resp.AuditLogs, 2)
+}
+
+func TestAuditHandler_List_FiltersByAction(t *testing.T) {
+	h, db := setupAuditHandler(t)
+	seedAudit(t, db, "user.login", "user")
+	seedAudit(t, db, "device.update", "device")
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/audit-logs?action=user.login&limit=10", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		AuditLogs []map[string]any `json:"audit_logs"`
+		Total     int              `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Equal(t, 1, resp.Total, "action filter narrows to the matching log")
+	require.Len(t, resp.AuditLogs, 1)
+	require.Equal(t, "user.login", resp.AuditLogs[0]["action"])
+}
+
+func TestAuditHandler_Facets(t *testing.T) {
+	h, db := setupAuditHandler(t)
+	seedAudit(t, db, "user.login", "user")
+	seedAudit(t, db, "device.update", "device")
+
+	rec := httptest.NewRecorder()
+	h.Facets(rec, httptest.NewRequest(http.MethodGet, "/api/v1/audit-logs/facets", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Actions       []string `json:"actions"`
+		ResourceTypes []string `json:"resource_types"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.ElementsMatch(t, []string{"user.login", "device.update"}, resp.Actions)
+	require.ElementsMatch(t, []string{"user", "device"}, resp.ResourceTypes)
+}

--- a/internal/api/handler/scanner_task_test.go
+++ b/internal/api/handler/scanner_task_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service/scannerv2/taskservice"
+	"mibee-steward/internal/testutil"
+)
+
+// These tests pin ScannerTaskHandler's HTTP error→status mapping (#171). The
+// underlying taskservice is covered by taskservice_test.go (incl. the
+// scheduler-coupled paths, #205); this locks the thin adapter: create/list/get
+// CRUD + the ErrScanTaskNotFound→404 mapping. A nil scheduler is fine — CRUD
+// doesn't dispatch scans.
+
+const validScanTaskBody = `{"name":"nightly","targets":"192.168.1.0/24","cron_expr":"0 2 * * *","timeout":60,"concurrent_hosts":16,"pipeline_config":{"icmp":{"enabled":true,"timeout":2}}}`
+
+func setupScannerTaskHandler(t *testing.T) (*ScannerTaskHandler, *db.Queries) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	return NewScannerTaskHandler(taskservice.New(queries, nil)), queries
+}
+
+func TestScannerTaskHandler_CreateThenGet(t *testing.T) {
+	h, _ := setupScannerTaskHandler(t)
+
+	rec := httptest.NewRecorder()
+	h.CreateTask(rec, httptest.NewRequest(http.MethodPost, "/api/v1/scanner/tasks", strings.NewReader(validScanTaskBody)))
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	id := int64(created["id"].(float64))
+
+	rec = httptest.NewRecorder()
+	h.GetTask(rec, reqWithURLParam(http.MethodGet, "/api/v1/scanner/tasks/"+strconv.FormatInt(id, 10), "", strconv.FormatInt(id, 10)))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestScannerTaskHandler_Create_InvalidBody(t *testing.T) {
+	h, _ := setupScannerTaskHandler(t)
+	rec := httptest.NewRecorder()
+	h.CreateTask(rec, httptest.NewRequest(http.MethodPost, "/api/v1/scanner/tasks", strings.NewReader("not-json")))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestScannerTaskHandler_GetTask_NotFound(t *testing.T) {
+	h, _ := setupScannerTaskHandler(t)
+	rec := httptest.NewRecorder()
+	h.GetTask(rec, reqWithURLParam(http.MethodGet, "/api/v1/scanner/tasks/999", "", "999"))
+	require.Equal(t, http.StatusNotFound, rec.Code, "missing task → 404")
+}
+
+func TestScannerTaskHandler_ListTasks(t *testing.T) {
+	h, _ := setupScannerTaskHandler(t)
+	// Seed two tasks.
+	for _, body := range []string{
+		`{"name":"a","targets":"10.0.0.0/24","cron_expr":"0 * * * *","timeout":60,"concurrent_hosts":8,"pipeline_config":{"icmp":{"enabled":true,"timeout":2}}}`,
+		`{"name":"b","targets":"10.0.1.0/24","cron_expr":"0 * * * *","timeout":60,"concurrent_hosts":8,"pipeline_config":{"icmp":{"enabled":true,"timeout":2}}}`,
+	} {
+		rec := httptest.NewRecorder()
+		h.CreateTask(rec, httptest.NewRequest(http.MethodPost, "/api/v1/scanner/tasks", strings.NewReader(body)))
+		require.Equal(t, http.StatusCreated, rec.Code)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ListTasks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/scanner/tasks?limit=10", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var list map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&list))
+	require.EqualValues(t, 2, list["total"], "both seeded tasks returned")
+}
+
+func TestScannerTaskHandler_DeleteThenGetNotFound(t *testing.T) {
+	h, _ := setupScannerTaskHandler(t)
+
+	rec := httptest.NewRecorder()
+	h.CreateTask(rec, httptest.NewRequest(http.MethodPost, "/api/v1/scanner/tasks", strings.NewReader(validScanTaskBody)))
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	id := strconv.FormatInt(int64(created["id"].(float64)), 10)
+
+	rec = httptest.NewRecorder()
+	h.DeleteTask(rec, reqWithURLParam(http.MethodDelete, "/api/v1/scanner/tasks/"+id, "", id))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	rec = httptest.NewRecorder()
+	h.GetTask(rec, reqWithURLParam(http.MethodGet, "/api/v1/scanner/tasks/"+id, "", id))
+	require.Equal(t, http.StatusNotFound, rec.Code, "deleted task is gone")
+}


### PR DESCRIPTION
## 背景
Refs #171。两个 handler 的 service 层已测（taskservice #205、AuditService），但 HTTP 适配层（错误→状态映射、filter 解析）未测。

## 改动
两个文件，8 个直接单元测试（构造 handler + httptest，不经路由/auth）：

### `scanner_task_test.go`（5 测试）
直接构造 `NewScannerTaskHandler(taskservice.New(queries, nil))`（nil scheduler——CRUD 不派发扫描）：
- Create→201 / Get→200；Create 坏 body→400；Get 不存在→**404**；List→{tasks,total}；Delete→**204** 后 Get→404
- 锁定 `ErrScanTaskNotFound→404` 的错误映射

### `audit_test.go`（3 测试）
直接构造 `NewAuditHandler(NewAuditService(db))`：
- List→{audit_logs,total}；List?action=X 过滤收窄到匹配项；Facets→{actions,resource_types} 与表实际一致（dropdown 数据源契约）

## 验证
`go test -race ./internal/api/handler/` 全绿（102s）；`gofmt`/`goimports`/`go vet` 干净；**golangci-lint 0 issues**。handler 覆盖率 **29.7% → 31.8%**。

Refs #171.