### PR TITLE
test(handler): SNMP credential handler 测试（含 passphrase 泄露守护）(#171)

### DIFF
--- a/internal/api/handler/credential_test.go
+++ b/internal/api/handler/credential_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/testutil"
+)
+
+// These tests pin the SNMP-credential handler's security invariants (#171):
+//   - With no master_key configured, mutating endpoints are DISABLED (503) —
+//     SNMPv3 passphrases can't be stored unencrypted.
+//   - The encrypted auth/priv passphrases NEVER appear in any API response —
+//     only HasAuth/HasPriv booleans (so a credential is identifiable without
+//     leaking its secret). A regression that echoes the *_enc column is a
+//     credential-disclosure hole.
+
+func setupCredentialHandler(t *testing.T) (*CredentialHandler, *sql.DB) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	// nil cipher + nil resolver: mirrors a deployment without security.master_key
+	// (the disabled-storage state). Get/List work without a cipher; Create/Update
+	// are the disabled-path guards under test.
+	return NewCredentialHandler(conn, nil, nil), conn
+}
+
+func TestCredentialHandler_NilCipher_CreateReturns503(t *testing.T) {
+	h, _ := setupCredentialHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/snmp-credentials", strings.NewReader(`{}`)))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"Create with no master_key must be disabled (503), not store an unencrypted passphrase")
+}
+
+func TestCredentialHandler_NilCipher_UpdateReturns503(t *testing.T) {
+	h, _ := setupCredentialHandler(t)
+	rec := httptest.NewRecorder()
+	h.Update(rec, reqWithURLParam(http.MethodPut, "/api/v1/snmp-credentials/1", `{}`, "1"))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"Update with no master_key must be disabled (503)")
+}
+
+func TestCredentialHandler_Get_NotFound(t *testing.T) {
+	h, _ := setupCredentialHandler(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, reqWithURLParam(http.MethodGet, "/api/v1/snmp-credentials/999", "", "999"))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestCredentialHandler_Get_RedactsPassphrases is the disclosure guard: a
+// credential row holding ENCRYPTED passphrases must surface only the
+// HasAuth/HasPriv booleans — the encrypted secret value must never appear in
+// the response body.
+func TestCredentialHandler_Get_RedactsPassphrases(t *testing.T) {
+	h, db := setupCredentialHandler(t)
+	const secret = "SUPER-SECRET-ENCRYPTED-PASSPHRASE"
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO snmp_credentials
+		  (name, security_level, community, username, auth_protocol, auth_passphrase_enc, priv_protocol, priv_passphrase_enc, notes)
+		VALUES ('router-v3', 'authPriv', 'public', 'snmpv3user', 'SHA', ?, 'AES', ?, 'notes')`,
+		secret, secret)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	h.Get(rec, reqWithURLParam(http.MethodGet, "/api/v1/snmp-credentials/1", "", "1"))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The encrypted passphrase must NOT leak into the API response.
+	require.NotContains(t, rec.Body.String(), secret,
+		"the encrypted passphrase must never appear in a credential response (disclosure guard)")
+
+	// Only the boolean "is it set" indicators are exposed.
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, true, resp["has_auth"], "has_auth surfaces without the passphrase")
+	require.Equal(t, true, resp["has_priv"], "has_priv surfaces without the passphrase")
+	// No passphrase-valued key exists at all.
+	for _, k := range []string{"auth_passphrase", "priv_passphrase", "auth_passphrase_enc", "priv_passphrase_enc"} {
+		require.NotContains(t, resp, k, "no passphrase field in response")
+	}
+}
+
+// TestCredentialHandler_List_RedactsPassphrases extends the disclosure guard to
+// the list endpoint (which uses a masked projection, but a regression that
+// swaps in the full row would leak there too).
+func TestCredentialHandler_List_RedactsPassphrases(t *testing.T) {
+	h, db := setupCredentialHandler(t)
+	const secret = "LIST-SECRET-ENC"
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO snmp_credentials
+		  (name, security_level, community, username, auth_protocol, auth_passphrase_enc, priv_protocol, priv_passphrase_enc)
+		VALUES ('list-v3', 'authPriv', 'public', 'u', 'SHA', ?, 'AES', ?)`, secret, secret)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/snmp-credentials", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), secret, "list response must not leak passphrases")
+}


### PR DESCRIPTION
## 背景
Refs #171。`credential.go` 是 SNMPv3 凭据 CRUD（加密存储 auth/priv passphrase），此前无测试 —— 回归即凭据泄露。

## 改动
`credential_test.go`，5 个直接单元测试（nil cipher，免 master_key 依赖；Get/List 不需 cipher，Create/Update 走禁用守卫）：

| 测试 | 锁定 |
|---|---|
| NilCipher_CreateReturns503 | 未配 master_key 时 Create 禁用（503），不存未加密 passphrase |
| NilCipher_UpdateReturns503 | 同上，Update |
| Get_NotFound | 404 |
| **Get_RedactsPassphrases**（泄露守护） | 种入 enc passphrase，Get 响应里 enc 值**绝不出现**——只 has_auth/has_priv 布尔；无 passphrase 字段 |
| List_RedactsPassphrases | list 端同样不泄露 |

### 关键安全契约
`toCredentialResponse` 只回 `HasAuth`/`HasPriv`，**绝不回 `*_passphrase_enc`**。这是凭据不外泄的命门 —— 本测试钉住（响应体不含 enc 值 + 无 passphrase 字段）。

## 验证
`go test -race ./internal/api/handler/`（前序 PR 已验证全包 race）；`gofmt`/`goimports`/`go vet` 干净；**golangci-lint 0 issues**。handler 覆盖率 **31.8% → ~33.7%**。

Refs #171.