### PR TITLE
test(web): devices 页渲染测试（第二个 .svelte 页测试）(#171)

### DIFF
--- a/web/src/__tests__/devices.page.test.ts
+++ b/web/src/__tests__/devices.page.test.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+// Mock external-behavior modules so the page loads under jsdom. render-only —
+// no submit/navigation exercised — so the spies exist only to resolve imports.
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$lib/api/client', () => ({
+	api: {
+		// The device list fires 3 GETs on mount (devices, stats, networks).
+		// Route each to an empty-but-shaped Promise so onMount doesn't throw.
+		get: vi.fn((url: string) => {
+			if (url.startsWith('/devices/stats')) return Promise.resolve({ by_status: {}, by_type: {} });
+			if (url.startsWith('/devices')) return Promise.resolve({ devices: [], total: 0 });
+			if (url.startsWith('/networks')) return Promise.resolve([]);
+			return Promise.resolve([]);
+		}),
+		post: vi.fn(() => Promise.resolve({})),
+		put: vi.fn(() => Promise.resolve({})),
+		del: vi.fn(() => Promise.resolve({}))
+	},
+	ApiError: class ApiError extends Error {},
+	SessionExpiredError: class SessionExpiredError extends Error {}
+}));
+
+import Devices from '../routes/devices/+page.svelte';
+
+describe('Devices page', () => {
+	it('mounts and renders the page header (title + view controls)', () => {
+		const { container } = render(Devices);
+
+		// The page header (h2 title) is always rendered — not gated on the
+		// loading state — so it's a stable "the page mounted" signal.
+		const h2 = container.querySelector('h2');
+		expect(h2).toBeTruthy();
+		expect((h2?.textContent ?? '').trim().length).toBeGreaterThan(0);
+
+		// The list/topology view toggle is part of the header chrome.
+		expect(container.querySelector('button')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## 背景
承接 #208（login 渲染 + svelteTesting 模式），补 #171 AC 的设备列表页渲染测试。devices 页是重页面（1475 行 + 11 子组件 + onMount 三路取数），但**无 ECharts**，按 login 的 mock 策略可渲染。

## 改动
`src/__tests__/devices.page.test.ts`：
- mock `$app/navigation` + `$lib/api/client`（`get` 按 URL 路由到空但成型 Promise，让 onMount 的 `/devices` `/devices/stats` `/networks` 三路取数不抛）
- 断言页头 h2 标题常驻渲染（不受 loading 状态门控）+ 有 button 控件

## 价值
验证了**重数据驱动页也能走 svelteTesting + api mock 渲染模式**（device detail 例外：用 ECharts/canvas，需另 mock Chart 组件）。#171 AC 的 4 页里 login + devices 两页已落地，模式可复用于 scanner-results。

## 验证
全前端套件 `npx vitest run` **10 文件 194 测试全绿**（既有无回归）。

Refs #171.