### PR TITLE
test(web): scanner 页渲染测试（#171 前端 AC 4 页全落）(#171)

### DIFF
--- a/web/src/__tests__/scanner.page.test.ts
+++ b/web/src/__tests__/scanner.page.test.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+// render-only — mock external-behavior modules so the page loads under jsdom.
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$lib/api/client', () => ({
+	api: {
+		// onMount fetches the SNMP credential list for the dropdown.
+		get: vi.fn((url: string) => {
+			if (url.startsWith('/snmp-credentials')) return Promise.resolve([]);
+			return Promise.resolve([]);
+		}),
+		post: vi.fn(() => Promise.resolve({ hosts: [] })),
+		put: vi.fn(() => Promise.resolve({})),
+		del: vi.fn(() => Promise.resolve({}))
+	},
+	ApiError: class ApiError extends Error {},
+	SessionExpiredError: class SessionExpiredError extends Error {}
+}));
+
+import Scanner from '../routes/devices/scanner/+page.svelte';
+
+describe('Scanner page', () => {
+	it('mounts and renders the scan form (heading + target inputs + scan button)', () => {
+		const { container } = render(Scanner);
+
+		// Page header is always rendered.
+		const h2 = container.querySelector('h2');
+		expect(h2).toBeTruthy();
+		expect((h2?.textContent ?? '').trim().length).toBeGreaterThan(0);
+
+		// The scan form has target inputs + a submit button.
+		expect(container.querySelectorAll('input').length).toBeGreaterThanOrEqual(1);
+		expect(container.querySelector('button')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## 背景
补 #171 前端 AC 的扫描页渲染测试。scanner 页（657 行，**无 ECharts**）onMount 取 `/snmp-credentials` —— 按 login(#208)/devices(#213) 的 mock 策略可渲染。

## 改动
`src/__tests__/scanner.page.test.ts`：
- mock `$app/navigation` + `$lib/api/client`（`get /snmp-credentials` → `[]`）
- 断言页头 h2 + 表单 input + scan button

## #171 前端 AC 状态（设备列表/详情/登录/扫描结果）
- ✅ login — #208
- ✅ devices 列表 — #213
- ✅ scanner 扫描 — 本批
- ⏳ device **详情** — 用 ECharts/canvas，jsdom 无法直接渲染，需另 mock Chart 组件（唯一未落，follow-up）

3/4 页落地 + 渲染模式（svelteTesting + api mock）确立。

## 验证
全前端套件 `npx vitest run` **11 文件 195 测试全绿**。

Refs #171.