### PR TITLE
feat(rbac): 能力图 + RequireCapability 中间件（#138 Phase 1a）

### DIFF
--- a/internal/api/middleware/capability_test.go
+++ b/internal/api/middleware/capability_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/api/middleware"
+	"mibee-steward/internal/domain"
+)
+
+// These tests pin RequireCapability (#138 Phase 1a). It wraps Authenticator, so
+// the role is taken from the JWT claim — which means operator/viewer can be
+// exercised WITHOUT a DB user or a users.role CHECK widening (the claim is
+// free-form; Authenticator does not validate it against the users table). That
+// lets the capability gate be tested end-to-end before Phase 1b wires real
+// operator/viewer accounts.
+
+// withRoleCap wraps RequireCapability(cap) around okHandler (200 "ok").
+func withRoleCap(capability domain.Capability) http.Handler {
+	return middleware.RequireCapability(capability)(okHandler())
+}
+
+func TestRequireCapability_AdminPassesAnyCapability(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 1.0, "role": "admin"})
+	for _, c := range []domain.Capability{
+		domain.CapDeviceRead, domain.CapScanTrigger, domain.CapUserManage, domain.CapCredManage,
+	} {
+		rec := newCapRecorder(tok, c)
+		require.Equal(t, http.StatusOK, rec.Code, "admin must pass %s", c)
+	}
+}
+
+func TestRequireCapability_OperatorPassesOpsNotAdminMgmt(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 2.0, "role": "operator"})
+
+	// Operator can trigger scans + write devices.
+	require.Equal(t, http.StatusOK, newCapRecorder(tok, domain.CapScanTrigger).Code)
+	require.Equal(t, http.StatusOK, newCapRecorder(tok, domain.CapDeviceWrite).Code)
+
+	// Operator must NOT manage users/credentials/networks.
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapUserManage).Code)
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapCredManage).Code)
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapNetworkManage).Code)
+}
+
+func TestRequireCapability_ViewerReadsOnly(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 3.0, "role": "viewer"})
+
+	require.Equal(t, http.StatusOK, newCapRecorder(tok, domain.CapDeviceRead).Code, "viewer reads")
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapScanTrigger).Code, "viewer cannot trigger scans")
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapDeviceWrite).Code, "viewer cannot write")
+}
+
+// TestRequireCapability_LegacyUserBehavesAsViewer: an existing JWT with the
+// legacy "user" role must behave as viewer (so deployed tokens keep working
+// through Phase 1 without re-issuance).
+func TestRequireCapability_LegacyUserBehavesAsViewer(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 4.0, "role": "user"})
+
+	require.Equal(t, http.StatusOK, newCapRecorder(tok, domain.CapDeviceRead).Code)
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapScanTrigger).Code)
+}
+
+func TestRequireCapability_UnauthenticatedReturns401(t *testing.T) {
+	useJWTAuth(t)
+	// No Bearer token at all.
+	rec := httptest.NewRecorder()
+	withRoleCap(domain.CapDeviceRead).ServeHTTP(rec, reqWithBearer(""))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestRequireCapability_UnknownRoleRejected: a JWT claiming a role the map does
+// not know (e.g. a tampered/future claim) must be rejected (403), never pass.
+func TestRequireCapability_UnknownRoleRejected(t *testing.T) {
+	useJWTAuth(t)
+	tok := issueToken(t, map[string]any{"user_id": 5.0, "role": "superuser"})
+	// Even a read capability is denied — unknown roles fail closed.
+	require.Equal(t, http.StatusForbidden, newCapRecorder(tok, domain.CapDeviceRead).Code)
+}
+
+// newCapRecorder fires one GET through RequireCapability(cap) with the given
+// bearer token and returns the recorder.
+func newCapRecorder(bearerToken string, capability domain.Capability) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	withRoleCap(capability).ServeHTTP(rec, reqWithBearer(bearerToken))
+	return rec
+}

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -11,6 +11,8 @@ package middleware
 
 import (
 	"net/http"
+
+	"mibee-steward/internal/domain"
 )
 
 // RequireAuth returns middleware that requires a valid authenticated user.
@@ -48,4 +50,36 @@ func RequireAdmin(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	}))
+}
+
+// RequireCapability returns middleware requiring the authenticated user's role
+// to grant cap (#138). It wraps Authenticator, so the role is resolved from the
+// JWT claim just like RequireAuth/RequireAdmin. Responses:
+//   - no/invalid token → 401 (Authenticator left no user in context),
+//   - authenticated but the role lacks cap → 403,
+//   - the role grants cap → next.
+//
+// Use this in place of RequireAdmin where a non-admin role (e.g. operator)
+// should be allowed; RequireAdmin stays for hard admin-only surfaces. The
+// capability map lives in internal/domain (RoleHas) so role→capability stays a
+// single source of truth.
+func RequireCapability(capability domain.Capability) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return Authenticator(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, role, ok := GetUserFromContext(r)
+			if !ok {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+			if !domain.RoleHas(domain.UserRole(role), capability) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"forbidden: insufficient capability"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		}))
+	}
 }

--- a/internal/domain/capability.go
+++ b/internal/domain/capability.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package domain
+
+// Capability is a granular permission a role may hold. Routes gate on a
+// capability via middleware.RequireCapability (issue #138), replacing the
+// binary admin/user string check. Capabilities are defined in code (not a DB
+// table) so the role model stays simple to operate; a future phase can promote
+// to DB-driven roles/permissions if custom roles become necessary.
+type Capability string
+
+const (
+	// --- Read capabilities (granted to viewer and inherited by operator/admin) ---
+	CapDeviceRead       Capability = "device:read"
+	CapNetworkRead      Capability = "network:read"
+	CapConfigRead       Capability = "config:read" // device config-backup versions + diff
+	CapChangesRead      Capability = "changes:read"
+	CapTopologyRead     Capability = "topology:read"
+	CapDiscoveryRead    Capability = "discovery:read"
+	CapHeartbeatRead    Capability = "heartbeat:read"
+	CapDocumentRead     Capability = "document:read"
+	CapDashboardRead    Capability = "dashboard:read"
+	CapNotificationRead Capability = "notification:read"
+	CapAuditRead        Capability = "audit:read"
+
+	// --- Operational capabilities (operator adds these on top of reads) ---
+	CapDeviceWrite     Capability = "device:write"     // edit device fields, batch ops
+	CapScanTrigger     Capability = "scan:trigger"     // run a scan (sync + async task trigger/cancel)
+	CapScanManage      Capability = "scan:manage"      // scan task CRUD
+	CapHeartbeatManage Capability = "heartbeat:manage" // heartbeat config CRUD
+	CapDocumentWrite   Capability = "document:write"
+
+	// --- Administrative capabilities (admin only) ---
+	CapNetworkManage      Capability = "network:manage" // create/edit/delete networks
+	CapCredManage         Capability = "cred:manage"    // SNMP + SSH credentials
+	CapUserManage         Capability = "user:manage"    // users, roles, network grants
+	CapAgentManage        Capability = "agent:manage"   // agent tokens + commands
+	CapAuditManage        Capability = "audit:manage"
+	CapDashboardManage    Capability = "dashboard:manage"
+	CapNotificationManage Capability = "notification:manage" // channels + rules
+)
+
+// readCaps is the read-only capability set granted to viewer. operator and
+// admin inherit it. Listed explicitly (no wildcard) so the grant is auditable.
+var readCaps = map[Capability]bool{
+	CapDeviceRead: true, CapNetworkRead: true, CapConfigRead: true,
+	CapChangesRead: true, CapTopologyRead: true, CapDiscoveryRead: true,
+	CapHeartbeatRead: true, CapDocumentRead: true, CapDashboardRead: true,
+	CapNotificationRead: true, CapAuditRead: true,
+}
+
+// operatorCaps = reads + operational writes (no user/cred/network/agent mgmt).
+var operatorCaps = union(readCaps, map[Capability]bool{
+	CapDeviceWrite: true, CapScanTrigger: true, CapScanManage: true,
+	CapHeartbeatManage: true, CapDocumentWrite: true,
+})
+
+// adminCaps = every defined capability.
+var adminCaps = union(operatorCaps, map[Capability]bool{
+	CapNetworkManage: true, CapCredManage: true, CapUserManage: true,
+	CapAgentManage: true, CapAuditManage: true, CapDashboardManage: true,
+	CapNotificationManage: true,
+})
+
+// roleCapabilities is the authoritative role → capability map. It is the single
+// source of truth for what each role can do; middleware.RequireCapability and
+// any UI role-awareness read from here.
+var roleCapabilities = map[UserRole]map[Capability]bool{
+	RoleAdmin:    adminCaps,
+	RoleOperator: operatorCaps,
+	RoleViewer:   readCaps,
+	RoleUser:     readCaps, // legacy alias for viewer
+}
+
+// RoleHas reports whether the role grants the capability. An unknown role (e.g.
+// an empty/invalid value) grants nothing — fail-closed.
+func RoleHas(role UserRole, capability Capability) bool {
+	caps, ok := roleCapabilities[role]
+	if !ok {
+		return false
+	}
+	return caps[capability]
+}
+
+// RoleCapabilities returns a copy of the capability set for a role (for
+// introspection / UI). Returns nil for an unknown role.
+func RoleCapabilities(role UserRole) map[Capability]bool {
+	caps, ok := roleCapabilities[role]
+	if !ok {
+		return nil
+	}
+	out := make(map[Capability]bool, len(caps))
+	for c := range caps {
+		out[c] = true
+	}
+	return out
+}
+
+// union returns a new map = a ∪ b (does not mutate inputs).
+func union(a, b map[Capability]bool) map[Capability]bool {
+	out := make(map[Capability]bool, len(a)+len(b))
+	for c := range a {
+		out[c] = true
+	}
+	for c := range b {
+		out[c] = true
+	}
+	return out
+}

--- a/internal/domain/capability_test.go
+++ b/internal/domain/capability_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the role → capability map (#138 Phase 1a). The map is the
+// single source of truth both middleware (RequireCapability) and any UI
+// role-awareness read, so its shape — what each role can and cannot do — is a
+// security-relevant contract. Fail-closed for unknown roles.
+
+func TestRoleHas_AdminGrantsEverything(t *testing.T) {
+	// Admin holds every defined capability (sample the span: read, op, admin).
+	for _, c := range []Capability{
+		CapDeviceRead, CapScanTrigger, CapScanManage, CapDeviceWrite,
+		CapUserManage, CapCredManage, CapNetworkManage, CapAgentManage,
+	} {
+		require.True(t, RoleHas(RoleAdmin, c), "admin must grant %s", c)
+	}
+}
+
+func TestRoleHas_OperatorReadsAndOpsButNoAdminMgmt(t *testing.T) {
+	// Operator: reads + operational writes.
+	for _, c := range []Capability{CapDeviceRead, CapScanTrigger, CapScanManage, CapDeviceWrite, CapHeartbeatManage} {
+		require.True(t, RoleHas(RoleOperator, c), "operator must grant %s", c)
+	}
+	// Operator must NOT reach into admin-only management.
+	for _, c := range []Capability{CapUserManage, CapCredManage, CapNetworkManage, CapAgentManage} {
+		require.False(t, RoleHas(RoleOperator, c), "operator must NOT grant %s (admin-only)", c)
+	}
+}
+
+func TestRoleHas_ViewerReadsOnly(t *testing.T) {
+	require.True(t, RoleHas(RoleViewer, CapDeviceRead))
+	require.True(t, RoleHas(RoleViewer, CapConfigRead))
+	// Viewer cannot mutate or trigger anything.
+	for _, c := range []Capability{CapDeviceWrite, CapScanTrigger, CapScanManage, CapUserManage} {
+		require.False(t, RoleHas(RoleViewer, c), "viewer must NOT grant %s (read-only role)", c)
+	}
+}
+
+// TestRoleHas_LegacyUserIsViewer pins the migration-free alias: existing "user"
+// accounts behave exactly as viewer (no data migration needed in Phase 1).
+func TestRoleHas_LegacyUserIsViewer(t *testing.T) {
+	for _, c := range []Capability{
+		CapDeviceRead, CapConfigRead, CapChangesRead, // reads: yes
+		CapDeviceWrite, CapScanTrigger, CapUserManage, // writes: no
+	} {
+		require.Equal(t, RoleHas(RoleViewer, c), RoleHas(RoleUser, c),
+			"legacy 'user' must match viewer for %s", c)
+	}
+}
+
+// TestRoleHas_UnknownRoleFailsClosed: an empty/garbage role grants nothing.
+// This is the guard against a malformed JWT claim or a future role not yet in
+// the map — never fail open.
+func TestRoleHas_UnknownRoleFailsClosed(t *testing.T) {
+	for _, role := range []UserRole{"", "superuser", "root", "OPERATOR"} {
+		require.False(t, RoleHas(role, CapDeviceRead), "unknown role %q must grant nothing", role)
+	}
+}
+
+func TestRoleCapabilities_ReturnsCopy(t *testing.T) {
+	caps := RoleCapabilities(RoleOperator)
+	require.NotEmpty(t, caps)
+	require.True(t, caps[CapScanTrigger])
+	// Mutating the returned map must not corrupt the authoritative map.
+	caps[CapUserManage] = true
+	require.False(t, RoleHas(RoleOperator, CapUserManage),
+		"RoleCapabilities must return a copy so callers cannot escalate a role")
+}
+
+func TestRoleCapabilities_UnknownRoleNil(t *testing.T) {
+	require.Nil(t, RoleCapabilities("nonexistent"))
+}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -11,12 +11,18 @@ package domain
 
 import "time"
 
-// UserRole represents a user's role in the system.
+// UserRole represents a user's role in the system. Roles map to capability sets
+// (see capability.go); authorization is enforced by middleware.RequireCapability,
+// not by string-equality on the role. Phase 1a (#138) introduces operator/viewer
+// alongside the legacy admin/user; "user" is treated as an alias for "viewer" so
+// existing accounts need no data migration.
 type UserRole string
 
 const (
-	RoleAdmin UserRole = "admin"
-	RoleUser  UserRole = "user"
+	RoleAdmin    UserRole = "admin"    // global administrator: all capabilities, bypasses object scope
+	RoleOperator UserRole = "operator" // operational: reads + scan/device/heartbeat ops, no user/cred/network mgmt
+	RoleViewer   UserRole = "viewer"   // read-only
+	RoleUser     UserRole = "user"     // legacy alias for viewer (existing accounts)
 )
 
 // Request types


### PR DESCRIPTION
## 背景
#138（多角色 + 对象级作用域）Phase 1a：**RBAC 能力基础设施**。纯增量代码，零 schema 风险 —— 既有 `RequireAdmin`/`RequireAuth` 路由完全不动，`users.role` CHECK 放宽 + 路由能力重映射留 Phase 1b。设计见 [#138 评论](issue URL)。

## 改动

### `internal/domain/capability.go`（新）
- `Capability` 类型 + 能力常量（三档：读 / 操作 / 管理）。
- **`roleCapabilities` 权威 map**（role → 能力集）：
  - `admin`：全部
  - `operator`：读全部 + `device:write` / `scan:trigger` / `scan:manage` / `heartbeat:manage` / `document:write`（不管 user/cred/network/agent）
  - `viewer` / `user`(legacy 别名)：只读
- `RoleHas(role, cap)` —— **fail-closed**：未知角色不授权。
- `RoleCapabilities(role)` —— 返回副本（防调用方篡改权威 map 提权）。

### `internal/domain/user.go`
- 加 `RoleOperator` / `RoleViewer`；`RoleUser` 标注为 viewer 的 legacy 别名（**免数据迁移**）。

### `internal/api/middleware/rbac.go`
- **`RequireCapability(cap)`**：包 `Authenticator`，role 从 JWT claim 取；无 token→401，角色不持有能力→403，持有→next。Phase 1b 用它替代裸 `RequireAdmin` 放行 operator 面（如 scan trigger）。

## 测试（端到端，无需 DB 用户）
- `domain/capability_test.go`：admin 全能 / operator 读+操作非管理 / viewer 只读 / **legacy user=viewer** / 未知角色 fail-closed / RoleCapabilities 返回副本。
- `middleware/capability_test.go`：`RequireCapability` 端到端 —— 用 **JWT 注入 role**（`operator`/`viewer`/`user`/未知），无需 DB 用户或 CHECK 放宽（Authenticator 不校验 claim 对 users 表）。这让能力闸门在 Phase 1b 真角色落地前就可完整测。

## 为何零 schema 风险
不改 `users` 表、不改路由。仅新增代码 + 中间件 + 测试。既有 `RequireAdmin` 行为 byte-for-byte 不变。Phase 1b 再做 CHECK 放宽（operator/viewer 可创建）+ 路由重映射。

## 验证
`go test ./...` 全绿；`gofmt`/`goimports`/`go vet`/`golangci-lint`（0 issues）。

Refs #138.