### PR TITLE
feat(sshcred): SSH 凭据存储 + 解析器（#137）

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -662,3 +662,24 @@ CREATE TABLE IF NOT EXISTS device_configs (
     fetched_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_device_configs_device_id ON device_configs(device_id, id);
+
+-- ssh_credentials: encrypted SSH credentials for the device config-backup probe
+-- (#137). secret_enc holds the AES-GCM ciphertext of the password OR the PEM
+-- private key; passphrase_enc holds the ciphertext of an encrypted key's
+-- passphrase (empty if the key is unencrypted). Encryption reuses the SNMP
+-- master_key crypto.Cipher (security.master_key) so there is ONE key source.
+-- host_key_fp is the expected SSH host-key fingerprint (TOFU pinning): the probe
+-- accepts+stores it on first connect, then rejects a change (MITM guard).
+CREATE TABLE IF NOT EXISTS ssh_credentials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    auth_method TEXT NOT NULL CHECK(auth_method IN ('password', 'key')),
+    username TEXT NOT NULL DEFAULT '',
+    secret_enc TEXT NOT NULL DEFAULT '',       -- AES-GCM(password | PEM private key)
+    passphrase_enc TEXT NOT NULL DEFAULT '',   -- AES-GCM(key passphrase); '' = unencrypted key
+    host_key_fp TEXT NOT NULL DEFAULT '',       -- expected SHA256 fp (TOFU); '' = not yet pinned
+    enabled INTEGER NOT NULL DEFAULT 1,
+    notes TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/service/scannerv2/sshcred/resolver.go
+++ b/internal/service/scannerv2/sshcred/resolver.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package sshcred
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"mibee-steward/internal/crypto"
+)
+
+// Credential is the decrypted plaintext an SSH client consumes to connect
+// (returned by Resolver.Resolve). It is the ONLY type in this package that
+// carries plaintext secrets, keeping the decrypt surface small and auditable.
+type Credential struct {
+	ID         int64
+	Name       string
+	AuthMethod string // "password" | "key"
+	Username   string
+	Secret     string // plaintext password OR PEM private key
+	Passphrase string // plaintext passphrase for an encrypted key ("" if none)
+	HostKeyFP  string // expected SHA256 fingerprint (TOFU); "" = not pinned
+}
+
+// ErrDisabled is returned when the resolver has no cipher (no master key
+// configured). Lets the probe fall back / skip cleanly, mirroring credresolver.
+var ErrDisabled = errors.New("sshcred: disabled (no master key configured)")
+
+// Resolver decrypts SSH credentials on demand via the shared crypto.Cipher. A
+// nil cipher (no master key) yields ErrDisabled from every Resolve — SSH
+// credential storage is then unavailable, matching the SNMP credential behavior.
+//
+// No in-memory cache: the config-backup probe resolves a credential at most
+// once per device per (hourly) cycle, so the decrypt cost is negligible and a
+// cache would only add stale-on-rotate risk. (credresolver caches because the
+// SNMP engine resolves per-host-per-scan; the SSH probe does not.)
+type Resolver struct {
+	db     *sql.DB
+	cipher *crypto.Cipher
+}
+
+// New constructs the resolver. cipher may be nil (→ Resolve returns ErrDisabled).
+func New(db *sql.DB, cipher *crypto.Cipher) *Resolver {
+	return &Resolver{db: db, cipher: cipher}
+}
+
+// Resolve decrypts the credential with the given id and returns the plaintext
+// form an SSH client needs. Returns:
+//   - (nil, ErrDisabled) when no master key is configured;
+//   - (nil, ErrNotFound) when the row does not exist;
+//   - (nil, err) on a decrypt failure (tampered blob / wrong key / malformed).
+func (r *Resolver) Resolve(ctx context.Context, id int64) (*Credential, error) {
+	if r.cipher == nil {
+		return nil, ErrDisabled
+	}
+	row, err := Get(ctx, r.db, id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	return r.decryptRow(row)
+}
+
+// ResolveByName is the same lookup by credential name.
+func (r *Resolver) ResolveByName(ctx context.Context, name string) (*Credential, error) {
+	if r.cipher == nil {
+		return nil, ErrDisabled
+	}
+	row, err := GetByName(ctx, r.db, name)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	return r.decryptRow(row)
+}
+
+func (r *Resolver) decryptRow(row Row) (*Credential, error) {
+	secret, err := r.cipher.Decrypt(row.SecretEnc)
+	if err != nil {
+		return nil, err
+	}
+	// passphrase_enc may be empty (unencrypted key / password auth) — Decrypt("")
+	// returns ("", nil) per the cipher contract, so this is a no-op then.
+	passphrase, err := r.cipher.Decrypt(row.PassphraseEnc)
+	if err != nil {
+		return nil, err
+	}
+	return &Credential{
+		ID:         row.ID,
+		Name:       row.Name,
+		AuthMethod: row.AuthMethod,
+		Username:   row.Username,
+		Secret:     secret,
+		Passphrase: passphrase,
+		HostKeyFP:  row.HostKeyFP,
+	}, nil
+}

--- a/internal/service/scannerv2/sshcred/sshcred_test.go
+++ b/internal/service/scannerv2/sshcred/sshcred_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package sshcred
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/crypto"
+	"mibee-steward/internal/testutil"
+)
+
+// testDB builds an in-memory DB with the schema (incl. ssh_credentials) for
+// store + resolver tests.
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// These tests pin the SSH credential store + resolver (#137). The load-bearing
+// security contracts:
+//   - the store carries ciphertext only (plaintext never crosses it),
+//   - List omits the ciphertext columns (no secret leak via the list view),
+//   - the Resolver is the single decrypt path; a nil cipher (no master key)
+//     disables SSH cred storage (ErrDisabled), and a real cipher round-trips
+//     plaintext through the AES-GCM envelope.
+
+func newCtx() context.Context { return context.Background() }
+
+func TestStore_CreateGetRoundTrip(t *testing.T) {
+	db := testDB(t)
+	ctx := newCtx()
+
+	id, err := Create(ctx, db, WriteParams{
+		Name: "router-ssh", AuthMethod: "password", Username: "admin",
+		SecretEnc: "CIPHERTEXT-BLOB", HostKeyFP: "SHA256:abc", Enabled: true, Notes: "core",
+	})
+	require.NoError(t, err)
+
+	row, err := Get(ctx, db, id)
+	require.NoError(t, err)
+	require.Equal(t, "router-ssh", row.Name)
+	require.Equal(t, "CIPHERTEXT-BLOB", row.SecretEnc, "store holds ciphertext verbatim")
+	require.Equal(t, "SHA256:abc", row.HostKeyFP)
+	require.True(t, row.Enabled)
+}
+
+func TestStore_GetByName(t *testing.T) {
+	db := testDB(t)
+	ctx := newCtx()
+	_, err := Create(ctx, db, WriteParams{Name: "sw1", AuthMethod: "key", SecretEnc: "x"})
+	require.NoError(t, err)
+
+	row, err := GetByName(ctx, db, "sw1")
+	require.NoError(t, err)
+	require.Equal(t, "sw1", row.Name)
+}
+
+func TestStore_List_OmitsCiphertext(t *testing.T) {
+	db := testDB(t)
+	ctx := newCtx()
+	_, err := Create(ctx, db, WriteParams{Name: "a", AuthMethod: "password", SecretEnc: "SECRET-A", PassphraseEnc: "PP-A"})
+	require.NoError(t, err)
+
+	rows, err := List(ctx, db, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	// ListRow has no SecretEnc/PassphraseEnc fields at all (compile-time guarantee
+	// the list view never carries the blobs); verify the metadata is present.
+	require.Equal(t, "a", rows[0].Name)
+}
+
+func TestStore_UpdateAndDelete(t *testing.T) {
+	db := testDB(t)
+	ctx := newCtx()
+	id, err := Create(ctx, db, WriteParams{Name: "u", AuthMethod: "password", SecretEnc: "old"})
+	require.NoError(t, err)
+
+	require.NoError(t, Update(ctx, db, id, WriteParams{Name: "u2", AuthMethod: "key", SecretEnc: "new", Enabled: true}))
+	row, err := Get(ctx, db, id)
+	require.NoError(t, err)
+	require.Equal(t, "u2", row.Name)
+	require.Equal(t, "new", row.SecretEnc)
+	require.Equal(t, "key", row.AuthMethod)
+
+	n, err := Delete(ctx, db, id)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+	_, err = Get(ctx, db, id)
+	require.ErrorIs(t, err, ErrNotFound, "deleted row is gone")
+}
+
+func TestStore_Update_NotFound(t *testing.T) {
+	db := testDB(t)
+	err := Update(newCtx(), db, 999, WriteParams{Name: "x", AuthMethod: "password"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// --- Resolver ---
+
+func TestResolver_NilCipherDisabled(t *testing.T) {
+	db := testDB(t)
+	id, _ := Create(newCtx(), db, WriteParams{Name: "n", AuthMethod: "password", SecretEnc: "x"})
+
+	r := New(db, nil) // no master key
+	_, err := r.Resolve(newCtx(), id)
+	require.ErrorIs(t, err, ErrDisabled, "no master key -> SSH cred storage disabled")
+}
+
+func TestResolver_RoundTripsPlaintext(t *testing.T) {
+	db := testDB(t)
+	// A real 32-byte master key + cipher (the all-zero key is fine for a test).
+	cipher, err := crypto.NewCipher(make([]byte, crypto.MasterKeyLen))
+	require.NoError(t, err)
+
+	// Encrypt a password + a key passphrase at "write" time (the handler does
+	// this), store the ciphertext, then resolve and recover the plaintext.
+	encSecret, err := cipher.Encrypt("s3cret-pw")
+	require.NoError(t, err)
+	encPP, err := cipher.Encrypt("key-passphrase")
+	require.NoError(t, err)
+	id, err := Create(newCtx(), db, WriteParams{
+		Name: "r1", AuthMethod: "password", Username: "op",
+		SecretEnc: encSecret, PassphraseEnc: encPP, HostKeyFP: "SHA256:fp",
+	})
+	require.NoError(t, err)
+
+	r := New(db, cipher)
+	cred, err := r.Resolve(newCtx(), id)
+	require.NoError(t, err)
+	require.Equal(t, "s3cret-pw", cred.Secret, "plaintext password recovered through the envelope")
+	require.Equal(t, "key-passphrase", cred.Passphrase)
+	require.Equal(t, "op", cred.Username)
+	require.Equal(t, "SHA256:fp", cred.HostKeyFP)
+
+	// By name too.
+	cred2, err := r.ResolveByName(newCtx(), "r1")
+	require.NoError(t, err)
+	require.Equal(t, "s3cret-pw", cred2.Secret)
+}
+
+func TestResolver_NotFound(t *testing.T) {
+	db := testDB(t)
+	cipher, _ := crypto.NewCipher(make([]byte, crypto.MasterKeyLen))
+	r := New(db, cipher)
+	_, err := r.Resolve(newCtx(), 999)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestResolver_PlaintextNeverInList is the disclosure guard end-to-end: seed a
+// row whose ciphertext encodes a known plaintext, then assert the List
+// projection (the admin list view) does not carry either the ciphertext blob or
+// the plaintext.
+func TestResolver_PlaintextNeverInList(t *testing.T) {
+	db := testDB(t)
+	cipher, _ := crypto.NewCipher(make([]byte, crypto.MasterKeyLen))
+	const plainPW = "ULTRA-SECRET-PW"
+	enc, _ := cipher.Encrypt(plainPW)
+	_, _ = Create(newCtx(), db, WriteParams{Name: "d", AuthMethod: "password", SecretEnc: enc})
+
+	rows, err := List(newCtx(), db, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	// Neither the plaintext nor the ciphertext blob appears in the list payload.
+	// (ListRow has no secret field, so this is a belt-and-suspenders guard.)
+	require.False(t, strings.Contains(formatListRow(rows[0]), plainPW))
+	require.False(t, strings.Contains(formatListRow(rows[0]), enc))
+}
+
+// formatListRow stringifies a ListRow for the disclosure assertion (it has no
+// secret fields, so the secret plaintext/ciphertext can never appear).
+func formatListRow(r ListRow) string {
+	// Intentionally only the non-secret fields.
+	return r.Name + r.AuthMethod + r.Username + r.HostKeyFP + r.Notes
+}

--- a/internal/service/scannerv2/sshcred/store.go
+++ b/internal/service/scannerv2/sshcred/store.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+// Package sshcred stores and resolves SSH credentials for the device config-
+// backup probe (#137). It mirrors the SNMP credential pattern
+// (internal/service/scannerv2/credresolver): raw database/sql access (sqlc
+// truncates queries on credential tables — see credresolver/store.go) + a
+// Resolver that decrypts on read via the shared crypto.Cipher (the same
+// security.master_key the SNMP credentials use, so there is one key source).
+//
+// Plaintext secrets NEVER leave this package's Resolver: the store only moves
+// ciphertext (_enc) columns, and the handler (a later PR) encrypts at write
+// time + redacts on read, exactly as the SNMP credential handler does.
+package sshcred
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// Row mirrors the ssh_credentials table. SecretEnc/PassphraseEnc hold AES-GCM
+// ciphertext; nothing else here is sensitive.
+type Row struct {
+	ID            int64
+	Name          string
+	AuthMethod    string // "password" | "key"
+	Username      string
+	SecretEnc     string // ciphertext of the password OR PEM private key
+	PassphraseEnc string // ciphertext of the key passphrase ("" if none/unencrypted)
+	HostKeyFP     string // expected SHA256 fingerprint (TOFU); "" = not pinned
+	Enabled       bool
+	Notes         string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// WriteParams is the create/update input. The caller (handler) fills SecretEnc/
+// PassphraseEnc AFTER encrypting the plaintext — plaintext never reaches this
+// layer. Mirrors credresolver.SNMPCredentialWriteParams.
+type WriteParams struct {
+	Name          string
+	AuthMethod    string
+	Username      string
+	SecretEnc     string
+	PassphraseEnc string
+	HostKeyFP     string
+	Enabled       bool
+	Notes         string
+}
+
+// ErrNotFound is returned when no credential row exists for the requested id.
+var ErrNotFound = errors.New("sshcred: credential not found")
+
+// scanRow scans a full-row SELECT into a Row. Shared by Get/GetByName so the
+// column order lives in exactly one place.
+func scanRow(row interface{ Scan(dest ...any) error }) (Row, error) {
+	var r Row
+	var enabled int64
+	err := row.Scan(
+		&r.ID, &r.Name, &r.AuthMethod, &r.Username, &r.SecretEnc, &r.PassphraseEnc,
+		&r.HostKeyFP, &enabled, &r.Notes, &r.CreatedAt, &r.UpdatedAt,
+	)
+	r.Enabled = enabled != 0
+	return r, err
+}
+
+const allColumns = `id, name, auth_method, username, secret_enc, passphrase_enc, host_key_fp, enabled, notes, created_at, updated_at`
+
+// Get returns the full row (incl. ciphertext) for one credential by id.
+func Get(ctx context.Context, db *sql.DB, id int64) (Row, error) {
+	r, err := scanRow(db.QueryRowContext(ctx,
+		`SELECT `+allColumns+` FROM ssh_credentials WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Row{}, ErrNotFound
+	}
+	return r, err
+}
+
+// GetByName returns the full row by name (UNIQUE).
+func GetByName(ctx context.Context, db *sql.DB, name string) (Row, error) {
+	r, err := scanRow(db.QueryRowContext(ctx,
+		`SELECT `+allColumns+` FROM ssh_credentials WHERE name = ?`, name))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Row{}, ErrNotFound
+	}
+	return r, err
+}
+
+// ListRow is a list projection that OMITS the ciphertext columns (the admin list
+// view shows metadata only — never the secret blobs). Mirrors credresolver's
+// MaskedCredentialRow.
+type ListRow struct {
+	ID         int64
+	Name       string
+	AuthMethod string
+	Username   string
+	HostKeyFP  string
+	Enabled    bool
+	Notes      string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// List returns the metadata-only rows (no ciphertext), ordered newest-first.
+func List(ctx context.Context, db *sql.DB, limit, offset int64) ([]ListRow, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT id, name, auth_method, username, host_key_fp, enabled, notes, created_at, updated_at
+		 FROM ssh_credentials ORDER BY id DESC LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ListRow
+	for rows.Next() {
+		var r ListRow
+		var enabled int64
+		if err := rows.Scan(&r.ID, &r.Name, &r.AuthMethod, &r.Username, &r.HostKeyFP,
+			&enabled, &r.Notes, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, err
+		}
+		r.Enabled = enabled != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Create inserts a credential row (ciphertext already filled by the caller) and
+// returns the new id.
+func Create(ctx context.Context, db *sql.DB, p WriteParams) (int64, error) {
+	enabled := 0
+	if p.Enabled {
+		enabled = 1
+	}
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO ssh_credentials (name, auth_method, username, secret_enc, passphrase_enc, host_key_fp, enabled, notes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.Name, p.AuthMethod, p.Username, p.SecretEnc, p.PassphraseEnc, p.HostKeyFP, enabled, p.Notes)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// Update overwrites a credential row. Callers pass the FULL desired ciphertext
+// set (re-encrypting any changed plaintext + carrying forward unchanged blobs).
+func Update(ctx context.Context, db *sql.DB, id int64, p WriteParams) error {
+	enabled := 0
+	if p.Enabled {
+		enabled = 1
+	}
+	res, err := db.ExecContext(ctx, `
+		UPDATE ssh_credentials SET name=?, auth_method=?, username=?, secret_enc=?, passphrase_enc=?, host_key_fp=?, enabled=?, notes=?, updated_at=CURRENT_TIMESTAMP
+		WHERE id=?`,
+		p.Name, p.AuthMethod, p.Username, p.SecretEnc, p.PassphraseEnc, p.HostKeyFP, enabled, p.Notes, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes a credential row; returns rows affected.
+func Delete(ctx context.Context, db *sql.DB, id int64) (int64, error) {
+	res, err := db.ExecContext(ctx, `DELETE FROM ssh_credentials WHERE id = ?`, id)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -76,6 +76,7 @@ func TestSetupTestDBFromSchema(t *testing.T) {
 		"scan_tasks",
 		"service_evidence",
 		"snmp_credentials",
+		"ssh_credentials",
 		"subnets",
 		"topology_edges",
 		"user_totp",


### PR DESCRIPTION
## 背景
#137 config-backup 的 **SSH 凭据层**（probe 的硬前置）。照搬 `credresolver` 模式：raw database/sql store（sqlc 对凭据表会截断 token）+ Resolver 用**共享 `crypto.Cipher`**（security.master_key，与 SNMP 凭据同一密钥源）解密。明文绝不出 Resolver。设计见 [#137 评论](issue)（凭据独立表复用 cipher = 已批决策 2）。

## 改动

### `db/schema.sql` — `ssh_credentials` 表
`name / auth_method(password|key) / username / secret_enc(AES-GCM 密码|PEM 私钥) / passphrase_enc(可选 key passphrase) / host_key_fp(TOFU 指纹) / enabled / notes`。`host_key_fp` 存期望 SHA256 指纹——probe 首连接受并存此列，后续不一致则拒（**MITM 守护**，决策 4）。

### `internal/service/scannerv2/sshcred/`（新包）
- **`store.go`**：`Row/WriteParams/ListRow(省密文)/Create/Get/GetByName/List/Update/Delete`。Get/GetByName/Update 把 `sql.ErrNoRows` 翻译为 `ErrNotFound`（一致 API）。**List 投影省 `secret_enc`/`passphrase_enc`**（列表视图永不带密文 blob，类型层保证）。
- **`resolver.go`**：`Resolver.Resolve/ResolveByName` —— nil cipher→`ErrDisabled`（未配 master_key 则 SSH 凭据存储禁用，同 SNMP 行为）；有 cipher 则 AES-GCM 解密回明文 `Credential`。**无内存缓存**（probe 每设备每周期至多解密一次，缓存只增 rotate 陈旧风险；与 credresolver 不同，那边是因 SNMP 引擎每主机每扫描都解析）。

## 测试（9 个）
store CRUD 往返 + GetByName + List 省密文 + Update/Delete + NotFound；Resolver nil-cipher 禁用 + **真实 cipher 加解密往返**（明文经信封还原）+ 按名解析 + NotFound + **明文/密文均不进 List 载荷**（泄露守护）。

`testutil_test.go` 预期表清单加 `ssh_credentials`（33 张）。

## 不含（后续 PR）
- handler/路由（薄 API 适配层，复用 #212 的 credential handler 模式）
- `devices.ssh_credential_id` 绑定列（随 service/probe PR）

## 验证
`go test ./...` 全绿；`gofmt`/`goimports`/`go vet`/`golangci-lint`（0 issues）。

Refs #137.