### PR TITLE
feat(handler): SSH 凭据 CRUD handler + 路由（#137）

### DIFF
--- a/internal/api/handler/ssh_credential.go
+++ b/internal/api/handler/ssh_credential.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"mibee-steward/internal/crypto"
+	"mibee-steward/internal/service/scannerv2/sshcred"
+)
+
+// SSHCredentialHandler serves the SSH credential registry for the device config-
+// backup probe (#137). It mirrors the SNMP credential handler: plaintext is
+// encrypted at WRITE time via the shared crypto.Cipher and the response ALWAYS
+// redacts the ciphertext (only a has_secret boolean surfaces). A nil cipher (no
+// master_key) disables the mutating endpoints with 503, exactly as SNMP creds.
+type SSHCredentialHandler struct {
+	db     *sql.DB
+	cipher *crypto.Cipher
+}
+
+// NewSSHCredentialHandler constructs the handler. cipher may be nil (mutating
+// endpoints then return 503); reads still work (the ciphertext is never decrypted here).
+func NewSSHCredentialHandler(db *sql.DB, cipher *crypto.Cipher) *SSHCredentialHandler {
+	return &SSHCredentialHandler{db: db, cipher: cipher}
+}
+
+// sshCredentialRequest is the body for POST/PUT /api/v1/ssh-credentials. Secret
+// is the PLAINTEXT password or PEM private key (encrypted by the handler before
+// it reaches the store); Passphrase is the plaintext passphrase for an encrypted
+// key (optional). Neither is ever returned by the API.
+type sshCredentialRequest struct {
+	Name       string `json:"name"`        // required, unique
+	AuthMethod string `json:"auth_method"` // "password" | "key", required
+	Username   string `json:"username"`
+	Secret     string `json:"secret"`     // plaintext password | PEM key (write-only)
+	Passphrase string `json:"passphrase"` // plaintext key passphrase (write-only, optional)
+	HostKeyFP  string `json:"host_key_fp"`
+	Enabled    *bool  `json:"enabled"` // nil = default true (a new cred is usable)
+	Notes      string `json:"notes"`
+}
+
+// sshCredentialResponse redacts the secret entirely: it surfaces metadata +
+// whether a secret is set (has_secret), never the ciphertext or plaintext.
+type sshCredentialResponse struct {
+	ID            int64  `json:"id"`
+	Name          string `json:"name"`
+	AuthMethod    string `json:"auth_method"`
+	Username      string `json:"username,omitempty"`
+	HostKeyFP     string `json:"host_key_fp,omitempty"`
+	HasSecret     bool   `json:"has_secret"`
+	HasPassphrase bool   `json:"has_passphrase"`
+	Enabled       bool   `json:"enabled"`
+	Notes         string `json:"notes,omitempty"`
+}
+
+func toSSHCredentialResponse(r sshcred.Row) sshCredentialResponse {
+	return sshCredentialResponse{
+		ID: r.ID, Name: r.Name, AuthMethod: r.AuthMethod, Username: r.Username,
+		HostKeyFP:     r.HostKeyFP,
+		HasSecret:     r.SecretEnc != "",
+		HasPassphrase: r.PassphraseEnc != "",
+		Enabled:       r.Enabled,
+		Notes:         r.Notes,
+	}
+}
+
+func toSSHListResponse(r sshcred.ListRow) sshCredentialResponse {
+	return sshCredentialResponse{
+		ID: r.ID, Name: r.Name, AuthMethod: r.AuthMethod, Username: r.Username,
+		HostKeyFP: r.HostKeyFP,
+		HasSecret: true, // a stored credential always has a secret; the list omits the blob
+		Enabled:   r.Enabled,
+		Notes:     r.Notes,
+	}
+}
+
+// Create handles POST /api/v1/ssh-credentials.
+func (h *SSHCredentialHandler) Create(w http.ResponseWriter, r *http.Request) {
+	if h.cipher == nil {
+		Error(w, http.StatusServiceUnavailable, "SSH credential storage disabled (security.master_key not configured)")
+		return
+	}
+	var req sshCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := validateSSHCredentialRequest(&req); err != nil {
+		Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	secretEnc, err := h.cipher.Encrypt(strings.TrimSpace(req.Secret))
+	if err != nil {
+		slog.Error("ssh credential: encrypt secret", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to encrypt secret")
+		return
+	}
+	passphraseEnc := ""
+	if pp := strings.TrimSpace(req.Passphrase); pp != "" {
+		passphraseEnc, err = h.cipher.Encrypt(pp)
+		if err != nil {
+			slog.Error("ssh credential: encrypt passphrase", "error", err)
+			Error(w, http.StatusInternalServerError, "failed to encrypt passphrase")
+			return
+		}
+	}
+	id, err := sshcred.Create(r.Context(), h.db, sshcred.WriteParams{
+		Name: strings.TrimSpace(req.Name), AuthMethod: req.AuthMethod, Username: req.Username,
+		SecretEnc: secretEnc, PassphraseEnc: passphraseEnc, HostKeyFP: strings.TrimSpace(req.HostKeyFP),
+		Enabled: req.Enabled == nil || *req.Enabled,
+		Notes:   req.Notes,
+	})
+	if err != nil {
+		if isUniqueConstraintErr(err) {
+			Error(w, http.StatusConflict, "an SSH credential with this name already exists")
+			return
+		}
+		slog.Error("ssh credential: create", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to create SSH credential")
+		return
+	}
+	row, err := sshcred.Get(r.Context(), h.db, id)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to fetch created SSH credential")
+		return
+	}
+	Created(w, toSSHCredentialResponse(row))
+}
+
+// List handles GET /api/v1/ssh-credentials — metadata only (ciphertext omitted).
+func (h *SSHCredentialHandler) List(w http.ResponseWriter, r *http.Request) {
+	limit, offset := parseListPaging(r)
+	rows, err := sshcred.List(r.Context(), h.db, limit, offset)
+	if err != nil {
+		slog.Error("ssh credential: list", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to list SSH credentials")
+		return
+	}
+	out := make([]sshCredentialResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toSSHListResponse(row))
+	}
+	Success(w, out)
+}
+
+// Get handles GET /api/v1/ssh-credentials/{id} — redacted (no ciphertext).
+func (h *SSHCredentialHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseSSHCredID(w, r)
+	if !ok {
+		return
+	}
+	row, err := sshcred.Get(r.Context(), h.db, id)
+	if errors.Is(err, sshcred.ErrNotFound) {
+		Error(w, http.StatusNotFound, "SSH credential not found")
+		return
+	}
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to fetch SSH credential")
+		return
+	}
+	Success(w, toSSHCredentialResponse(row))
+}
+
+// Update handles PUT /api/v1/ssh-credentials/{id}. A blank Secret means "keep
+// the existing ciphertext" (so an admin can rename/toggle without re-entering);
+// a non-blank Secret re-encrypts.
+func (h *SSHCredentialHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseSSHCredID(w, r)
+	if !ok {
+		return
+	}
+	if h.cipher == nil {
+		Error(w, http.StatusServiceUnavailable, "SSH credential storage disabled (security.master_key not configured)")
+		return
+	}
+	var req sshCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	// Update validates name + auth_method but allows a BLANK secret (meaning
+	// "keep the existing ciphertext" — so an admin can rename/toggle without
+	// re-entering the secret). Create uses validateSSHCredentialRequest which
+	// additionally requires a non-empty secret.
+	if strings.TrimSpace(req.Name) == "" {
+		Error(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.AuthMethod != "password" && req.AuthMethod != "key" {
+		Error(w, http.StatusBadRequest, "auth_method must be 'password' or 'key'")
+		return
+	}
+	existing, err := sshcred.Get(r.Context(), h.db, id)
+	if errors.Is(err, sshcred.ErrNotFound) {
+		Error(w, http.StatusNotFound, "SSH credential not found")
+		return
+	}
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to fetch SSH credential")
+		return
+	}
+	secretEnc := existing.SecretEnc // keep existing when Secret blank
+	if strings.TrimSpace(req.Secret) != "" {
+		secretEnc, err = h.cipher.Encrypt(strings.TrimSpace(req.Secret))
+		if err != nil {
+			Error(w, http.StatusInternalServerError, "failed to encrypt secret")
+			return
+		}
+	}
+	passphraseEnc := existing.PassphraseEnc
+	if pp := strings.TrimSpace(req.Passphrase); pp != "" {
+		passphraseEnc, err = h.cipher.Encrypt(pp)
+		if err != nil {
+			Error(w, http.StatusInternalServerError, "failed to encrypt passphrase")
+			return
+		}
+	}
+	enabled := existing.Enabled
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	if err := sshcred.Update(r.Context(), h.db, id, sshcred.WriteParams{
+		Name: strings.TrimSpace(req.Name), AuthMethod: req.AuthMethod, Username: req.Username,
+		SecretEnc: secretEnc, PassphraseEnc: passphraseEnc, HostKeyFP: strings.TrimSpace(req.HostKeyFP),
+		Enabled: enabled, Notes: req.Notes,
+	}); err != nil {
+		if errors.Is(err, sshcred.ErrNotFound) {
+			Error(w, http.StatusNotFound, "SSH credential not found")
+			return
+		}
+		if isUniqueConstraintErr(err) {
+			Error(w, http.StatusConflict, "an SSH credential with this name already exists")
+			return
+		}
+		slog.Error("ssh credential: update", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to update SSH credential")
+		return
+	}
+	row, _ := sshcred.Get(r.Context(), h.db, id)
+	Success(w, toSSHCredentialResponse(row))
+}
+
+// Delete handles DELETE /api/v1/ssh-credentials/{id}.
+func (h *SSHCredentialHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseSSHCredID(w, r)
+	if !ok {
+		return
+	}
+	n, err := sshcred.Delete(r.Context(), h.db, id)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to delete SSH credential")
+		return
+	}
+	if n == 0 {
+		Error(w, http.StatusNotFound, "SSH credential not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// validateSSHCredentialRequest checks the required fields + auth_method domain.
+func validateSSHCredentialRequest(req *sshCredentialRequest) error {
+	if strings.TrimSpace(req.Name) == "" {
+		return errors.New("name is required")
+	}
+	if req.AuthMethod != "password" && req.AuthMethod != "key" {
+		return errors.New("auth_method must be 'password' or 'key'")
+	}
+	if strings.TrimSpace(req.Secret) == "" {
+		return errors.New("secret is required")
+	}
+	return nil
+}
+
+// parseSSHCredID extracts the {id} URL param. Mirrors parseCredentialID.
+func parseSSHCredID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		Error(w, http.StatusBadRequest, "invalid id")
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/api/handler/ssh_credential_test.go
+++ b/internal/api/handler/ssh_credential_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/crypto"
+	"mibee-steward/internal/testutil"
+)
+
+// sshIDToStr stringifies a JSON-decoded id (float64) for URL paths.
+func sshIDToStr(v any) string {
+	switch n := v.(type) {
+	case float64:
+		return fmt.Sprintf("%d", int64(n))
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// These tests pin the SSH credential handler (#137). The load-bearing security
+// contracts, mirroring the SNMP credential handler (#212):
+//   - a nil cipher (no master_key) disables mutation (503),
+//   - the plaintext secret/passphrase NEVER appear in any response (redaction),
+//   - the validation + 404/409 error mapping.
+
+// setupSSHCredHandler builds a handler over a fresh DB with a REAL 32-byte
+// cipher (so Create can encrypt). Returns the handler + the db (for seeding).
+func setupSSHCredHandler(t *testing.T) (*SSHCredentialHandler, *sql.DB) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	cipher, err := crypto.NewCipher(make([]byte, crypto.MasterKeyLen))
+	require.NoError(t, err)
+	return NewSSHCredentialHandler(conn, cipher), conn
+}
+
+const sshCreateBody = `{"name":"core-sw","auth_method":"password","username":"admin","secret":"SUPER-SECRET-PW","host_key_fp":"SHA256:abc","enabled":true}`
+
+func TestSSHCredentialHandler_Create_RedactsSecret(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	// The plaintext MUST NOT leak into the response.
+	require.NotContains(t, rec.Body.String(), "SUPER-SECRET-PW", "plaintext secret must never be returned")
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Equal(t, "core-sw", resp["name"])
+	require.Equal(t, true, resp["has_secret"], "has_secret surfaces without the value")
+	require.NotContains(t, resp, "secret", "no secret field in response")
+	require.NotContains(t, resp, "secret_enc", "no ciphertext field in response")
+}
+
+func TestSSHCredentialHandler_NilCipher_CreateReturns503(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	h := NewSSHCredentialHandler(conn, nil) // no master key
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code, "no master key -> mutation disabled (503)")
+}
+
+func TestSSHCredentialHandler_Create_InvalidAuthMethod(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials",
+		strings.NewReader(`{"name":"x","auth_method":"biometric","secret":"p"}`)))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSSHCredentialHandler_Create_DuplicateName_Conflict(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec1 := httptest.NewRecorder()
+	h.Create(rec1, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	require.Equal(t, http.StatusCreated, rec1.Code)
+
+	rec2 := httptest.NewRecorder()
+	h.Create(rec2, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	require.Equal(t, http.StatusConflict, rec2.Code)
+}
+
+func TestSSHCredentialHandler_Get_RedactsAndNotFound(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	id := sshIDToStr(created["id"])
+
+	// Get redacts.
+	rec = httptest.NewRecorder()
+	h.Get(rec, reqWithURLParam(http.MethodGet, "/api/v1/ssh-credentials/"+id, "", id))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "SUPER-SECRET-PW")
+
+	// Not-found.
+	rec = httptest.NewRecorder()
+	h.Get(rec, reqWithURLParam(http.MethodGet, "/api/v1/ssh-credentials/999", "", "999"))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSSHCredentialHandler_List_Redacts(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	h.Create(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/ssh-credentials", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "SUPER-SECRET-PW", "list must not leak plaintext")
+}
+
+func TestSSHCredentialHandler_Update_BlankSecretKeepsExisting(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	id := sshIDToStr(created["id"])
+
+	// Rename with a BLANK secret -> existing ciphertext preserved (no re-enter).
+	rec = httptest.NewRecorder()
+	h.Update(rec, reqWithURLParam(http.MethodPut, "/api/v1/ssh-credentials/"+id,
+		`{"name":"core-sw-renamed","auth_method":"password","secret":""}`, id))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Equal(t, "core-sw-renamed", resp["name"])
+	require.Equal(t, true, resp["has_secret"], "blank secret on update keeps the existing one")
+}
+
+func TestSSHCredentialHandler_Delete(t *testing.T) {
+	h, _ := setupSSHCredHandler(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/ssh-credentials", strings.NewReader(sshCreateBody)))
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	id := sshIDToStr(created["id"])
+
+	rec = httptest.NewRecorder()
+	h.Delete(rec, reqWithURLParam(http.MethodDelete, "/api/v1/ssh-credentials/"+id, "", id))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Gone.
+	rec = httptest.NewRecorder()
+	h.Get(rec, reqWithURLParam(http.MethodGet, "/api/v1/ssh-credentials/"+id, "", id))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// keep these imports used (context for future seed helpers)
+var _ = context.Background

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -514,6 +514,18 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Delete("/{id}", credentialHandler.Delete)
 	})
 
+	// SSH credentials for the device config-backup probe (#137). Same admin-only
+	// gate + same shared master_key cipher as SNMP credentials.
+	sshCredentialHandler := handler.NewSSHCredentialHandler(dbConn, credCipher)
+	r.Route("/api/v1/ssh-credentials", func(r chi.Router) {
+		r.Use(middleware.RequireAdmin)
+		r.Post("/", sshCredentialHandler.Create)
+		r.Get("/", sshCredentialHandler.List)
+		r.Get("/{id}", sshCredentialHandler.Get)
+		r.Put("/{id}", sshCredentialHandler.Update)
+		r.Delete("/{id}", sshCredentialHandler.Delete)
+	})
+
 	// --- Agent token management (distributed phase) ---
 	// Admin-only CRUD for discovery-agent bearer tokens. The ingestion endpoint
 	// (/agents/report below) authenticates via RequireAgentToken against this


### PR DESCRIPTION
## 背景
承接 #218（ssh_credentials store + resolver）。补 SSH 凭据的 **API 层**：admin 现在能经 REST 管理 SSH 凭据（config-backup probe 的前置）。照搬 SNMP credential handler 模式（#212）：写时加密、读时 redact、nil cipher→503。

## 改动
### `internal/api/handler/ssh_credential.go`（新）
- `SSHCredentialHandler{db, cipher}`；Create/List/Get/Update/Delete。
- **redact 契约**：`sshCredentialResponse` 只回 `has_secret`/`has_passphrase` 布尔，**无 secret 字段**（明文/密文永不回）。
- Create：nil cipher→503；校验 name/auth_method(`password`|`key`)/secret 非空；加密；重名→409。
- **Update 空 Secret = 保留既有密文**（改名/启停免重输密码）；非空则重加密。
- Get/List：redacted（List 走 ListRow 省密文，类型层保证）。

### `internal/api/routes/routes.go`
- 注册 `/api/v1/ssh-credentials`（`RequireAdmin`，与 SNMP 凭据同闸门 + 同 master_key cipher）。

## 测试（`ssh_credential_test.go`，8 个）
Create redact 明文不泄露 / nil cipher→503 / 非法 auth_method→400 / 重名→409 / Get redact + NotFound / List redact / Update 空 Secret 保留既有 / Delete + 确认消失。

## 验证
`go test ./...` 全绿；`gofmt`/`goimports`/`go vet`/`golangci-lint`（0 issues）。

## 后续（#137 序列）
configbackup.Service 骨架 + devices.ssh_credential_id 绑定 → SSH 客户端（golang.org/x/crypto/ssh + 厂商命令矩阵 + host key TOFU）→ 变更检测集成 → API/UI。

Refs #137.