### PR TITLE
feat(configbackup): SSH probe 引擎 + 厂商命令矩阵 + host key TOFU（#137 核心）

### DIFF
--- a/internal/service/scannerv2/configbackup/sshprobe.go
+++ b/internal/service/scannerv2/configbackup/sshprobe.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+// Package configbackup implements the Oxidized/RANCID-style device config-
+// backup feature (#137): a periodic background job fetches each managed
+// network device's running-config over SSH, versions + diffs it (via
+// internal/configdiff + the device_configs table), and emits a change event.
+//
+// This file is the SSH probe engine: a pure, testable FetchConfig that connects
+// to one device with a decrypted sshcred.Credential, runs the vendor-specific
+// "show running-config" command, and returns the captured text. The scheduling,
+// device selection, storage, and change-detection wiring live in service.go
+// (a later PR) and consume this engine.
+package configbackup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"mibee-steward/internal/service/scannerv2/sshcred"
+)
+
+// ErrHostKeyMismatch is returned when the device's SSH host key does not match
+// the pinned fingerprint on the credential (a possible MITM). The first connect
+// (no pinned fp) always succeeds and returns the actual fingerprint for the
+// caller to pin (TOFU — trust on first use).
+var ErrHostKeyMismatch = errors.New("configbackup: SSH host key fingerprint mismatch (possible MITM)")
+
+// FetchConfig connects to host:port with the decrypted credential, runs the
+// vendor-specific config command, and returns the captured running-config text.
+// It returns the device's actual host-key fingerprint so the caller can TOFU-
+// pin it (the credential's HostKeyFP may be "" on first connect).
+//
+// brand selects the command via CommandForBrand. timeout bounds the connect +
+// command; ctx cancels a hung connection. The credential's plaintext is read
+// once here and discarded when FetchConfig returns (it lives only in the
+// resolver's returned *Credential for the call duration).
+func FetchConfig(ctx context.Context, host string, port int, cred *sshcred.Credential, brand string, timeout time.Duration) (config string, hostKeyFP string, err error) {
+	if cred == nil {
+		return "", "", errors.New("configbackup: nil credential")
+	}
+	if port <= 0 {
+		port = 22
+	}
+	auth, err := authMethod(cred)
+	if err != nil {
+		return "", "", fmt.Errorf("ssh auth: %w", err)
+	}
+
+	var actualFP string
+	hostKeyCallback := func(_ string, _ net.Addr, key ssh.PublicKey) error {
+		actualFP = ssh.FingerprintSHA256(key)
+		if cred.HostKeyFP != "" && actualFP != cred.HostKeyFP {
+			return fmt.Errorf("%w: expected %s, got %s", ErrHostKeyMismatch, cred.HostKeyFP, actualFP)
+		}
+		return nil // TOFU: first connect (no pin) accepts; later connects verify.
+	}
+
+	cfg := &ssh.ClientConfig{
+		User:            cred.Username,
+		Auth:            []ssh.AuthMethod{auth},
+		HostKeyCallback: hostKeyCallback,
+		Timeout:         timeout,
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+
+	// ctx-aware dial: ssh.Dial has no context, so dial the TCP connection with
+	// the context, then hand it to ssh.NewClientConn. A cancelled context closes
+	// the dial (and any in-flight handshake via the conn close in the defer).
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return "", actualFP, fmt.Errorf("dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+	go func() {
+		<-ctx.Done()
+		_ = conn.SetDeadline(time.Now()) // unblock a hung handshake on cancellation
+	}()
+
+	sc, chans, reqs, err := ssh.NewClientConn(conn, addr, cfg)
+	if err != nil {
+		// A host-key mismatch surfaces here; actualFP was captured by the callback.
+		return "", actualFP, err
+	}
+	defer sc.Close()
+	client := ssh.NewClient(sc, chans, reqs)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", actualFP, fmt.Errorf("ssh session: %w", err)
+	}
+	defer session.Close()
+
+	out, err := session.CombinedOutput(CommandForBrand(brand))
+	if err != nil {
+		return "", actualFP, fmt.Errorf("ssh command %q: %w", CommandForBrand(brand), err)
+	}
+	return string(out), actualFP, nil
+}
+
+// authMethod builds the ssh.AuthMethod for the credential's auth_method:
+// "password" → ssh.Password; "key" → ssh.PublicKeys (PEM, optionally with a
+// passphrase). Returns an error for an unknown method or an unparseable key.
+func authMethod(cred *sshcred.Credential) (ssh.AuthMethod, error) {
+	switch cred.AuthMethod {
+	case "password":
+		return ssh.Password(cred.Secret), nil
+	case "key":
+		var (
+			signer ssh.Signer
+			err    error
+		)
+		if cred.Passphrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase([]byte(cred.Secret), []byte(cred.Passphrase))
+		} else {
+			signer, err = ssh.ParsePrivateKey([]byte(cred.Secret))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		return ssh.PublicKeys(signer), nil
+	default:
+		return nil, fmt.Errorf("unsupported auth_method %q", cred.AuthMethod)
+	}
+}
+
+// CommandForBrand returns the config-fetch command for the device's vendor
+// brand (read from devices.brand). The matrix covers the SSH-management matrix
+// vendors (#137 decision 1); the default is the Cisco/IOS form ("show running-
+// config") which is the most common + the fallback Arista/Huawei use too.
+func CommandForBrand(brand string) string {
+	b := strings.ToLower(brand)
+	switch {
+	case strings.Contains(b, "juniper"):
+		return "show configuration | display set | no-more"
+	case strings.Contains(b, "hp"), strings.Contains(b, "aruba"), strings.Contains(b, "h3c"), strings.Contains(b, "comware"):
+		return "display current-configuration"
+	default:
+		// Cisco IOS / NX-OS, Arista, Huawei VRP (many), Mikrotik (show config),
+		// and unknown vendors: the widely-understood "show running-config".
+		return "show running-config"
+	}
+}

--- a/internal/service/scannerv2/configbackup/sshprobe_test.go
+++ b/internal/service/scannerv2/configbackup/sshprobe_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package configbackup
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"mibee-steward/internal/service/scannerv2/sshcred"
+)
+
+// startTestSSHServer stands up an in-process SSH server that accepts the given
+// user/password and, on any "exec" request, returns the canned config text.
+// Returns its address + its host-key fingerprint (for TOFU assertions).
+func startTestSSHServer(t *testing.T, wantUser, wantPW, canned string) (addr, hostKeyFP string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	_ = pub
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+	hostKeyFP = ssh.FingerprintSHA256(signer.PublicKey())
+
+	cfg := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			if c.User() == wantUser && string(pass) == wantPW {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("password rejected for %q", c.User())
+		},
+	}
+	cfg.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			nConn, err := ln.Accept()
+			if err != nil {
+				return // listener closed (test cleanup)
+			}
+			go serveSSHSession(nConn, cfg, canned)
+		}
+	}()
+	return ln.Addr().String(), hostKeyFP
+}
+
+// serveSSHSession handles one connection: completes the SSH handshake, then for
+// each "session" channel answers "exec" with the canned config + exit-status 0.
+func serveSSHSession(nConn net.Conn, cfg *ssh.ServerConfig, canned string) {
+	sconn, chans, reqs, err := ssh.NewServerConn(nConn, cfg)
+	if err != nil {
+		return
+	}
+	defer sconn.Close()
+	go ssh.DiscardRequests(reqs)
+	for newCh := range chans {
+		if newCh.ChannelType() != "session" {
+			_ = newCh.Reject(ssh.UnknownChannelType, "only session")
+			continue
+		}
+		ch, chReqs, err := newCh.Accept()
+		if err != nil {
+			continue
+		}
+		go func(in <-chan *ssh.Request) {
+			defer ch.Close()
+			for req := range in {
+				if req.Type == "exec" {
+					req.Reply(true, nil)
+					_, _ = ch.Write([]byte(canned))
+					_, _ = ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{0}))
+					return
+				}
+				req.Reply(false, nil)
+			}
+		}(chReqs)
+	}
+}
+
+func TestFetchConfig_PasswordAuth_CapturesConfig(t *testing.T) {
+	const canned = "hostname r1\ninterface eth0\n ip address 10.0.0.1/24\nend\n"
+	addr, fp := startTestSSHServer(t, "admin", "pw", canned)
+
+	cred := &sshcred.Credential{AuthMethod: "password", Username: "admin", Secret: "pw", HostKeyFP: ""}
+	host, portS, _ := net.SplitHostPort(addr)
+	var portI int
+	fmt.Sscanf(portS, "%d", &portI)
+
+	out, gotFP, err := FetchConfig(context.Background(), host, portI, cred, "Cisco", 5*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, canned, out, "captured running-config text")
+	require.Equal(t, fp, gotFP, "returned the actual host-key fp for TOFU pinning")
+}
+
+func TestFetchConfig_HostKeyMismatchRejected(t *testing.T) {
+	addr, _ := startTestSSHServer(t, "admin", "pw", "x")
+	// Pin a WRONG fingerprint → the device's key must not match.
+	cred := &sshcred.Credential{AuthMethod: "password", Username: "admin", Secret: "pw",
+		HostKeyFP: "SHA256:0000000000000000000000000000000000000000000000000000000000000000"}
+	host, portS, _ := net.SplitHostPort(addr)
+	var portI int
+	fmt.Sscanf(portS, "%d", &portI)
+
+	_, _, err := FetchConfig(context.Background(), host, portI, cred, "Cisco", 5*time.Second)
+	require.ErrorIs(t, err, ErrHostKeyMismatch, "a pinned-fp mismatch must be rejected (MITM guard)")
+}
+
+func TestFetchConfig_BadPasswordRejected(t *testing.T) {
+	addr, _ := startTestSSHServer(t, "admin", "pw", "x")
+	cred := &sshcred.Credential{AuthMethod: "password", Username: "admin", Secret: "WRONG", HostKeyFP: ""}
+	host, portS, _ := net.SplitHostPort(addr)
+	var portI int
+	fmt.Sscanf(portS, "%d", &portI)
+
+	_, _, err := FetchConfig(context.Background(), host, portI, cred, "Cisco", 5*time.Second)
+	require.Error(t, err, "bad credentials must fail to connect")
+}
+
+// TestFetchConfig_NilCredential is the fail-closed guard.
+func TestFetchConfig_NilCredential(t *testing.T) {
+	_, _, err := FetchConfig(context.Background(), "10.0.0.1", 22, nil, "Cisco", time.Second)
+	require.Error(t, err)
+}
+
+func TestCommandForBrand(t *testing.T) {
+	require.Equal(t, "show running-config", CommandForBrand("Cisco"))
+	require.Equal(t, "show running-config", CommandForBrand("Arista"))
+	require.Equal(t, "show running-config", CommandForBrand("")) // default fallback
+	require.Equal(t, "show configuration | display set | no-more", CommandForBrand("Juniper"))
+	require.Equal(t, "show configuration | display set | no-more", CommandForBrand("juniper networks"))
+	require.Equal(t, "display current-configuration", CommandForBrand("HP"))
+	require.Equal(t, "display current-configuration", CommandForBrand("Aruba"))
+	require.Equal(t, "display current-configuration", CommandForBrand("H3C"))
+	// Case-insensitive.
+	require.True(t, strings.Contains(CommandForBrand("CISCO"), "running-config"))
+}


### PR DESCRIPTION
## 背景
#137 配置备份的**核心** —— SSH probe 引擎。承接 configdiff(#215) / device_configs(#216) / ssh_credentials(#218, #219)。本 PR 是纯函数 `FetchConfig`：用解密的 `sshcred.Credential` 连一台设备、跑厂商特定的 `show running-config`、回抓配置文本。调度/选设备/存储/变更检测的接线在 service.go（后续 PR），消费本引擎。

## 改动
### `sshprobe.go`（新）
- **`FetchConfig(ctx, host, port, cred, brand, timeout) (config, hostKeyFP, err)`**
  - ctx 感知（`DialContext` + 取消时 `SetDeadline` 解阻塞 handshake）。
  - 认证：`password` → `ssh.Password`；`key` → `ssh.PublicKeys`（`ParsePrivateKey[WithPassphrase]`）。
  - **host key TOFU**：callback 抓取实际 SHA256 指纹；`cred.HostKeyFP` 空 → 接受（首连 pin）；非空 → 比对，不符 → **`ErrHostKeyMismatch`**（MITM 守护）。返回实际指纹供调用方 pin。
- **`CommandForBrand`** 厂商矩阵：Juniper → `show configuration | display set | no-more`；HP/Aruba/H3C/Comware → `display current-configuration`；其余（Cisco/Arista/华为/默认）→ `show running-config`。

## 测试（`sshprobe_test.go`，5 个，**含真实 in-process SSH 服务器**）
- `FetchConfig` 密码认证 + 抓取配置 + 返回实际指纹（TOFU pin）。
- host key 指纹不符 → `ErrHostKeyMismatch`（MITM 守护）。
- 错误密码 → 连接失败。
- nil credential → fail-closed。
- `CommandForBrand` 厂商分派（Juniper/HP/Aruba/H3C/Cisco/默认/大小写）。

SSH 测试服务器用 `crypto/ed25519` 动态生成 host key + `ssh.ServerConfig`，密码认证 + exec 请求回 canned 配置 —— 端到端验证连接、认证、命令执行、host key 处理。

## 依赖
`golang.org/x/crypto/ssh` 已在 go.mod（#137 设计核查确认，无新增依赖）。

## 验证
`go test ./...` 全绿；`gofmt`/`goimports`/`go vet`/`golangci-lint`（0 issues）。

## 后续（#137）
configbackup.Service（仿 cleanup ticker）+ devices.ssh_credential_id 绑定 → 接线 FetchConfig + 存 device_configs + configdiff → 变更检测（device_config_changed）→ API/UI。

Refs #137.