### PR TITLE
feat(configbackup): Service 集成层（调度+选设备+FetchConfig+configdiff+变更事件）(#137 核心)

### DIFF
--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -91,6 +91,10 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		// backfill below approximates it for existing offline devices from
 		// updated_at (the last status write).
 		"ALTER TABLE devices ADD COLUMN offline_since TIMESTAMP",
+		// ssh_credential_id: binds a device to an SSH credential for the config-
+		// backup probe (#137). NULL = not config-backed-up. SET NULL on credential
+		// delete so the device row survives (backup just pauses for it).
+		"ALTER TABLE devices ADD COLUMN ssh_credential_id INTEGER REFERENCES ssh_credentials(id) ON DELETE SET NULL",
 		// Dual JSON layer (scan_attributes + user_attributes). Generated columns
 		// (scan_vendor/scan_mac/scan_os/scan_hostname) can't be added via ALTER
 		// on existing DBs — those are only present on fresh installs. For

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -98,6 +98,11 @@ CREATE TABLE IF NOT EXISTS devices (
     -- cmd/server/main.go (applyIdentityIndexMigrations) so existing rows can be
     -- de-duplicated first.
     network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL,
+    -- ssh_credential_id binds this device to an SSH credential for the config-
+    -- backup probe (#137). NULL = this device is not config-backed-up.
+    -- ON DELETE SET NULL so deleting the credential pauses backup for the device
+    -- (rather than dropping the device row).
+    ssh_credential_id INTEGER REFERENCES ssh_credentials(id) ON DELETE SET NULL,
     -- first_seen / last_seen record when the device was first/last observed
     -- ONLINE by a scan (distinct from created_at/updated_at which track the
     -- row's own lifetime and bump on any write). Needed for asset-freshness

--- a/internal/changedetect/recorder.go
+++ b/internal/changedetect/recorder.go
@@ -74,6 +74,11 @@ const (
 	ChangeTypeDeviceChanged   = "device_changed"
 	ChangeTypeDeviceLost      = "device_lost"
 	ChangeTypeDeviceRecovered = "device_recovered"
+	// ChangeTypeDeviceConfigChanged: a device's running-config backup changed
+	// between two config-backup fetches (#137). Emitted by the configbackup
+	// Service when configdiff.Diff is non-empty. dedupKind returns "" for it
+	// (never throttled) — every real config change is worth recording.
+	ChangeTypeDeviceConfigChanged = "device_config_changed"
 )
 
 // EntityType is always "device" in this phase (service/neighbor reserved).

--- a/internal/service/scannerv2/configbackup/service.go
+++ b/internal/service/scannerv2/configbackup/service.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package configbackup
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"log/slog"
+	"time"
+
+	"mibee-steward/internal/changedetect"
+	"mibee-steward/internal/configdiff"
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service/scannerv2/sshcred"
+)
+
+// FetchFunc is the config-fetch signature. Production wires FetchConfig; tests
+// inject a mock so runOnce is testable without a real SSH server.
+type FetchFunc func(ctx context.Context, host string, port int, cred *sshcred.Credential, brand string, timeout time.Duration) (config string, hostKeyFP string, err error)
+
+// Service is the periodic config-backup sweep (#137). It mirrors cleanup.Service:
+// a ticker goroutine (Start/Stop) that runs runOnce on startup + each tick.
+// runOnce selects the router/switch/firewall devices with an SSH credential
+// bound, fetches each device's running-config, and on a real change stores a new
+// device_configs version (with the configdiff vs the prior version) + emits a
+// device_config_changed event. Unchanged fetches store nothing (the hash gate).
+type Service struct {
+	db             *sql.DB
+	queries        *db.Queries
+	sshResolver    *sshcred.Resolver
+	changeRecorder changedetect.ChangeRecorder
+	fetchFn        FetchFunc
+	interval       time.Duration
+	timeout        time.Duration
+	port           int
+	logger         *slog.Logger
+	cancel         context.CancelFunc
+	done           chan struct{}
+}
+
+// New constructs the Service. fetchFn is FetchConfig in production; tests inject
+// a mock. interval<=0 defaults to 6h; timeout<=0 defaults to 30s; port<=0 → 22.
+func New(dbConn *sql.DB, queries *db.Queries, sshResolver *sshcred.Resolver, rec changedetect.ChangeRecorder, fetchFn FetchFunc, interval, timeout time.Duration, logger *slog.Logger) *Service {
+	if interval <= 0 {
+		interval = 6 * time.Hour
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		db: dbConn, queries: queries, sshResolver: sshResolver, changeRecorder: rec,
+		fetchFn: fetchFn, interval: interval, timeout: timeout, port: 22, logger: logger,
+		done: make(chan struct{}),
+	}
+}
+
+// Start runs one sweep immediately, then on every interval tick, until Stop.
+func (s *Service) Start(ctx context.Context) {
+	ctx, s.cancel = context.WithCancel(ctx)
+	go func() {
+		defer close(s.done)
+		s.runOnce(ctx)
+		t := time.NewTicker(s.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.runOnce(ctx)
+			}
+		}
+	}()
+}
+
+// Stop signals the sweep loop to exit and waits for it.
+func (s *Service) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+		<-s.done
+	}
+}
+
+// runOnce backs up every candidate device. Each device is independent — a
+// failure (no credential / SSH error / store error) is logged and skipped so one
+// bad device doesn't abort the sweep.
+func (s *Service) runOnce(ctx context.Context) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, ip_address, COALESCE(brand,''), ssh_credential_id
+		FROM devices
+		WHERE type IN ('router','switch','firewall') AND ssh_credential_id IS NOT NULL`)
+	if err != nil {
+		s.logger.Warn("configbackup: select devices failed", "error", err)
+		return
+	}
+	// Materialize the candidates and CLOSE the rows cursor BEFORE the per-device
+	// work. Holding the cursor open while backupOne runs DB queries + SSH fetch
+	// per device would (a) hold a pooled connection for the whole sweep and
+	// (b) deadlock under a single-connection pool (test in-memory DB). Scanning
+	// into a slice first is both safer and the correct production pattern.
+	type candidate struct {
+		deviceID  int64
+		ip        string
+		brand     string
+		sshCredID int64
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.deviceID, &c.ip, &c.brand, &c.sshCredID); err != nil {
+			s.logger.Warn("configbackup: scan device row", "error", err)
+			continue
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	for _, c := range candidates {
+		if ctx.Err() != nil {
+			return
+		}
+		s.backupOne(ctx, c.deviceID, c.ip, c.brand, c.sshCredID)
+	}
+}
+
+// backupOne fetches one device's config, diffs vs the latest stored version, and
+// on a change stores a new version + emits an event. First capture (no prior
+// version) stores a baseline without emitting (it's not a "change").
+func (s *Service) backupOne(ctx context.Context, deviceID int64, ip, brand string, sshCredID int64) {
+	cred, err := s.sshResolver.Resolve(ctx, sshCredID)
+	if err != nil {
+		s.logger.Warn("configbackup: resolve ssh credential skipped", "device_id", deviceID, "cred_id", sshCredID, "error", err)
+		return
+	}
+	config, fp, err := s.fetchFn(ctx, ip, s.port, cred, brand, s.timeout)
+	if err != nil {
+		s.logger.Warn("configbackup: fetch config failed", "device_id", deviceID, "ip", ip, "error", err)
+		return
+	}
+	// TOFU pin: first connect (no pinned fp) accepts any key; pin the actual fp
+	// so subsequent connects verify against it (MITM guard).
+	if cred.HostKeyFP == "" && fp != "" {
+		if err := sshcred.SetHostKeyFP(ctx, s.db, sshCredID, fp); err != nil {
+			s.logger.Warn("configbackup: pin host key failed", "device_id", deviceID, "error", err)
+		}
+	}
+
+	newHash := hashOf(config)
+	latest, err := s.queries.GetLatestDeviceConfig(ctx, deviceID)
+	hasLatest := err == nil
+	if hasLatest && latest.ConfigHash == newHash {
+		return // unchanged — no-op (the common case on a stable device)
+	}
+	diff := ""
+	if hasLatest {
+		diff = configdiff.MustDiff("prev", latest.ConfigText, "current", config)
+	}
+	if _, err := s.queries.CreateDeviceConfig(ctx, db.CreateDeviceConfigParams{
+		DeviceID: deviceID, ConfigHash: newHash, ConfigText: config, Protocol: "ssh", DiffFromPrev: diff,
+	}); err != nil {
+		s.logger.Warn("configbackup: store config failed", "device_id", deviceID, "error", err)
+		return
+	}
+	if diff != "" {
+		// A real change (not the first capture) → record it.
+		s.changeRecorder.Record(ctx, changedetect.ChangeEvent{
+			ChangeType: changedetect.ChangeTypeDeviceConfigChanged,
+			EntityType: changedetect.EntityTypeDevice,
+			DeviceID:   deviceID,
+		})
+	}
+	s.logger.Info("configbackup: stored config version", "device_id", deviceID, "changed", diff != "")
+}
+
+// hashOf returns the lowercase hex sha256 of s (the device_configs.config_hash).
+func hashOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/service/scannerv2/configbackup/service_test.go
+++ b/internal/service/scannerv2/configbackup/service_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package configbackup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/changedetect"
+	"mibee-steward/internal/crypto"
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service/scannerv2/sshcred"
+	"mibee-steward/internal/testutil"
+)
+
+// captureRecorder collects emitted events for assertions.
+type captureRecorder struct{ events []changedetect.ChangeEvent }
+
+func (r *captureRecorder) Record(_ context.Context, ev changedetect.ChangeEvent) {
+	r.events = append(r.events, ev)
+}
+
+// setupSvc builds a Service over an in-memory DB seeded with one router device
+// bound to an SSH credential. Returns the service, the queries (to read
+// device_configs), and a pointer to the mock fetch's "current config" so the
+// test can mutate it between sweeps.
+func setupSvc(t *testing.T) (*Service, *db.Queries, *string) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	// Force a single pooled connection: :memory: is per-connection (not shared),
+	// and runOnce runs a per-row query while the outer rows query holds its conn,
+	// which would otherwise route the inner Get to a different empty in-memory DB.
+	conn.SetMaxOpenConns(1)
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	cipher, err := crypto.NewCipher(make([]byte, crypto.MasterKeyLen))
+	require.NoError(t, err)
+	encSecret, err := cipher.Encrypt("router-pw")
+	require.NoError(t, err)
+	credID, err := sshcred.Create(ctx, conn, sshcred.WriteParams{
+		Name: "r1-ssh", AuthMethod: "password", Username: "admin", SecretEnc: encSecret, Enabled: true,
+	})
+	require.NoError(t, err)
+	// Seed a router bound to the SSH credential.
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand, ssh_credential_id) VALUES ('r1','router','10.0.0.1','Cisco',?)`, credID)
+	require.NoError(t, err)
+
+	current := "hostname r1\ninterface eth0\n ip address 10.0.0.1/24\n"
+	fetchFn := func(_ context.Context, _ string, _ int, _ *sshcred.Credential, _ string, _ time.Duration) (string, string, error) {
+		return current, "", nil // fp="" (no TOFU pin in this test)
+	}
+	rec := &captureRecorder{}
+	svc := New(conn, queries, sshcred.New(conn, cipher), rec, fetchFn, time.Hour, time.Second, nil)
+	return svc, queries, &current
+}
+
+func countConfigs(t *testing.T, queries *db.Queries, deviceID int64) int64 {
+	t.Helper()
+	// deviceID is 1 (the seeded device) — CountDeviceConfigs takes device_id.
+	n, err := queries.CountDeviceConfigs(context.Background(), deviceID)
+	require.NoError(t, err)
+	return n
+}
+
+func TestService_FirstCapture_StoresBaselineNoEvent(t *testing.T) {
+	svc, queries, _ := setupSvc(t)
+	svc.runOnce(context.Background())
+
+	require.Equal(t, int64(1), countConfigs(t, queries, 1), "first capture stores a baseline version")
+	// A capture recorder: no event on the first (baseline) capture.
+	require.Empty(t, svc.changeRecorder.(*captureRecorder).events, "first capture emits no change event")
+}
+
+func TestService_ChangedCapture_StoresVersionAndEmitsEvent(t *testing.T) {
+	svc, queries, current := setupSvc(t)
+	svc.runOnce(context.Background()) // baseline
+
+	// Mutate the running-config the mock returns.
+	*current = "hostname r1\ninterface eth0\n ip address 10.0.0.2/24\n" // last octet changed
+	svc.runOnce(context.Background())
+
+	require.Equal(t, int64(2), countConfigs(t, queries, 1), "changed capture stores a new version")
+	rec := svc.changeRecorder.(*captureRecorder)
+	require.Len(t, rec.events, 1, "exactly one device_config_changed event")
+	require.Equal(t, changedetect.ChangeTypeDeviceConfigChanged, rec.events[0].ChangeType)
+
+	// The new version carries the diff vs the prior one.
+	latest, err := queries.GetLatestDeviceConfig(context.Background(), 1)
+	require.NoError(t, err)
+	require.Contains(t, latest.DiffFromPrev, "- ip address 10.0.0.1/24")
+	require.Contains(t, latest.DiffFromPrev, "+ ip address 10.0.0.2/24")
+}
+
+func TestService_UnchangedCapture_NoOp(t *testing.T) {
+	svc, queries, _ := setupSvc(t)
+	svc.runOnce(context.Background()) // baseline
+	svc.runOnce(context.Background()) // identical config
+
+	require.Equal(t, int64(1), countConfigs(t, queries, 1), "unchanged capture stores no new version")
+	require.Empty(t, svc.changeRecorder.(*captureRecorder).events, "unchanged capture emits no event")
+}
+
+// TestService_SkipsDevicesWithoutCred asserts the selection gate: a device with
+// no ssh_credential_id is never backed up.
+func TestService_SkipsDevicesWithoutCred(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	// A router with NO ssh_credential_id + a PC (wrong type) — neither is a candidate.
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand) VALUES ('nobody','router','10.0.0.9','Cisco')`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address) VALUES ('mypc','pc','10.0.0.10')`)
+	require.NoError(t, err)
+
+	called := false
+	fetchFn := func(context.Context, string, int, *sshcred.Credential, string, time.Duration) (string, string, error) {
+		called = true
+		return "", "", nil
+	}
+	svc := New(conn, queries, sshcred.New(conn, nil), &captureRecorder{}, fetchFn, time.Hour, time.Second, nil)
+	svc.runOnce(context.Background())
+
+	require.False(t, called, "no fetch attempted for devices without a bound SSH credential")
+}

--- a/internal/service/scannerv2/sshcred/store.go
+++ b/internal/service/scannerv2/sshcred/store.go
@@ -175,3 +175,12 @@ func Delete(ctx context.Context, db *sql.DB, id int64) (int64, error) {
 	}
 	return res.RowsAffected()
 }
+
+// SetHostKeyFP pins the TOFU host-key fingerprint on a credential (the probe
+// calls this after a first connect that had no pinned fp, so subsequent
+// connects verify against it). Best-effort: a no-row update is not an error.
+func SetHostKeyFP(ctx context.Context, db *sql.DB, id int64, fp string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE ssh_credentials SET host_key_fp = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, fp, id)
+	return err
+}


### PR DESCRIPTION
## 背景
#137 配置备份的**集成高潮**：configbackup.Service 把前 5 个 PR 的件接起来（configdiff #215 / device_configs #216 / ssh_credentials #218/#219 / FetchConfig #220）。定时后台 job 仿 `cleanup.Service`（ticker Start/Stop）；`runOnce` 选设备 → 每台 FetchConfig → configdiff vs 上一版 → 变更则存新版本 + 发 `device_config_changed` 事件。

## 改动
- **`db/schema.sql` + `migrations.go`**：`devices.ssh_credential_id`（FK→ssh_credentials，ON DELETE SET NULL；幂等 ALTER）。
- **`changedetect/recorder.go`**：`ChangeTypeDeviceConfigChanged` 常量（dedupKind 默认不节流）。
- **`sshcred/store.go`**：`SetHostKeyFP`（TOFU pin）。
- **`configbackup/service.go`**（新）：
  - `Service{db, queries, sshResolver, changeRecorder, fetchFn, interval, timeout}` + `Start/Stop`（ticker，仿 cleanup.Service）+ `runOnce` + `backupOne`。
  - **FetchFunc 注入**：production=FetchConfig，test=mock（runOnce 可测，免真实 SSH）。
  - 选设备：`type∈router/switch/firewall AND ssh_credential_id IS NOT NULL`。
  - **物化候选后关 cursor 再逐设备处理**（不在 cursor 期间持有 conn 做 SSH+查询——避免单连接池死锁 + 正确生产模式）。
  - 每设备：resolve SSH 凭据 → FetchConfig → TOFU pin fp → **hash 比对，未变 no-op**；变则 configdiff + `CreateDeviceConfig` + 发 `device_config_changed`（首抓只建基线不发事件）。

## 测试（`service_test.go`，4 个，FetchFunc mock + 单连接 in-memory）
- 首抓建基线不发事件。
- 变更抓取：建新版本 + 发 `device_config_changed` + diff_from_prev 正确。
- 未变抓取：no-op（不建版本不发事件）。
- 无 SSH 凭据绑定的设备不触发 fetch（选设备门控）。

## 验证
`go test ./...` 全绿；`gofmt`/`goimports`/`go vet`/`golangci-lint`（0 issues）。

## 后续（#137）
routes.go 接线（config + Start/Stop + sshcred.Resolver 构造）→ API + 设备详情配置历史 tab + diff 视图。

Refs #137.