### PR TITLE
feat(configbackup): routes 接线 + config 字段（#137，启用 sweep）

### DIFF
--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -31,6 +31,7 @@ import (
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
 	scannerv2cleanup "mibee-steward/internal/service/scannerv2/cleanup"
+	scannerv2configbackup "mibee-steward/internal/service/scannerv2/configbackup"
 	credresolver "mibee-steward/internal/service/scannerv2/credresolver"
 	scannerv2discovery "mibee-steward/internal/service/scannerv2/discovery"
 	scannerv2ebpf "mibee-steward/internal/service/scannerv2/ebpf"
@@ -39,6 +40,7 @@ import (
 	scannerv2reconcile "mibee-steward/internal/service/scannerv2/reconcile"
 	scannerv2runner "mibee-steward/internal/service/scannerv2/runner"
 	scannerv2scheduler "mibee-steward/internal/service/scannerv2/scheduler"
+	"mibee-steward/internal/service/scannerv2/sshcred"
 	scannerv2task "mibee-steward/internal/service/scannerv2/taskservice"
 )
 
@@ -600,6 +602,23 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	cleanupSvc := scannerv2cleanup.New(scanQueries, hbStore.Queries(), hbStore.DB(), dbConn, cfg.Retention)
 	cleanupSvc.Start(context.Background())
 
+	// Config-backup sweep (#137): fetches running-configs over SSH for devices
+	// with a bound SSH credential. Opt-in (scanner.config_backup.enabled) — needs
+	// security.master_key + bound creds to do anything useful.
+	var configBackupSvc *scannerv2configbackup.Service
+	if cfg.Scanner.ConfigBackup.Enabled {
+		sshResolver := sshcred.New(dbConn, credCipher)
+		configBackupSvc = scannerv2configbackup.New(
+			dbConn, scanQueries, sshResolver, changeRecorder, scannerv2configbackup.FetchConfig,
+			time.Duration(cfg.Scanner.ConfigBackup.Interval)*time.Second,
+			time.Duration(cfg.Scanner.ConfigBackup.Timeout)*time.Second,
+			slog.Default(),
+		)
+		configBackupSvc.Start(context.Background())
+		slog.Info("config-backup sweep started",
+			"interval_s", cfg.Scanner.ConfigBackup.Interval, "timeout_s", cfg.Scanner.ConfigBackup.Timeout)
+	}
+
 	if scanScheduler != nil {
 		scanScheduler.Start(context.Background())
 	}
@@ -833,6 +852,9 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		}
 		discSvc.Stop()
 		cleanupSvc.Stop()
+		if configBackupSvc != nil {
+			configBackupSvc.Stop()
+		}
 		// Stop the rule engine BEFORE the dispatcher — it holds a Watcher
 		// subscriber and calls dispatcher.Dispatch; stopping it first prevents
 		// in-flight dispatch attempts against a stopped dispatcher.

--- a/internal/config/scanner_config.go
+++ b/internal/config/scanner_config.go
@@ -26,6 +26,10 @@ type ScannerConfig struct {
 	// 0 means "use the default" (2). Applied by DetectLost (runner), shared by
 	// the local scan path + the agent→center ingestion path + the lease sweeper.
 	LostThreshold int `koanf:"lost_threshold"`
+	// ConfigBackup configures the periodic device running-config backup (#137).
+	// Disabled by default — requires security.master_key + at least one device
+	// with an SSH credential bound. See BackupConfig.
+	ConfigBackup BackupConfig `koanf:"config_backup"`
 	// PerProbeTimeout bounds a SINGLE probe attempt (one SNMP Get, one TCP dial,
 	// one HTTP fetch) in seconds. Distinct from default_timeout (which bounds
 	// the whole per-host pipeline). Default 3s — keeps /24 scans fast even when
@@ -103,6 +107,17 @@ type RouterARPConfig struct {
 	Routers   []string `koanf:"routers"`
 	Community string   `koanf:"community"`
 	Timeout   int      `koanf:"timeout"` // seconds; default 4
+}
+
+// BackupConfig configures the device config-backup sweep (#137). The
+// service fetches each router/switch/firewall device's running-config over SSH
+// (using its bound ssh_credential), diffs it, and records a version when it
+// changes. All fields default (0/empty) → "use sensible defaults"; Enabled
+// defaults to false (opt-in — requires master_key + bound SSH credentials).
+type BackupConfig struct {
+	Enabled  bool `koanf:"enabled"`
+	Interval int  `koanf:"interval_seconds"` // seconds between sweeps; <=0 → 6h
+	Timeout  int  `koanf:"timeout_seconds"`  // per-device SSH timeout; <=0 → 30s
 }
 
 // RDNSConfig tunes the reverse-DNS probe. DNSServers (optional) overrides the


### PR DESCRIPTION
## 背景
把 configbackup.Service 接进 `routes.go`（composition root），让 #137 在生产可启用。仿 `cleanup.Service` 模式：构造 + Start + 优雅 Stop。**默认 disabled（opt-in）**。

## 改动
- **`config/scanner_config.go`**：`ScannerConfig` 加 `ConfigBackup BackupConfig`（`{Enabled, IntervalSeconds, TimeoutSeconds}`，koanf: `config_backup`）。
- **`routes.go`**：当 `cfg.Scanner.ConfigBackup.Enabled` → 构造 `sshResolver`（`sshcred.New(db, credCipher)`，复用 SNMP 的 master_key cipher）→ `configbackup.New(..., FetchConfig, ...)` → `Start`。shutdown 路径 `configBackupSvc.Stop()`。

## 启用方式
```yaml
scanner:
  config_backup:
    enabled: true
    interval_seconds: 21600   # 6h
    timeout_seconds: 30
```

## 验证
`go build` + `go test ./internal/api/routes/` 全绿；`golangci-lint` 0 issues。

## #137 全景（7 PR，本 PR 是第 7 个——接线完成）
#215 configdiff → #216 device_configs 存储 → #218 ssh_credentials store+resolver → #219 ssh_credentials handler+routes → #220 SSH probe 引擎 → #221 configbackup.Service → **#222 routes 接线**。核心 engine + Service + 接线全完成。后续：API（GET /devices/{id}/configs）+ 前端配置历史 tab。

Refs #137.