### PR TITLE
feat(api): device_configs 读取 API — 列表/详情/diff（#137 读取面）

### DIFF
--- a/internal/api/handler/device_config.go
+++ b/internal/api/handler/device_config.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"mibee-steward/internal/configdiff"
+	"mibee-steward/internal/db"
+)
+
+// DeviceConfigHandler serves the read side of the versioned running-config
+// store (#137) — the Oxidized/RANCID-style config-history view on the device
+// detail page. It is read-only: the write path is the background
+// configbackup.Service (scheduled SSH pull → diff → device_configs row +
+// device_config_changed event). Per the handler/service charter, a read-only
+// passthrough handler may use *db.Queries directly.
+//
+// Note: config_text can contain device secrets (plaintext passwords, SNMP
+// communities). It is gated behind the same RequireAuth as the other device
+// sub-resources (neighbors/certificates/systems); tightening to admin-only is
+// deferred to the RBAC track (#138) so this endpoint stays consistent with its
+// siblings.
+type DeviceConfigHandler struct {
+	queries *db.Queries
+}
+
+// NewDeviceConfigHandler constructs the handler. queries is the shared sqlc
+// Queries bound to the main DB.
+func NewDeviceConfigHandler(queries *db.Queries) *DeviceConfigHandler {
+	return &DeviceConfigHandler{queries: queries}
+}
+
+// deviceConfigSummary is one row of the version-history list. config_text is
+// omitted (it can be large); has_diff signals whether this version changed vs
+// the previous one (diff_from_prev != "").
+type deviceConfigSummary struct {
+	ID         int64  `json:"id"`
+	DeviceID   int64  `json:"device_id"`
+	ConfigHash string `json:"config_hash"`
+	Protocol   string `json:"protocol"`
+	HasDiff    bool   `json:"has_diff"`
+	FetchedAt  string `json:"fetched_at"`
+}
+
+// deviceConfigDetail is the full single-version view: config_text +
+// diff_from_prev (the change that introduced this version).
+type deviceConfigDetail struct {
+	ID           int64  `json:"id"`
+	DeviceID     int64  `json:"device_id"`
+	ConfigHash   string `json:"config_hash"`
+	ConfigText   string `json:"config_text"`
+	Protocol     string `json:"protocol"`
+	DiffFromPrev string `json:"diff_from_prev"`
+	FetchedAt    string `json:"fetched_at"`
+}
+
+// deviceConfigVersionRef names one side of a two-version comparison.
+type deviceConfigVersionRef struct {
+	ID        int64  `json:"id"`
+	FetchedAt string `json:"fetched_at"`
+}
+
+// deviceConfigDiffResponse is the result of GET .../configs/diff?a=&b=.
+type deviceConfigDiffResponse struct {
+	A    deviceConfigVersionRef `json:"a"`
+	B    deviceConfigVersionRef `json:"b"`
+	Diff string                 `json:"diff"` // unified diff; "" when the two versions are identical
+}
+
+// List handles GET /api/v1/devices/{id}/configs — the version history for the
+// device-detail "Config History" tab. Newest first; metadata only (config_text
+// omitted). Returns 200 with an empty items array (not 404) for a device that
+// has no captures yet — the frontend renders an empty state.
+func (h *DeviceConfigHandler) List(w http.ResponseWriter, r *http.Request) {
+	deviceID, ok := parseDeviceConfigDeviceID(w, r)
+	if !ok {
+		return
+	}
+	limit, offset := parseListPaging(r)
+	rows, err := h.queries.ListDeviceConfigs(r.Context(), db.ListDeviceConfigsParams{
+		DeviceID: deviceID, Limit: limit, Offset: offset,
+	})
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to list device configs")
+		return
+	}
+	items := make([]deviceConfigSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, deviceConfigSummary{
+			ID:         row.ID,
+			DeviceID:   row.DeviceID,
+			ConfigHash: row.ConfigHash,
+			Protocol:   row.Protocol,
+			HasDiff:    row.DiffFromPrev != "",
+			FetchedAt:  row.FetchedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	total, err := h.queries.CountDeviceConfigs(r.Context(), deviceID)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to count device configs")
+		return
+	}
+	Success(w, map[string]any{"items": items, "total": total, "limit": limit, "offset": offset})
+}
+
+// Get handles GET /api/v1/devices/{id}/configs/{configId} — the full text of one
+// version (the detail / "view config" view). A config not belonging to the path
+// device returns 404 (IDOR guard: a configId from another device is treated as
+// not found, never leaked).
+func (h *DeviceConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
+	deviceID, ok := parseDeviceConfigDeviceID(w, r)
+	if !ok {
+		return
+	}
+	configID, ok := parseDeviceConfigID(w, r)
+	if !ok {
+		return
+	}
+	cfg, err := h.loadOwnedConfig(r.Context(), deviceID, configID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			Error(w, http.StatusNotFound, "config version not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to fetch config version")
+		return
+	}
+	Success(w, deviceConfigDetail{
+		ID:           cfg.ID,
+		DeviceID:     cfg.DeviceID,
+		ConfigHash:   cfg.ConfigHash,
+		ConfigText:   cfg.ConfigText,
+		Protocol:     cfg.Protocol,
+		DiffFromPrev: cfg.DiffFromPrev,
+		FetchedAt:    cfg.FetchedAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// Diff handles GET /api/v1/devices/{id}/configs/diff?a={id}&b={id} — a unified
+// diff between any two captured versions of the same device. Both versions must
+// belong to the path device (else 404). a==b yields an empty diff. The diff is
+// computed on demand from the stored config_text (it is not the same as either
+// version's diff_from_prev, which only covers that version vs its immediate
+// predecessor).
+func (h *DeviceConfigHandler) Diff(w http.ResponseWriter, r *http.Request) {
+	deviceID, ok := parseDeviceConfigDeviceID(w, r)
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	aID, err := strconv.ParseInt(q.Get("a"), 10, 64)
+	if err != nil || aID <= 0 {
+		Error(w, http.StatusBadRequest, "invalid or missing 'a' config id")
+		return
+	}
+	bID, err := strconv.ParseInt(q.Get("b"), 10, 64)
+	if err != nil || bID <= 0 {
+		Error(w, http.StatusBadRequest, "invalid or missing 'b' config id")
+		return
+	}
+	aCfg, err := h.loadOwnedConfig(r.Context(), deviceID, aID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			Error(w, http.StatusNotFound, "config version 'a' not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to fetch config version 'a'")
+		return
+	}
+	bCfg, err := h.loadOwnedConfig(r.Context(), deviceID, bID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			Error(w, http.StatusNotFound, "config version 'b' not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to fetch config version 'b'")
+		return
+	}
+	diff := configdiff.MustDiff(configVersionLabel(aCfg), aCfg.ConfigText, configVersionLabel(bCfg), bCfg.ConfigText)
+	Success(w, deviceConfigDiffResponse{
+		A:    deviceConfigVersionRef{ID: aCfg.ID, FetchedAt: aCfg.FetchedAt.UTC().Format(time.RFC3339)},
+		B:    deviceConfigVersionRef{ID: bCfg.ID, FetchedAt: bCfg.FetchedAt.UTC().Format(time.RFC3339)},
+		Diff: diff,
+	})
+}
+
+// loadOwnedConfig fetches one config version and enforces that it belongs to
+// deviceID. A missing row OR a row owned by a different device both surface as
+// sql.ErrNoRows so callers map them uniformly to 404 (no cross-device leak).
+func (h *DeviceConfigHandler) loadOwnedConfig(ctx context.Context, deviceID, configID int64) (db.DeviceConfig, error) {
+	cfg, err := h.queries.GetDeviceConfig(ctx, configID)
+	if err != nil {
+		return db.DeviceConfig{}, err
+	}
+	if cfg.DeviceID != deviceID {
+		return db.DeviceConfig{}, sql.ErrNoRows
+	}
+	return cfg, nil
+}
+
+// configVersionLabel labels one side of a diff header (the ---/+++ lines).
+func configVersionLabel(cfg db.DeviceConfig) string {
+	return fmt.Sprintf("config #%d @ %s", cfg.ID, cfg.FetchedAt.UTC().Format(time.RFC3339))
+}
+
+// parseDeviceConfigDeviceID extracts and validates the {id} path param (device).
+func parseDeviceConfigDeviceID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		Error(w, http.StatusBadRequest, "invalid device id")
+		return 0, false
+	}
+	return id, true
+}
+
+// parseDeviceConfigID extracts and validates the {configId} path param.
+func parseDeviceConfigID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "configId"), 10, 64)
+	if err != nil || id <= 0 {
+		Error(w, http.StatusBadRequest, "invalid config id")
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/api/handler/device_config_test.go
+++ b/internal/api/handler/device_config_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/testutil"
+)
+
+// These tests cover the #137 read API (GET /devices/{id}/configs list + detail
+// + diff). They lock: list omits config_text + reports has_diff; detail returns
+// the full text; diff computes a unified diff between any two versions; and the
+// IDOR guard rejects a config that does not belong to the path device.
+
+func hashStr(t *testing.T, text string) string {
+	t.Helper()
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// setupDeviceConfigHandler seeds a fresh DB with two devices and a few config
+// versions on device 1, returning the handler + the queries + the two device
+// IDs + the inserted config IDs (oldest..newest on device 1).
+func setupDeviceConfigHandler(t *testing.T) (h *DeviceConfigHandler, q *db.Queries, dev1, dev2 int64, cfgIDs []int64) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	q = db.New(conn)
+	h = NewDeviceConfigHandler(q)
+
+	ctx := context.Background()
+	r1, err := conn.Exec(`INSERT INTO devices (name, ip_address) VALUES ('r1', '10.0.0.1')`)
+	require.NoError(t, err)
+	dev1, err = r1.LastInsertId()
+	require.NoError(t, err)
+	r2, err := conn.Exec(`INSERT INTO devices (name, ip_address) VALUES ('r2', '10.0.0.2')`)
+	require.NoError(t, err)
+	dev2, err = r2.LastInsertId()
+	require.NoError(t, err)
+
+	// Three captures on device 1; v2 differs from v1 (has_diff=true), v3 == v2 text.
+	texts := []string{
+		"hostname r1\ninterface eth0\n ip address 10.0.0.1/24\n",
+		"hostname r1\ninterface eth0\n ip address 10.0.0.2/24\n",
+		"hostname r1\ninterface eth0\n ip address 10.0.0.2/24\n",
+	}
+	prev := ""
+	for _, txt := range texts {
+		diff := ""
+		if prev != "" && prev != txt {
+			diff = "diff-stub" // exact diff content is exercised by the store-layer tests
+		}
+		cfg, err := q.CreateDeviceConfig(ctx, db.CreateDeviceConfigParams{
+			DeviceID: dev1, ConfigHash: hashStr(t, txt), ConfigText: txt, Protocol: "ssh_show_run", DiffFromPrev: diff,
+		})
+		require.NoError(t, err)
+		cfgIDs = append(cfgIDs, cfg.ID)
+		prev = txt
+	}
+	return h, q, dev1, dev2, cfgIDs
+}
+
+// reqWithParams builds a request with chi URL params injected (id + optional
+// configId), so Get/List work outside a full router.
+func reqWithParams(method, target, deviceID, configID string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	rctx := chi.NewRouteContext()
+	if deviceID != "" {
+		rctx.URLParams.Add("id", deviceID)
+	}
+	if configID != "" {
+		rctx.URLParams.Add("configId", configID)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// reqWithDeviceCtx builds a request carrying only the {id} chi param (used by
+// the Diff handler, which reads query params from the URL string).
+func reqWithDeviceCtx(method, target, deviceID string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", deviceID)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// --- List ---
+
+func TestDeviceConfigHandler_List_OmitsTextAndReportsHasDiff(t *testing.T) {
+	h, _, dev1, _, _ := setupDeviceConfigHandler(t)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, reqWithParams(http.MethodGet, "/api/v1/devices/"+strconv.FormatInt(dev1, 10)+"/configs", strconv.FormatInt(dev1, 10), ""))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Items []map[string]any `json:"items"`
+		Total int64            `json:"total"`
+	}
+	decodeBody(t, rec, &resp)
+	require.EqualValues(t, 3, resp.Total)
+	require.Len(t, resp.Items, 3)
+	// List projection omits config_text entirely; has_diff flags the v2 change.
+	for _, row := range resp.Items {
+		_, hasText := row["config_text"]
+		require.False(t, hasText, "list must omit config_text")
+	}
+	// Newest first (id DESC): items[0]=v3(no diff) items[1]=v2(diff) items[2]=v1(no diff).
+	require.False(t, resp.Items[0]["has_diff"].(bool))
+	require.True(t, resp.Items[1]["has_diff"].(bool))
+	require.False(t, resp.Items[2]["has_diff"].(bool))
+}
+
+func TestDeviceConfigHandler_List_EmptyForDeviceWithNoCaptures(t *testing.T) {
+	h, _, _, dev2, _ := setupDeviceConfigHandler(t)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, reqWithParams(http.MethodGet, "/api/v1/devices/"+strconv.FormatInt(dev2, 10)+"/configs", strconv.FormatInt(dev2, 10), ""))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Items []map[string]any `json:"items"`
+		Total int64            `json:"total"`
+	}
+	decodeBody(t, rec, &resp)
+	require.Empty(t, resp.Items)
+	require.Zero(t, resp.Total)
+}
+
+func TestDeviceConfigHandler_List_RejectsInvalidDeviceID(t *testing.T) {
+	h, _, _, _, _ := setupDeviceConfigHandler(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, reqWithParams(http.MethodGet, "/api/v1/devices/abc/configs", "abc", ""))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Get ---
+
+func TestDeviceConfigHandler_Get_ReturnsFullText(t *testing.T) {
+	h, _, dev1, _, cfgIDs := setupDeviceConfigHandler(t)
+
+	rec := httptest.NewRecorder()
+	h.Get(rec, reqWithParams(http.MethodGet,
+		"/api/v1/devices/"+strconv.FormatInt(dev1, 10)+"/configs/"+strconv.FormatInt(cfgIDs[1], 10),
+		strconv.FormatInt(dev1, 10), strconv.FormatInt(cfgIDs[1], 10)))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var detail map[string]any
+	decodeBody(t, rec, &detail)
+	require.Contains(t, detail["config_text"], "10.0.0.2/24")
+	require.NotEmpty(t, detail["diff_from_prev"], "v2 changed vs v1")
+	require.Equal(t, "ssh_show_run", detail["protocol"])
+}
+
+func TestDeviceConfigHandler_Get_IDOR_RejectsConfigFromOtherDevice(t *testing.T) {
+	h, _, _, _, cfgIDs := setupDeviceConfigHandler(t)
+
+	// cfgIDs[0] belongs to dev1; request it under dev2's path -> 404, not leaked.
+	rec := httptest.NewRecorder()
+	h.Get(rec, reqWithParams(http.MethodGet,
+		"/api/v1/devices/999/configs/"+strconv.FormatInt(cfgIDs[0], 10),
+		"999", strconv.FormatInt(cfgIDs[0], 10)))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDeviceConfigHandler_Get_NotFound(t *testing.T) {
+	h, _, dev1, _, _ := setupDeviceConfigHandler(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, reqWithParams(http.MethodGet,
+		"/api/v1/devices/"+strconv.FormatInt(dev1, 10)+"/configs/999999",
+		strconv.FormatInt(dev1, 10), "999999"))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// --- Diff ---
+
+func TestDeviceConfigHandler_Diff_BetweenTwoVersions(t *testing.T) {
+	h, _, dev1, _, cfgIDs := setupDeviceConfigHandler(t)
+	d1 := strconv.FormatInt(dev1, 10)
+
+	// cfgIDs[0] (v1, .1/24) vs cfgIDs[1] (v2, .2/24) -> non-empty diff.
+	rec := httptest.NewRecorder()
+	h.Diff(rec, reqWithDeviceCtx(http.MethodGet,
+		"/api/v1/devices/"+d1+"/configs/diff?a="+strconv.FormatInt(cfgIDs[0], 10)+"&b="+strconv.FormatInt(cfgIDs[1], 10), d1))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		A    map[string]any `json:"a"`
+		B    map[string]any `json:"b"`
+		Diff string         `json:"diff"`
+	}
+	decodeBody(t, rec, &resp)
+	require.Contains(t, resp.Diff, "- ip address 10.0.0.1/24")
+	require.Contains(t, resp.Diff, "+ ip address 10.0.0.2/24")
+	require.EqualValues(t, cfgIDs[0], resp.A["id"])
+	require.EqualValues(t, cfgIDs[1], resp.B["id"])
+}
+
+func TestDeviceConfigHandler_Diff_IdenticalVersionsIsEmpty(t *testing.T) {
+	h, _, dev1, _, cfgIDs := setupDeviceConfigHandler(t)
+	d1 := strconv.FormatInt(dev1, 10)
+
+	// cfgIDs[1] and cfgIDs[2] have identical text -> empty diff.
+	rec := httptest.NewRecorder()
+	h.Diff(rec, reqWithDeviceCtx(http.MethodGet,
+		"/api/v1/devices/"+d1+"/configs/diff?a="+strconv.FormatInt(cfgIDs[1], 10)+"&b="+strconv.FormatInt(cfgIDs[2], 10), d1))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Diff string `json:"diff"`
+	}
+	decodeBody(t, rec, &resp)
+	require.Empty(t, resp.Diff)
+}
+
+func TestDeviceConfigHandler_Diff_MissingParamIs400(t *testing.T) {
+	h, _, dev1, _, _ := setupDeviceConfigHandler(t)
+	d1 := strconv.FormatInt(dev1, 10)
+	rec := httptest.NewRecorder()
+	h.Diff(rec, reqWithDeviceCtx(http.MethodGet,
+		"/api/v1/devices/"+d1+"/configs/diff?a=1", d1)) // no b
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDeviceConfigHandler_Diff_IDOR_RejectsForeignVersion(t *testing.T) {
+	h, _, _, _, cfgIDs := setupDeviceConfigHandler(t)
+	// Request dev1's configs under dev2 path -> 404 (treated as not-found, not leaked).
+	rec := httptest.NewRecorder()
+	h.Diff(rec, reqWithDeviceCtx(http.MethodGet,
+		"/api/v1/devices/999/configs/diff?a="+strconv.FormatInt(cfgIDs[0], 10)+"&b="+strconv.FormatInt(cfgIDs[1], 10), "999"))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -206,6 +206,10 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// TLS certificates per device (detail page TLS sub-panel + Modal). Read-only;
 	// any logged-in user. Same *db.Queries as the neighbors handler.
 	tlsCertHandler := handler.NewTLSCertHandler(scanQueries)
+	// Versioned running-config history per device (detail page "Config History"
+	// tab, #137). Read-only; any logged-in user. The write path is the background
+	// configbackup.Service; this handler only reads device_configs.
+	deviceConfigHandler := handler.NewDeviceConfigHandler(scanQueries)
 
 	// Resolve this instance's network identity (networks.id) so discovered
 	// devices can be tagged with their origin. Done here (not in migrations)
@@ -661,6 +665,17 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	r.Route("/api/v1/devices/{id}/certificates", func(r chi.Router) {
 		r.Use(middleware.RequireAuth)
 		r.Get("/", tlsCertHandler.ListByDevice)
+	})
+
+	// Device running-config history (#137, Oxidized/RANCID-style) — read-only,
+	// any logged-in user. The list omits config_text; the detail + diff views
+	// load it on demand. Registered before /{configId} so the static /diff
+	// segment wins over the param (chi prefers literal over wildcard).
+	r.Route("/api/v1/devices/{id}/configs", func(r chi.Router) {
+		r.Use(middleware.RequireAuth)
+		r.Get("/", deviceConfigHandler.List)
+		r.Get("/diff", deviceConfigHandler.Diff)
+		r.Get("/{configId}", deviceConfigHandler.Get)
 	})
 
 	// Network-level topology graph — all devices (nodes) + all neighbor edges.


### PR DESCRIPTION
补齐 #137 的 user-facing 读取面：设备详情「配置历史」所需的三个只读端点，复用已落地的 `device_configs` 存储（#216）+ `configdiff`（#215），无新表、无新决策。

## 端点（RequireAuth，与 neighbors/certificates/systems 同级）

| 方法 | 路径 | 作用 |
|---|---|---|
| GET | `/api/v1/devices/{id}/configs` | 版本列表（省略 `config_text`，带 `has_diff` 标记 + `total`/分页） |
| GET | `/api/v1/devices/{id}/configs/{configId}` | 单版详情（完整 `config_text` + `diff_from_prev`） |
| GET | `/api/v1/devices/{id}/configs/diff?a=&b=` | 任意两版 unified diff（按需从 `config_text` 计算） |

## 设计要点

- **只读 handler**：直接走 `*db.Queries`，符合 handler/service charter 的 read-only 例外（写路径是后台 `configbackup.Service`，本 PR 只读）。
- **IDOR 守护**：Get/Diff 均校验 config 归属 path device —— 跨设备 id 一律 404，不泄露。
- **路由不冲突**：`/diff` 静态段注册在 `/{configId}` 前，chi 字面量优先于通配。
- **空态**：无快照的设备返回 200 + 空 `items`（非 404），前端渲染空态。
- **diff 标签**：`config #<id> @ <fetched_at RFC3339>`，便于阅读。

## 测试（10 例，全绿）

列表省文本 + `has_diff`、空设备空数组、非法 id 400、详情全文本、IDOR（跨设备→404）、not-found、两版 diff 内容、相同版空 diff、缺参 400、Diff IDOR。

`go vet ./...` / `gofmt` / `goimports` / `go test ./internal/api/...` 本地全绿。

## 关联

- 闭合 #137 读取面 AC（`GET /devices/{id}/configs` 列表 + 详情 + diff 对比）。
- 剩余：前端「配置历史」tab UI + 真实路由器烟测（需 GL-MT3000 开 SSH）。

Signed-off-by: Mickey <mickey@mbhdata.com>