### PR TITLE
feat(db): users.role CHECK 加宽含 operator/viewer（#138 Phase 1b 基础）

### DIFF
--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -240,6 +240,15 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		return fmt.Errorf("devices type-check migration: %w", err)
 	}
 
+	// Extend users.role CHECK to include 'operator' and 'viewer' (RBAC capability
+	// graph, #138). SQLite can't ALTER a CHECK in place, so on existing DBs we
+	// rebuild the table; fresh installs already get the wider CHECK from
+	// schema.sql. Idempotent: skips the rebuild if 'operator' is already allowed.
+	// Purely additive — no route grants the new roles new access yet.
+	if err := extendUsersRoleCheck(context.Background(), db); err != nil {
+		return fmt.Errorf("users role-check migration: %w", err)
+	}
+
 	// Distributed-identity index migration: replace the legacy global-unique
 	// devices(ip_address) index with the (ip_address, network_id) composite +
 	// MAC lookup index. Runs LAST (after the devices rebuild) so the indexes
@@ -496,6 +505,96 @@ func extendDevicesTypeCheck(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("commit type-check rebuild: %w", err)
 	}
 	slog.Info("devices type CHECK widened (phone, printer added)")
+	return nil
+}
+
+// extendUsersRoleCheck widens the users.role CHECK constraint to include
+// 'operator' and 'viewer' (the RBAC capability graph, #138). SQLite cannot
+// ALTER a CHECK in place, so on existing DBs the table is rebuilt with the new
+// constraint; fresh installs already get the wider CHECK from schema.sql. The
+// rebuild is shape-identical to the current table (only the CHECK clause on
+// `role` differs) — same columns, same UNIQUE(username)/UNIQUE(email) implicit
+// indexes (recreated by the column definitions), no explicit secondary indexes.
+//
+// Idempotent: probes whether 'operator' is already accepted by the CHECK
+// (sentinel INSERT + rollback); if so, the rebuild is a no-op. This mirrors the
+// extendDevicesTypeCheck probe pattern.
+//
+// Behavior is purely additive: existing 'admin'/'user' rows stay valid, and no
+// route grants the new roles new access yet (that is the route-remap follow-up).
+// This migration only enables an admin to CREATE operator/viewer users.
+func extendUsersRoleCheck(ctx context.Context, db *sql.DB) error {
+	// Probe: can the current CHECK accept 'operator'? Insert a sentinel row in a
+	// rolled-back transaction; a CHECK violation means the migration is needed.
+	probe, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin role-check probe tx: %w", err)
+	}
+	probeErr := func() error {
+		if _, err := probe.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+			return err
+		}
+		_, err := probe.ExecContext(ctx,
+			`INSERT INTO users (username, email, password_hash, role) VALUES ('__role_probe__', '__role_probe__@invalid', 'x', 'operator')`)
+		return err
+	}()
+	_ = probe.Rollback()
+	if probeErr == nil {
+		// CHECK already permits 'operator' — nothing to do.
+		return nil
+	}
+	if !strings.Contains(probeErr.Error(), "CHECK constraint failed") {
+		return fmt.Errorf("probe users role CHECK: %w", probeErr)
+	}
+
+	slog.Info("rebuilding users table to widen role CHECK (add operator, viewer)")
+
+	// Rebuild preserving the FULL current column set — only the CHECK clause on
+	// `role` differs (now includes 'operator', 'viewer'). No generated columns,
+	// no explicit secondary indexes to recreate (UNIQUE constraints come back via
+	// the column definitions; FKs referencing users(id) survive via FKs=OFF).
+	stmts := []string{
+		`CREATE TABLE users_new (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			username TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			role TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'operator', 'viewer', 'user')),
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+			locked_until TIMESTAMP,
+			password_changed_at DATETIME,
+			must_change_password BOOLEAN NOT NULL DEFAULT 0
+		)`,
+		`INSERT INTO users_new (id, username, email, password_hash, role, created_at, updated_at,
+			failed_login_attempts, locked_until, password_changed_at, must_change_password)
+		SELECT id, username, email, password_hash, role, created_at, updated_at,
+			failed_login_attempts, locked_until, password_changed_at, must_change_password FROM users`,
+		`DROP TABLE users`,
+		`ALTER TABLE users_new RENAME TO users`,
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin role-check rebuild tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return fmt.Errorf("disable FKs for role-check rebuild: %w", err)
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("role-check rebuild step failed: %w (stmt: %s)", err, s)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+		return fmt.Errorf("re-enable FKs after role-check rebuild: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit role-check rebuild: %w", err)
+	}
+	slog.Info("users role CHECK widened (operator, viewer added)")
 	return nil
 }
 

--- a/cmd/server/migrations_test.go
+++ b/cmd/server/migrations_test.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"path/filepath"
@@ -65,4 +66,83 @@ func TestRunMigrations_FreshDB(t *testing.T) {
 	// Verify users table exists (seedAdminUser depends on it).
 	_, err = db.Exec(`SELECT id, username FROM users LIMIT 0`)
 	require.NoError(t, err, "users table must exist after fresh migration")
+}
+
+// TestRunMigrations_UsersRoleCheckWidened verifies that after runMigrations the
+// users.role CHECK accepts all four RBAC roles (#138). A fresh DB gets the wide
+// CHECK straight from schema.sql; an upgraded DB gets it from
+// extendUsersRoleCheck. Either way, all four roles must be insertable.
+func TestRunMigrations_UsersRoleCheckWidened(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "role.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, runMigrations(db, dbPath))
+
+	for _, role := range []string{"admin", "operator", "viewer", "user"} {
+		_, err := db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, 'x', ?)`,
+			"u_"+role, "u_"+role+"@invalid", role)
+		require.NoError(t, err, "role %q must be accepted after migration", role)
+	}
+	// An unknown role is still rejected (CHECK enforced, not dropped).
+	_, err = db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES ('u_bogus', 'u_bogus@invalid', 'x', 'superuser')`)
+	require.Error(t, err, "an unknown role must still be rejected by the CHECK")
+}
+
+// TestExtendUsersRoleCheck_RebuildsFromNarrowCheck verifies the migration
+// rebuilds an OLD-shape users table (narrow admin/user CHECK) to accept
+// operator/viewer, preserves existing rows (id + role), and is idempotent. This
+// exercises the rebuild path directly — a fresh install already gets the wide
+// CHECK from schema.sql and short-circuits via the probe.
+func TestExtendUsersRoleCheck_RebuildsFromNarrowCheck(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "narrow.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	// Create the OLD-shape users table (narrow CHECK, pre-#138).
+	_, err = db.Exec(`CREATE TABLE users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		username TEXT NOT NULL UNIQUE,
+		email TEXT NOT NULL UNIQUE,
+		password_hash TEXT NOT NULL,
+		role TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'user')),
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+		locked_until TIMESTAMP,
+		password_changed_at DATETIME,
+		must_change_password BOOLEAN NOT NULL DEFAULT 0
+	)`)
+	require.NoError(t, err)
+
+	// Seed a real user; confirm the narrow CHECK rejects 'operator'.
+	_, err = db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES ('admin1', 'a@x', 'h', 'admin')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES ('op1', 'o@x', 'h', 'operator')`)
+	require.Error(t, err, "narrow CHECK must reject 'operator' before migration")
+
+	// Run the migration.
+	require.NoError(t, extendUsersRoleCheck(ctx, db))
+
+	// The seed row survived the rebuild (id + role preserved).
+	var id int64
+	var role string
+	require.NoError(t, db.QueryRow(`SELECT id, role FROM users WHERE username = 'admin1'`).Scan(&id, &role))
+	require.Equal(t, "admin", role)
+	require.EqualValues(t, 1, id, "id must be preserved across the rebuild")
+
+	// 'operator' is now insertable (the widened CHECK accepts it).
+	_, err = db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES ('op1', 'o@x', 'h', 'operator')`)
+	require.NoError(t, err, "widened CHECK must accept 'operator'")
+
+	// 'viewer' too.
+	_, err = db.Exec(`INSERT INTO users (username, email, password_hash, role) VALUES ('v1', 'v@x', 'h', 'viewer')`)
+	require.NoError(t, err, "widened CHECK must accept 'viewer'")
+
+	// Idempotent: re-running is a no-op (the probe short-circuits).
+	require.NoError(t, extendUsersRoleCheck(ctx, db))
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT NOT NULL UNIQUE,
     email TEXT NOT NULL UNIQUE,
     password_hash TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'user')),
+    role TEXT NOT NULL DEFAULT 'user' CHECK(role IN ('admin', 'operator', 'viewer', 'user')),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     failed_login_attempts INTEGER NOT NULL DEFAULT 0,
@@ -590,7 +590,7 @@ CREATE INDEX IF NOT EXISTS idx_change_log_detected_at ON change_log(detected_at)
 -- Only the SHA-256 hash is stored; the plaintext is returned once at creation
 -- time. An admin creates a token per network/agent and hands it to the agent
 -- operator. Revocation = setting revoked_at. This is the machine-auth path —
--- distinct from the human user JWT flow (users.role CHECK is admin/user only).
+-- distinct from the human user JWT flow (users.role CHECK is admin/operator/viewer/user).
 CREATE TABLE IF NOT EXISTS agent_tokens (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     agent_id TEXT NOT NULL UNIQUE,    -- stable identifier the agent reports as


### PR DESCRIPTION
把 `users.role` CHECK 从 `(\admin,'user)` 加宽到 `(\admin,'operator,'viewer,'user)`，落地 #138 RBAC 能力图（#217）的角色值。这是 **Phase 1b 的存储基础**（紧随的 PR B 做路由能力重映射）。

## 为什么需要

#217 已落地能力图（`RoleAdmin/Operator/Viewer/User` + `RequireCapability` 中间件），但 `users.role` 的 DB CHECK 仍是窄的 `(admin,user)` —— 无法存储 operator/viewer。本 PR 打通这一层。

## 改动

- **`db/schema.sql`**：宽 CHECK（全新库直接拿到）+ 更新 `agent_tokens` 注释。
- **`cmd/server/migrations.go`**：`extendUsersRoleCheck` —— 仿 `extendDevicesTypeCheck` 的探针（sentinel `INSERT … operator` + rollback）幂等；既有库走 `CREATE users_new → INSERT … SELECT → DROP users → RENAME`，期间 `PRAGMA foreign_keys=OFF`。重建 shape-identical（只 CHECK 变），无显式二级索引需重建。
- **`cmd/server/migrations_test.go`**：
  - `TestExtendUsersRoleCheck_RebuildsFromNarrowCheck`：在旧窄 CHECK 表上跑重建 → 验证种子行 `id`/`role` 保留、`operator`/`viewer` 可插入、二次运行 no-op。
  - `TestRunMigrations_UsersRoleCheckWidened`：`runMigrations` 后四角色均可插入、未知角色仍被 CHECK 拒。

## 安全性

**纯加法、零鉴权行为变化**：
- 既有 `admin`/`user` 行依旧合法；
- 没有任何路由在新角色上授予新访问（路由重映射是 PR B）；
- 本 PR 只让 admin 能 *创建* operator/viewer 用户（注册流程透传 role，DB CHECK 是唯一约束）；
- 探针用 sentinel 用户名 `__role_probe__`，事务内 rollback，不留痕；未知角色仍被 CHECK 拒。

`go vet ./…` / `go test ./…`（全包）/ `gofmt` / `goimports` 本地全绿。

关联：#138 Phase 1a（#217）已合；本 PR 是 1b 存储；PR B（路由重映射）紧随。

Signed-off-by: Mickey <mickey@mbhdata.com>