### PR TITLE
feat(rbac): scanner 路由能力重映射（#138 Phase 1b）

### DIFF
--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -28,6 +28,7 @@ import (
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/crypto"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
 	scannerv2cleanup "mibee-steward/internal/service/scannerv2/cleanup"
@@ -479,31 +480,55 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	scannerTaskHandler := handler.NewScannerTaskHandler(scanTaskService)
 	scannerResultHandler := handler.NewScannerResultHandler(scanQueries, dbConn)
 	r.Route("/api/v1/scanner", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
-		// Rate-limited scan trigger endpoints (per-IP, 10/min default)
+		// #138 Phase 1b: scanner routes are gated by capability, not a blanket
+		// RequireAdmin. admin inherits every capability (unchanged access); the
+		// new operator role gains scan access; viewer gains read-only access to
+		// results/tasks/runs (same inventory-data class as the RequireAuth device
+		// endpoints). Each tier is its own group so the capability matches the
+		// action (reads → discovery:read, triggers → scan:trigger, task CRUD +
+		// bulk delete → scan:manage, add-devices → device:write).
+
+		// Reads: discovery:read (viewer+). Scan results, task lists, runs.
 		r.Group(func(r chi.Router) {
+			r.Use(middleware.RequireCapability(domain.CapDiscoveryRead))
+			r.Get("/tasks", scannerTaskHandler.ListTasks)
+			r.Get("/tasks/{id}", scannerTaskHandler.GetTask)
+			r.Get("/tasks/{id}/runs", scannerTaskHandler.GetTaskRuns)
+			r.Get("/tasks/{id}/results", scannerTaskHandler.GetTaskResults)
+			r.Get("/results", scannerResultHandler.ListResults)
+			r.Get("/results/{id}", scannerResultHandler.GetResult)
+			r.Get("/runs", scannerResultHandler.ListRuns)
+			r.Get("/runs/{id}", scannerResultHandler.GetRun)
+			r.Get("/results/export", scannerResultHandler.ExportScanResults)
+		})
+
+		// Scan triggers: scan:trigger (operator+). Rate-limited per-IP (these
+		// START scans). The rate limiter runs AFTER the capability gate, so a
+		// rejected (403) request never consumes a rate token.
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.RequireCapability(domain.CapScanTrigger))
 			r.Use(scanLimiter.Middleware)
 			r.Post("/scan", scannerHandler.Scan)
 			r.Post("/tasks/{id}/trigger", scannerTaskHandler.TriggerTask)
 		})
-		// Non-rate-limited scanner routes
-		r.Post("/add-devices", scannerHandler.AddDevices)
-		// Task CRUD
-		r.Post("/tasks", scannerTaskHandler.CreateTask)
-		r.Get("/tasks", scannerTaskHandler.ListTasks)
-		r.Get("/tasks/{id}", scannerTaskHandler.GetTask)
-		r.Put("/tasks/{id}", scannerTaskHandler.UpdateTask)
-		r.Delete("/tasks/{id}", scannerTaskHandler.DeleteTask)
-		r.Get("/tasks/{id}/runs", scannerTaskHandler.GetTaskRuns)
-		r.Get("/tasks/{id}/results", scannerTaskHandler.GetTaskResults)
-		r.Post("/tasks/{id}/cancel", scannerTaskHandler.CancelScanTask)
-		// Results & runs
-		r.Get("/results", scannerResultHandler.ListResults)
-		r.Get("/results/{id}", scannerResultHandler.GetResult)
-		r.Get("/runs", scannerResultHandler.ListRuns)
-		r.Get("/runs/{id}", scannerResultHandler.GetRun)
-		r.Get("/results/export", scannerResultHandler.ExportScanResults)
-		r.Delete("/results", scannerResultHandler.BulkDeleteResults)
+
+		// Cancel a running scan: scan:trigger (operator+), but NOT rate-limited
+		// (it stops a run, doesn't start one).
+		r.With(middleware.RequireCapability(domain.CapScanTrigger)).
+			Post("/tasks/{id}/cancel", scannerTaskHandler.CancelScanTask)
+
+		// Scan task CRUD + bulk result delete: scan:manage (operator+).
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.RequireCapability(domain.CapScanManage))
+			r.Post("/tasks", scannerTaskHandler.CreateTask)
+			r.Put("/tasks/{id}", scannerTaskHandler.UpdateTask)
+			r.Delete("/tasks/{id}", scannerTaskHandler.DeleteTask)
+			r.Delete("/results", scannerResultHandler.BulkDeleteResults)
+		})
+
+		// Add devices from a scan: device:write (operator+).
+		r.With(middleware.RequireCapability(domain.CapDeviceWrite)).
+			Post("/add-devices", scannerHandler.AddDevices)
 	})
 
 	// --- SNMP credential management (issue #135 — SNMPv3) ---

--- a/internal/api/routes/scanner_rbac_test.go
+++ b/internal/api/routes/scanner_rbac_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/jwtauth/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the scanner route capability wiring (#138 Phase 1b). Unlike
+// the middleware-level capability tests (which prove RequireCapability itself),
+// these exercise the REAL router built by NewRouter: one representative route
+// per capability tier is fired for each role, asserting the privilege boundary
+// is enforced at the route (not just the middleware) layer.
+//
+// "Pass" means the request cleared the auth gate and reached the handler (so the
+// status is anything OTHER than 401/403 — e.g. 200/400/404 from the handler on a
+// near-empty test DB). "Deny" means exactly 403 (authenticated, insufficient
+// capability) or 401 (no token). This decouples the boundary assertion from
+// handler/DB specifics while still catching a mis-wired capability.
+
+// scannerRBACCase is one (route, role) probe.
+type scannerRBACCase struct {
+	name   string
+	method string
+	path   string
+	role   string // "" = anonymous (no Bearer token)
+	pass   bool   // true = expect to clear the gate; false = expect 403 (or 401 if anon)
+}
+
+func TestScannerRoutes_CapabilityBoundary(t *testing.T) {
+	cfg := newTestConfig()
+	db := newTestDB(t)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() {
+		heartbeatSvc.Stop()
+		shutdown()
+	})
+
+	// Representative route per capability tier:
+	//   read        → GET    /scanner/results          (discovery:read)
+	//   trigger     → POST   /scanner/tasks/999/cancel (scan:trigger, not rate-limited)
+	//   manage      → DELETE /scanner/tasks/999        (scan:manage)
+	//   device-write→ POST   /scanner/add-devices      (device:write)
+	cases := []scannerRBACCase{
+		// --- read tier: viewer+ pass ---
+		{"read/admin", http.MethodGet, "/api/v1/scanner/results", "admin", true},
+		{"read/operator", http.MethodGet, "/api/v1/scanner/results", "operator", true},
+		{"read/viewer", http.MethodGet, "/api/v1/scanner/results", "viewer", true},
+		{"read/user", http.MethodGet, "/api/v1/scanner/results", "user", true},
+		{"read/anon", http.MethodGet, "/api/v1/scanner/results", "", false},
+
+		// --- trigger tier (cancel): operator+ pass, viewer/user 403, anon 401 ---
+		{"trigger/admin", http.MethodPost, "/api/v1/scanner/tasks/999/cancel", "admin", true},
+		{"trigger/operator", http.MethodPost, "/api/v1/scanner/tasks/999/cancel", "operator", true},
+		{"trigger/viewer", http.MethodPost, "/api/v1/scanner/tasks/999/cancel", "viewer", false},
+		{"trigger/user", http.MethodPost, "/api/v1/scanner/tasks/999/cancel", "user", false},
+		{"trigger/anon", http.MethodPost, "/api/v1/scanner/tasks/999/cancel", "", false},
+
+		// --- manage tier (delete task): operator+ pass, viewer/user 403, anon 401 ---
+		{"manage/admin", http.MethodDelete, "/api/v1/scanner/tasks/999", "admin", true},
+		{"manage/operator", http.MethodDelete, "/api/v1/scanner/tasks/999", "operator", true},
+		{"manage/viewer", http.MethodDelete, "/api/v1/scanner/tasks/999", "viewer", false},
+		{"manage/user", http.MethodDelete, "/api/v1/scanner/tasks/999", "user", false},
+		{"manage/anon", http.MethodDelete, "/api/v1/scanner/tasks/999", "", false},
+
+		// --- device-write tier (add-devices): operator+ pass, viewer/user 403, anon 401 ---
+		{"devwrite/admin", http.MethodPost, "/api/v1/scanner/add-devices", "admin", true},
+		{"devwrite/operator", http.MethodPost, "/api/v1/scanner/add-devices", "operator", true},
+		{"devwrite/viewer", http.MethodPost, "/api/v1/scanner/add-devices", "viewer", false},
+		{"devwrite/user", http.MethodPost, "/api/v1/scanner/add-devices", "user", false},
+		{"devwrite/anon", http.MethodPost, "/api/v1/scanner/add-devices", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			if tc.role != "" {
+				req.Header.Set("Authorization", "Bearer "+tokenForRole(t, cfg.Auth.JWTSecret, tc.role))
+			}
+			handler.ServeHTTP(rec, req)
+
+			code := rec.Code
+			switch {
+			case tc.role == "" && tc.pass:
+				t.Fatalf("anon marked pass — malformed case")
+			case tc.role == "":
+				require.Equal(t, http.StatusUnauthorized, code, "anon must be 401")
+			case tc.pass:
+				require.NotEqual(t, http.StatusUnauthorized, code, "authenticated pass must not be 401")
+				require.NotEqual(t, http.StatusForbidden, code, "%s with role %s must clear the gate (got 403)", tc.method, tc.path, tc.role)
+			default:
+				require.Equal(t, http.StatusForbidden, code, "%s %s with role %s must be denied 403", tc.method, tc.path, tc.role)
+			}
+		})
+	}
+}
+
+// tokenForRole signs a JWT (same secret NewRouter configured via SetJWTAuth)
+// carrying the given role claim. user_id is arbitrary; the auth gate only reads
+// role (and presence of user_id) for the capability check.
+func tokenForRole(t *testing.T, secret, role string) string {
+	t.Helper()
+	auth := jwtauth.New("HS256", []byte(secret), nil)
+	_, token, err := auth.Encode(map[string]any{"user_id": float64(1), "role": role})
+	require.NoError(t, err)
+	return token
+}


### PR DESCRIPTION
把 `/api/v1/scanner` 从 blanket `RequireAdmin` 改为按能力分组的 `RequireCapability`。这是 **#138 Phase 1b 的路由面**（PR A #224 已加宽 `users.role` CHECK）。

## 能力分派（#217 能力图）

| 动作 | 路由 | 能力 | 角色 |
|---|---|---|---|
| 读 | GET `/results` `/tasks` `/runs` `/results/export` | `discovery:read` | viewer+ |
| 触发 | POST `/scan`、`/tasks/{id}/trigger` | `scan:trigger` | operator+（保留 per-IP 限流） |
| 取消 | POST `/tasks/{id}/cancel` | `scan:trigger` | operator+（不限流——停止非启动） |
| 任务 CRUD + 批量删 | POST/PUT/DELETE `/tasks`、DELETE `/results` | `scan:manage` | operator+ |
| add-devices | POST `/add-devices` | `device:write` | operator+ |

## 行为变化（设计已批）

- **admin**：继承全部能力，访问**不变**。
- **operator**：新获扫描访问（此前 admin-only）。
- **viewer / 旧 user**：新获**只读**访问（结果/任务/运行历史）——与 `devices`/`neighbors`/`certificates` 等 `RequireAuth` 端点同属清单数据类，一致。
- 限流器在能力门**之后**执行 → 被拒（403）请求不消耗限流 token。

## 测试

`scanner_rbac_test.go`：用真实 `NewRouter`，对每个能力层取一条代表路由 × `{admin, operator, viewer, user, anon}`，断言边界：
- **pass**（清过关）= 到达 handler，状态非 401/403（200/400/404/500 等）；
- **deny** = 精确 403（已认证但能力不足）/ 401（无 token）。

20 子用例全绿，与 handler/DB 细节解耦——只锁鉴权边界。中间件层 `RequireCapability` 本身已由 `capability_test.go`（#217）覆盖。

`go vet ./…` / `go test ./internal/api/…` / `gofmt` / `goimports` 本地全绿。

关联：#138 Phase 1a（#217）+ 1b 存储（#224）已合；本 PR 闭合 Phase 1b。

Signed-off-by: Mickey <mickey@mbhdata.com>