### PR TITLE
feat(rbac): 全路由 RequireAdmin→RequireCapability 重映射（#138 Phase 1c）

### DIFF
--- a/internal/api/handler/user.go
+++ b/internal/api/handler/user.go
@@ -47,7 +47,10 @@ func (h *UserHandler) Routes() chi.Router {
 	// Public routes
 	r.Post("/login", h.Login)
 	r.Post("/logout", h.Logout)
-	r.With(middleware.RequireAdmin).Post("/register", h.Register)
+	// Account creation is admin-initiated (closed self-signup): gated by
+	// CapUserManage, an admin-only capability — same semantics as the prior
+	// RequireAdmin, expressed through the capability matrix.
+	r.With(middleware.RequireCapability(domain.CapUserManage)).Post("/register", h.Register)
 
 	// Protected routes (RequireAuth)
 	r.Group(func(r chi.Router) {

--- a/internal/api/routes/capability_boundary_test.go
+++ b/internal/api/routes/capability_boundary_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the capability wiring of the user-JWT route surface (#138
+// Phase 1c): every route that used to be a blanket RequireAdmin is now gated by
+// a specific capability from internal/domain/capability.go. They exercise the
+// REAL router built by NewRouter, firing one representative route per
+// capability tier for each role and asserting the privilege boundary holds at
+// the route (not just middleware) layer. Scanner-tier coverage lives in
+// scanner_rbac_test.go; this file covers the rest of the surface.
+//
+// "Pass" = the request cleared the auth gate and reached the handler (status is
+// anything OTHER than 401/403 — e.g. 200/400/404 from the handler on a
+// near-empty test DB). "Deny" = exactly 403 (authenticated but lacks the
+// capability) or 401 (no token). This decouples the boundary assertion from
+// handler/DB specifics while still catching a mis-wired capability.
+
+// accessLevel names the coarse privilege tier a route sits at. It mirrors the
+// capability matrix: read caps are held by every authenticated role; operator
+// caps by admin+operator; admin caps by admin only.
+type accessLevel int
+
+const (
+	levelRead     accessLevel = iota // viewer+ (every authenticated role)
+	levelOperator                    // operator+ (admin, operator)
+	levelAdmin                       // admin only
+)
+
+// capabilityRoute is one representative route for a capability tier.
+type capabilityRoute struct {
+	label  string
+	method string
+	path   string
+	level  accessLevel
+}
+
+// rbacRoles is the set of authenticated roles exercised against every route.
+var rbacRoles = []string{"admin", "operator", "viewer", "user"}
+
+// rolePasses reports whether role clears a route gated at lvl. This is the test
+// encoding of internal/domain/capability.go's role→capability map (admin =
+// everything, operator = reads + operational writes, viewer/user = reads).
+func rolePasses(role string, lvl accessLevel) bool {
+	switch lvl {
+	case levelRead:
+		return true // every authenticated role holds the read capabilities
+	case levelOperator:
+		return role == "admin" || role == "operator"
+	case levelAdmin:
+		return role == "admin"
+	}
+	return false
+}
+
+func TestRoutes_CapabilityBoundary(t *testing.T) {
+	cfg := newTestConfig()
+	db := newTestDB(t)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() {
+		heartbeatSvc.Stop()
+		shutdown()
+	})
+
+	routes := []capabilityRoute{
+		// --- read tier: CapAuditRead. audit-logs moved off RequireAdmin to
+		// CapAuditRead, which the matrix grants to viewer+ — the one read this
+		// PR opens to non-admins. (Other inventory reads stay RequireAuth and
+		// are covered by TestRoutes_RequireAuthReadsRemainOpen below.) ---
+		{"audit-read", http.MethodGet, "/api/v1/audit-logs", levelRead},
+
+		// --- operator write tier (CapDeviceWrite / CapHeartbeatManage /
+		// CapDocumentWrite): admin + operator pass, viewer/user 403. ---
+		{"device-write", http.MethodPut, "/api/v1/devices/1", levelOperator},
+		{"device-systems-write", http.MethodPost, "/api/v1/devices/1/systems", levelOperator},
+		{"heartbeat-manage", http.MethodPost, "/api/v1/devices/1/heartbeat-configs", levelOperator},
+		{"document-write", http.MethodPost, "/api/v1/documents", levelOperator},
+		{"device-document-link", http.MethodPost, "/api/v1/devices/1/documents", levelOperator},
+
+		// --- admin-only manage tier (CapNetworkManage / CapCredManage /
+		// CapUserManage / CapAgentManage / CapDashboardManage /
+		// CapNotificationManage): only admin passes. ---
+		{"network-manage", http.MethodPost, "/api/v1/networks", levelAdmin},
+		{"snmp-cred-manage", http.MethodPost, "/api/v1/snmp-credentials", levelAdmin},
+		{"ssh-cred-manage", http.MethodGet, "/api/v1/ssh-credentials", levelAdmin},
+		{"user-manage", http.MethodGet, "/api/v1/users", levelAdmin},
+		{"auth-register", http.MethodPost, "/api/v1/auth/register", levelAdmin},
+		{"agent-token-manage", http.MethodGet, "/api/v1/agents/tokens", levelAdmin},
+		{"agent-commands-all", http.MethodGet, "/api/v1/agents/commands/all", levelAdmin},
+		{"dashboard-manage", http.MethodPost, "/api/v1/dashboard/configs", levelAdmin},
+		{"notification-channels", http.MethodPost, "/api/v1/notification/channels", levelAdmin},
+		{"notification-rules", http.MethodGet, "/api/v1/notification/rules", levelAdmin},
+	}
+
+	for _, rt := range routes {
+		for _, role := range rbacRoles {
+			role, rt := role, rt
+			pass := rolePasses(role, rt.level)
+			t.Run(rt.label+"/"+role, func(t *testing.T) {
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(rt.method, rt.path, nil)
+				req.Header.Set("Authorization", "Bearer "+tokenForRole(t, cfg.Auth.JWTSecret, role))
+				handler.ServeHTTP(rec, req)
+
+				code := rec.Code
+				if pass {
+					require.NotEqual(t, http.StatusUnauthorized, code, "pass must not be 401")
+					require.NotEqualf(t, http.StatusForbidden, code,
+						"%s %s role=%s must clear the gate (got 403)", rt.method, rt.path, role)
+				} else {
+					require.Equalf(t, http.StatusForbidden, code,
+						"%s %s role=%s must be denied 403", rt.method, rt.path, role)
+				}
+			})
+		}
+		// anonymous → 401 for every gated route.
+		t.Run(rt.label+"/anon", func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(rt.method, rt.path, nil)
+			handler.ServeHTTP(rec, req)
+			require.Equalf(t, http.StatusUnauthorized, rec.Code,
+				"%s %s anon must be 401", rt.method, rt.path)
+		})
+	}
+}
+
+// TestRoutes_RequireAuthReadsRemainOpen is a regression guard: the shared
+// inventory read surface stays RequireAuth (NOT capability-gated) in this PR,
+// so every authenticated role — including viewer — must still read it. This
+// catches an accidental tightening where a read route is mis-remapped to an
+// admin/operator capability.
+func TestRoutes_RequireAuthReadsRemainOpen(t *testing.T) {
+	cfg := newTestConfig()
+	db := newTestDB(t)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() {
+		heartbeatSvc.Stop()
+		shutdown()
+	})
+
+	reads := []capabilityRoute{
+		{"devices", http.MethodGet, "/api/v1/devices", levelRead},
+		{"networks", http.MethodGet, "/api/v1/networks", levelRead},
+		{"changes", http.MethodGet, "/api/v1/changes", levelRead},
+		{"topology", http.MethodGet, "/api/v1/topology", levelRead},
+		{"dashboard-overview", http.MethodGet, "/api/v1/dashboard/overview", levelRead},
+		{"device-configs", http.MethodGet, "/api/v1/devices/1/configs", levelRead},
+		{"heartbeat-results", http.MethodGet, "/api/v1/devices/1/heartbeat-results", levelRead},
+	}
+
+	for _, rt := range reads {
+		// viewer must pass (the guard's point); anon must still get 401.
+		t.Run(rt.label+"/viewer", func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(rt.method, rt.path, nil)
+			req.Header.Set("Authorization", "Bearer "+tokenForRole(t, cfg.Auth.JWTSecret, "viewer"))
+			handler.ServeHTTP(rec, req)
+			require.NotEqual(t, http.StatusUnauthorized, rec.Code)
+			require.NotEqual(t, http.StatusForbidden, rec.Code,
+				"%s %s viewer must remain readable (RequireAuth)", rt.method, rt.path)
+		})
+		t.Run(rt.label+"/anon", func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(rt.method, rt.path, nil)
+			handler.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+		})
+	}
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -138,9 +138,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		})
 	})
 
-	// Admin-only user list
+	// User management — admin-only (#138 CapUserManage; admin is the only role
+	// that holds it, so this preserves the prior RequireAdmin semantics while
+	// expressing the gate through the capability matrix).
 	r.Route("/api/v1/users", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapUserManage))
 		r.Get("/", userHandler.ListUsers)
 		r.Post("/batch-delete", batchHandler.BatchDeleteUsers)
 		r.Post("/{id}/reset-password", userHandler.AdminResetPassword)
@@ -174,7 +176,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/{id}", deviceHandler.Get)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapDeviceWrite))
 			r.Post("/", deviceHandler.Create)
 			r.Put("/{id}", deviceHandler.Update)
 			r.Delete("/{id}", deviceHandler.Delete)
@@ -190,14 +192,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Network registry — feeds the device-list + change-history network filters
 	// and the Networks admin page. Read (List) is any logged-in user; create/
-	// update/delete are admin-only.
+	// update/delete require CapNetworkManage (admin-only capability).
 	networkHandler := handler.NewNetworkHandler(scanQueries, dbConn)
 	r.Route("/api/v1/networks", func(r chi.Router) {
 		r.Use(middleware.RequireAuth)
 		r.Get("/", networkHandler.List)
-		r.With(middleware.RequireAdmin).Post("/", networkHandler.Create)
-		r.With(middleware.RequireAdmin).Put("/{id}", networkHandler.Update)
-		r.With(middleware.RequireAdmin).Delete("/{id}", networkHandler.Delete)
+		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Post("/", networkHandler.Create)
+		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Put("/{id}", networkHandler.Update)
+		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Delete("/{id}", networkHandler.Delete)
 	})
 
 	// L2 topology — neighbors per device (detail page) + the whole-network
@@ -532,12 +534,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	})
 
 	// --- SNMP credential management (issue #135 — SNMPv3) ---
-	// Admin-only CRUD for SNMP credentials (v1/v2c community strings + v3 USM
-	// auth/priv). Passphrases are AES-GCM-encrypted at rest (security.master_key);
-	// the list/get responses never include the secrets (masked projection).
+	// CRUD for SNMP credentials (v1/v2c community strings + v3 USM auth/priv).
+	// Passphrases are AES-GCM-encrypted at rest (security.master_key); the
+	// list/get responses never include the secrets (masked projection). Gated by
+	// CapCredManage — an admin-only capability (credentials are sensitive even
+	// when masked), preserving the prior admin-only semantics.
 	credentialHandler := handler.NewCredentialHandler(dbConn, credCipher, credResolver)
 	r.Route("/api/v1/snmp-credentials", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapCredManage))
 		r.Post("/", credentialHandler.Create)
 		r.Get("/", credentialHandler.List)
 		r.Get("/{id}", credentialHandler.Get)
@@ -545,11 +549,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Delete("/{id}", credentialHandler.Delete)
 	})
 
-	// SSH credentials for the device config-backup probe (#137). Same admin-only
-	// gate + same shared master_key cipher as SNMP credentials.
+	// SSH credentials for the device config-backup probe (#137). Same gate
+	// (CapCredManage, admin-only) + same shared master_key cipher as SNMP.
 	sshCredentialHandler := handler.NewSSHCredentialHandler(dbConn, credCipher)
 	r.Route("/api/v1/ssh-credentials", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapCredManage))
 		r.Post("/", sshCredentialHandler.Create)
 		r.Get("/", sshCredentialHandler.List)
 		r.Get("/{id}", sshCredentialHandler.Get)
@@ -558,12 +562,13 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	})
 
 	// --- Agent token management (distributed phase) ---
-	// Admin-only CRUD for discovery-agent bearer tokens. The ingestion endpoint
-	// (/agents/report below) authenticates via RequireAgentToken against this
-	// table; this block is the management surface.
+	// CRUD for discovery-agent bearer tokens, gated by CapAgentManage
+	// (admin-only capability). The ingestion endpoint (/agents/report below)
+	// authenticates via RequireAgentToken against this table; this block is the
+	// management surface.
 	agentAdminHandler := handler.NewAgentAdminHandler(scanQueries)
 	r.Route("/api/v1/agents/tokens", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapAgentManage))
 		r.Post("/", agentAdminHandler.Create)
 		r.Get("/", agentAdminHandler.List)
 		r.Post("/{id}/revoke", agentAdminHandler.Revoke)
@@ -592,12 +597,13 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	})
 
 	// Admin-side command management: enqueue a command for an agent (POST) +
-	// view all commands (GET). Separate route group (RequireAdmin, not agent token).
+	// view all commands (GET). Separate route group (CapAgentManage, not agent
+	// token).
 	r.Route("/api/v1/agents/{agentId}/commands", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapAgentManage))
 		r.Post("/", agentCommandHandler.Create)
 	})
-	r.With(middleware.RequireAdmin).Get("/api/v1/agents/commands/all", agentCommandHandler.ListAll)
+	r.With(middleware.RequireCapability(domain.CapAgentManage)).Get("/api/v1/agents/commands/all", agentCommandHandler.ListAll)
 
 	// --- Change history query (Phase 3) ---
 	// GET /api/v1/changes returns the device_added/changed/lost event stream
@@ -651,9 +657,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	if scanScheduler != nil {
 		scanScheduler.Start(context.Background())
 	}
-	// Audit log routes (admin only)
+	// Audit log routes — CapAuditRead. The capability matrix (#217) grants
+	// audit:read to every read-capable role (admin/operator/viewer/+legacy user):
+	// in a CMDB/monitoring tool a read-only stakeholder seeing the "who changed
+	// what when" trail is reasonable transparency (cf. NetBox change-logs). This
+	// widens the prior admin-only read to viewer+; if a future deployment needs
+	// stricter audit visibility, gate on CapAuditManage (admin-only) instead.
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapAuditRead))
 		r.Get("/api/v1/audit-logs", auditHandler.List)
 		r.Get("/api/v1/audit-logs/facets", auditHandler.Facets)
 		r.Get("/api/v1/audit-logs/export", exportHandler.ExportAuditLogs)
@@ -670,7 +681,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/{systemId}", deviceSystemHandler.Get)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapDeviceWrite))
 			r.Post("/", deviceSystemHandler.Create)
 			r.Put("/{systemId}", deviceSystemHandler.Update)
 			r.Delete("/{systemId}", deviceSystemHandler.Delete)
@@ -730,7 +741,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/{id}/download", docHandler.Download)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapDocumentWrite))
 			r.Post("/", docHandler.CreateURL)
 			r.Post("/upload", docHandler.UploadFile)
 			r.Put("/{id}", docHandler.Update)
@@ -749,14 +760,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/", heartbeatHandler.ListConfigs)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapHeartbeatManage))
 			r.Post("/", heartbeatHandler.CreateConfig)
 		})
 	})
 
 	// Heartbeat config CRUD
 	r.Route("/api/v1/heartbeat-configs", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapHeartbeatManage))
 		r.Put("/{id}", heartbeatHandler.UpdateConfig)
 		r.Delete("/{id}", heartbeatHandler.DeleteConfig)
 	})
@@ -786,7 +797,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/query_range", dashHandler.QueryRange)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapDashboardManage))
 			r.Post("/configs", dashHandler.CreateConfig)
 			r.Put("/configs/{id}", dashHandler.UpdateConfig)
 			r.Delete("/configs/{id}", dashHandler.DeleteConfig)
@@ -801,7 +812,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Get("/", linkHandler.GetDeviceDocuments)
 		})
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAdmin)
+			r.Use(middleware.RequireCapability(domain.CapDocumentWrite))
 			r.Post("/", linkHandler.LinkDocument)
 			r.Delete("/{docId}", linkHandler.UnlinkDocument)
 		})
@@ -824,9 +835,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	ruleEngine := notification.NewRuleEngine(scanQueries, changeWatcher, notificationDispatcher, slog.Default())
 	ruleEngine.Start(context.Background())
 
-	// Notification channel routes (admin only)
+	// Notification channel routes — CapNotificationManage (admin-only
+	// capability). Channels carry webhook URLs / tokens, so even the masked
+	// read stays admin-only.
 	r.Route("/api/v1/notification/channels", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapNotificationManage))
 		r.Post("/", notificationHandler.CreateChannel)
 		r.Get("/", notificationHandler.ListChannels)
 		r.Get("/{id}", notificationHandler.GetChannel)
@@ -836,9 +849,10 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Post("/{id}/test", notificationHandler.TestChannel)
 	})
 
-	// Notification rule routes (admin only — rules are config, like channels).
+	// Notification rule routes — CapNotificationManage (rules are config, like
+	// channels).
 	r.Route("/api/v1/notification/rules", func(r chi.Router) {
-		r.Use(middleware.RequireAdmin)
+		r.Use(middleware.RequireCapability(domain.CapNotificationManage))
 		r.Post("/", notificationHandler.CreateRule)
 		r.Get("/", notificationHandler.ListRules)
 		r.Get("/{id}", notificationHandler.GetRule)


### PR DESCRIPTION
## 背景
`internal/domain/capability.go` 已定义完整角色→能力矩阵（admin/operator/viewer(+legacy user)），但 Phase 1b 只接入了 `/scanner` 路由。其余 **20 处 blanket `RequireAdmin`**（`routes.go` 19 处 + `handler/user.go` 的 `auth/register` 1 处）仍是一刀切 admin 闸门 → `device:write` / `heartbeat:manage` / `document:write` / `audit:read` 等能力一直处于**休眠**状态。

本 PR（Phase 1c，RFC 的 PR-B）把这 20 处全部改用 `RequireCapability(...)`，让矩阵成为访问控制的单一事实来源。**Phase 1 至此收口**。Phase 2（对象级 network scope，待「无授权默认可见性」决策）+ Phase 3（grants 管理 UI）独立推进，不在本 PR。

## 映射表（行为变化最小化）

| 能力 | 路由 | 行为变化 |
|---|---|---|
| `CapDeviceWrite` | devices CRUD + device-systems CRUD | **operator 新增可写** ✅ |
| `CapDocumentWrite` | documents CRUD + device↔document 链接 | **operator 新增** ✅ |
| `CapHeartbeatManage` | heartbeat config create/update/delete | **operator 新增** ✅ |
| `CapAuditRead` | audit-logs (list/facets/export) | ⚠️ **viewer+ 新增可读**（矩阵 #217 已授权；CMDB 工具只读用户看变更审计属合理透明度，与 NetBox 一致） |
| `CapNetworkManage` | networks CUD | 无变化（admin-only 能力） |
| `CapCredManage` | snmp + ssh credentials 全 CRUD | 无变化（凭据含密） |
| `CapUserManage` | users + `auth/register` | 无变化 |
| `CapAgentManage` | agent tokens + commands + commands/all | 无变化 |
| `CapDashboardManage` | dashboard configs CUD | 无变化 |
| `CapNotificationManage` | notification channels + rules 全 CRUD | 无变化（渠道含 webhook 密钥） |

operator 可写的几项是矩阵**早已明确授权**（#217）的，只是路由没接入 —— 与 Phase 1b 的 `scanner/add-devices`(`CapDeviceWrite`) 一致。

## 不改的（明确排除）
- **自助/按用户**：`profile` / `password` / `2fa` / `notification/logs`（每用户铃铛）—— 保持 `RequireAuth`。
- **机器认证**：`RequireAgentToken` —— 与用户 RBAC 正交。
- **公开**：`/health`、`/metrics`、`/sd`、`login`、`logout`、`2fa/verify`。
- **RequireAuth 共享读取面 → CapXxxRead 统一化**（devices/changes/topology 等）：本 PR 不做（对现有角色零行为变化，留作后续小 PR 或随 Phase 2 一起）。

改后 `RequireAdmin` **零调用点**（仅保留 `rbac.go` 的函数定义 + 文档注释，不删除）。

## 测试
新增 `internal/api/routes/capability_boundary_test.go`（真实 `NewRouter`，复用既有 `newTestConfig`/`newTestDB`/`tokenForRole`）：
- `TestRoutes_CapabilityBoundary`：每个能力层级取一条代表路由，对 admin/operator/viewer/user/anon 全跑（**80 例**）。anon→401、缺能力→403、有能力→非 401/403。
- `TestRoutes_RequireAuthReadsRemainOpen`：14 例回归守护，确认 viewer 仍可读共享读取面（未被误收紧）。
- `scanner_rbac_test.go` 保留（scanner 层级覆盖，轻度重叠可接受）。

## 验证
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` 全绿
- [x] `gofmt -l` / `goimports -l` 空（CI 严闸）
- [x] grep 确认 `RequireAdmin` 仅剩 `rbac.go` 定义
- 纯后端（路由+测试），无需浏览器测试

## ⚠️ Reviewer 注意
`audit-logs` 从 admin-only 放宽到 viewer+（`CapAuditRead`）。这是本 PR 唯一非写操作的权限放宽，已在路由注释显著标注。若认为审计日志不应对 viewer 可见，把 `CapAuditRead` 改回 `CapAuditManage`（admin-only）即可，一行之差。