### PR TITLE
feat(rbac): 共享读取面 RequireAuth→CapXxxRead 统一化（#138 read-uniformity）

### DIFF
--- a/internal/api/routes/capability_boundary_test.go
+++ b/internal/api/routes/capability_boundary_test.go
@@ -74,10 +74,21 @@ func TestRoutes_CapabilityBoundary(t *testing.T) {
 	})
 
 	routes := []capabilityRoute{
-		// --- read tier: CapAuditRead. audit-logs moved off RequireAdmin to
-		// CapAuditRead, which the matrix grants to viewer+ — the one read this
-		// PR opens to non-admins. (Other inventory reads stay RequireAuth and
-		// are covered by TestRoutes_RequireAuthReadsRemainOpen below.) ---
+		// --- read tier: every read capability (granted to viewer+). Phase 1c
+		// opened audit-logs to viewer+; this PR (read-uniformity) gates the rest
+		// of the shared inventory read surface on its CapXxxRead capability too
+		// (previously RequireAuth). All authenticated roles hold the read caps, so
+		// every role passes; anon → 401. A future role lacking a read cap would be
+		// denied — fail-closed by capability. ---
+		{"device-read", http.MethodGet, "/api/v1/devices", levelRead},
+		{"network-read", http.MethodGet, "/api/v1/networks", levelRead},
+		{"config-read", http.MethodGet, "/api/v1/devices/1/configs", levelRead},
+		{"changes-read", http.MethodGet, "/api/v1/changes", levelRead},
+		{"topology-read", http.MethodGet, "/api/v1/topology", levelRead},
+		{"discovery-read", http.MethodGet, "/api/v1/discovery/status", levelRead},
+		{"heartbeat-read", http.MethodGet, "/api/v1/devices/1/heartbeat-results", levelRead},
+		{"document-read", http.MethodGet, "/api/v1/documents", levelRead},
+		{"dashboard-read", http.MethodGet, "/api/v1/dashboard/overview", levelRead},
 		{"audit-read", http.MethodGet, "/api/v1/audit-logs", levelRead},
 
 		// --- operator write tier (CapDeviceWrite / CapHeartbeatManage /
@@ -135,12 +146,14 @@ func TestRoutes_CapabilityBoundary(t *testing.T) {
 	}
 }
 
-// TestRoutes_RequireAuthReadsRemainOpen is a regression guard: the shared
-// inventory read surface stays RequireAuth (NOT capability-gated) in this PR,
-// so every authenticated role — including viewer — must still read it. This
-// catches an accidental tightening where a read route is mis-remapped to an
-// admin/operator capability.
-func TestRoutes_RequireAuthReadsRemainOpen(t *testing.T) {
+// TestRoutes_SelfServiceRoutesAreRequireAuth guards the routes that are
+// INTENTIONALLY left on RequireAuth (not capability-gated): self-service /
+// per-user surfaces — own profile, own per-user notification log bell. Any
+// authenticated user reaches these regardless of their role's capability set,
+// because they operate on the caller's own identity/state. This catches an
+// accidental mis-remap that would, say, gate a user's own profile behind an
+// admin capability.
+func TestRoutes_SelfServiceRoutesAreRequireAuth(t *testing.T) {
 	cfg := newTestConfig()
 	db := newTestDB(t)
 	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
@@ -150,18 +163,14 @@ func TestRoutes_RequireAuthReadsRemainOpen(t *testing.T) {
 		shutdown()
 	})
 
-	reads := []capabilityRoute{
-		{"devices", http.MethodGet, "/api/v1/devices", levelRead},
-		{"networks", http.MethodGet, "/api/v1/networks", levelRead},
-		{"changes", http.MethodGet, "/api/v1/changes", levelRead},
-		{"topology", http.MethodGet, "/api/v1/topology", levelRead},
-		{"dashboard-overview", http.MethodGet, "/api/v1/dashboard/overview", levelRead},
-		{"device-configs", http.MethodGet, "/api/v1/devices/1/configs", levelRead},
-		{"heartbeat-results", http.MethodGet, "/api/v1/devices/1/heartbeat-results", levelRead},
+	// viewer (least-privileged authenticated role) must reach each self-service
+	// route (status anything but 401/403); anon must get 401.
+	selfService := []capabilityRoute{
+		{"profile", http.MethodGet, "/api/v1/auth/profile", levelRead},
+		{"notification-logs", http.MethodGet, "/api/v1/notification/logs", levelRead},
 	}
 
-	for _, rt := range reads {
-		// viewer must pass (the guard's point); anon must still get 401.
+	for _, rt := range selfService {
 		t.Run(rt.label+"/viewer", func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(rt.method, rt.path, nil)
@@ -169,7 +178,7 @@ func TestRoutes_RequireAuthReadsRemainOpen(t *testing.T) {
 			handler.ServeHTTP(rec, req)
 			require.NotEqual(t, http.StatusUnauthorized, rec.Code)
 			require.NotEqual(t, http.StatusForbidden, rec.Code,
-				"%s %s viewer must remain readable (RequireAuth)", rt.method, rt.path)
+				"%s %s viewer must reach self-service route (RequireAuth)", rt.method, rt.path)
 		})
 		t.Run(rt.label+"/anon", func(t *testing.T) {
 			rec := httptest.NewRecorder()

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -169,7 +169,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	deviceHandler := handler.NewDeviceHandler(deviceSvc)
 	r.Route("/api/v1/devices", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 			r.Get("/export", exportHandler.ExportDevices)
 			r.Get("/", deviceHandler.List)
 			r.Get("/stats", deviceHandler.GetStats)
@@ -195,7 +195,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// update/delete require CapNetworkManage (admin-only capability).
 	networkHandler := handler.NewNetworkHandler(scanQueries, dbConn)
 	r.Route("/api/v1/networks", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapNetworkRead))
 		r.Get("/", networkHandler.List)
 		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Post("/", networkHandler.Create)
 		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Put("/{id}", networkHandler.Update)
@@ -614,7 +614,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	changeLogHandler := handler.NewChangeLogHandler(scanQueries)
 	changeWatchHandler := handler.NewChangeWatchHandler(changeWatcher, slog.Default())
 	r.Route("/api/v1/changes", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapChangesRead))
 		r.Get("/", changeLogHandler.List)
 		r.Get("/watch", changeWatchHandler.Watch)
 	})
@@ -624,7 +624,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// which sources are active. Auth-gated (any logged-in user). Returns
 	// enabled=false when discovery is off or the service was never started.
 	r.Route("/api/v1/discovery", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapDiscoveryRead))
 		r.Get("/status", handler.DiscoveryStatusHandler(discSvcForStatus))
 	})
 
@@ -676,7 +676,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	deviceSystemHandler := handler.NewDeviceSystemHandler(deviceSystemSvc)
 	r.Route("/api/v1/devices/{id}/systems", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 			r.Get("/", deviceSystemHandler.ListByDevice)
 			r.Get("/{systemId}", deviceSystemHandler.Get)
 		})
@@ -688,36 +688,36 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		})
 	})
 
-	// Device L2 neighbors (Bridge-MIB / LLDP / CDP / ARP) — read-only, any
-	// logged-in user. Feeds the detail-page Neighbors panel.
+	// Device L2 neighbors (Bridge-MIB / LLDP / CDP / ARP) — read-only. Feeds
+	// the detail-page Neighbors panel.
 	r.Route("/api/v1/devices/{id}/neighbors", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 		r.Get("/", neighborHandler.ListByDevice)
 	})
 
-	// Device TLS certificates (https/ldaps/imaps/etc) — read-only, any logged-in
-	// user. Feeds the detail-page TLS Certificates sub-panel and the per-port
-	// certificate Modal (full chain + PEM).
+	// Device TLS certificates (https/ldaps/imaps/etc) — read-only. Feeds the
+	// detail-page TLS Certificates sub-panel and the per-port certificate Modal
+	// (full chain + PEM).
 	r.Route("/api/v1/devices/{id}/certificates", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 		r.Get("/", tlsCertHandler.ListByDevice)
 	})
 
-	// Device running-config history (#137, Oxidized/RANCID-style) — read-only,
-	// any logged-in user. The list omits config_text; the detail + diff views
-	// load it on demand. Registered before /{configId} so the static /diff
-	// segment wins over the param (chi prefers literal over wildcard).
+	// Device running-config history (#137, Oxidized/RANCID-style) — read-only.
+	// The list omits config_text; the detail + diff views load it on demand.
+	// Registered before /{configId} so the static /diff segment wins over the
+	// param (chi prefers literal over wildcard).
 	r.Route("/api/v1/devices/{id}/configs", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapConfigRead))
 		r.Get("/", deviceConfigHandler.List)
 		r.Get("/diff", deviceConfigHandler.Diff)
 		r.Get("/{configId}", deviceConfigHandler.Get)
 	})
 
 	// Network-level topology graph — all devices (nodes) + all neighbor edges.
-	// Read-only, any logged-in user. Feeds the /topology page.
+	// Read-only. Feeds the /topology page.
 	r.Route("/api/v1/topology", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapTopologyRead))
 		r.Get("/", topologyHandler.Graph)
 	})
 
@@ -735,7 +735,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	docHandler := handler.NewDocumentHandler(docSvc, uploadPath, auditRepo)
 	r.Route("/api/v1/documents", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapDocumentRead))
 			r.Get("/", docHandler.List)
 			r.Get("/{id}", docHandler.Get)
 			r.Get("/{id}/download", docHandler.Download)
@@ -756,7 +756,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Device heartbeat configs
 	r.Route("/api/v1/devices/{id}/heartbeat-configs", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 			r.Get("/", heartbeatHandler.ListConfigs)
 		})
 		r.Group(func(r chi.Router) {
@@ -774,14 +774,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Heartbeat results
 	r.Route("/api/v1/devices/{id}/heartbeat-results", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 		r.Get("/export", exportHandler.ExportHeartbeatResults)
 		r.Get("/", heartbeatHandler.ListResults)
 	})
 
 	// Heartbeat history and stats
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 		r.Get("/api/v1/devices/{id}/heartbeat-history", heartbeatHandler.ListHistory)
 		r.Get("/api/v1/devices/{id}/heartbeat-stats", heartbeatHandler.GetStats)
 	})
@@ -790,7 +790,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	dashHandler := handler.NewDashboardHandler(dashSvc)
 	r.Route("/api/v1/dashboard", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapDashboardRead))
 			r.Get("/configs", dashHandler.ListConfigs)
 			r.Get("/overview", dashHandler.Overview)
 			r.Get("/query", dashHandler.Query)
@@ -808,7 +808,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	linkHandler := handler.NewLinkHandler(dbConn, auditRepo)
 	r.Route("/api/v1/devices/{id}/documents", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.RequireAuth)
+			r.Use(middleware.RequireCapability(domain.CapDocumentRead))
 			r.Get("/", linkHandler.GetDeviceDocuments)
 		})
 		r.Group(func(r chi.Router) {
@@ -818,7 +818,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		})
 	})
 	r.Route("/api/v1/documents/{id}/devices", func(r chi.Router) {
-		r.Use(middleware.RequireAuth)
+		r.Use(middleware.RequireCapability(domain.CapDocumentRead))
 		r.Get("/", linkHandler.GetDocumentDevices)
 	})
 

--- a/internal/api/routes/scanner_integration_test.go
+++ b/internal/api/routes/scanner_integration_test.go
@@ -22,6 +22,16 @@ func newTestConfig() *config.Config {
 			MaxConcurrentHosts: 10,
 			RetentionDays:      7,
 		},
+		// Auth-gate / capability-boundary tests fire ~100+ requests per test
+		// function. The default global limiter (100/min, burst 100) would trip
+		// and return 429, which has nothing to do with what these tests assert
+		// (401/403 at the auth layer). Raise the user-facing limiters out of the
+		// way; rate-limit *behavior* is tested separately in middleware/ against
+		// its own isolated limiter.
+		RateLimit: config.RateLimitConfig{
+			GlobalPerMinute: 1_000_000,
+			LoginPerMinute:  1_000_000,
+		},
 	}
 }
 


### PR DESCRIPTION
## 背景
承接 PR #227（Phase 1c：写入面 RequireAdmin→RequireCapability）。本 PR 把**共享库存读取面**也统一到能力矩阵：`RequireAuth` → 对应的 `CapXxxRead`。

此前矩阵里 `device:read` / `network:read` / `changes:read` / `topology:read` / `heartbeat:read` / `document:read` / `dashboard:read` / `config:read` 等读取能力**已定义但未接线**（读取路由一直是 RequireAuth）。本 PR 让矩阵成为读+写访问控制的单一事实来源。

## 改动（routes.go）
读取组 `RequireAuth` → `RequireCapability(domain.CapXxxRead)`：
- `device:read` — devices 读取组 + device neighbors/certificates/systems(读)
- `network:read` — networks 列表
- `config:read` — device configs（list/diff/get）
- `changes:read` — changes（list/watch）
- `topology:read` — topology graph
- `discovery:read` — discovery status
- `heartbeat:read` — heartbeat-results/history/stats + heartbeat-configs 列表
- `document:read` — documents 读取 + device↔document 读取
- `dashboard:read` — dashboard 读取组
- （`audit:read` 已在 #227 接入）

## 不动（刻意保留 RequireAuth）
自助/按用户路由：`auth/profile`、`password`、`force-password`、`2fa/*`、`notification/logs`（每用户铃铛）——用户管自己的身份/通知，与角色能力无关。机器认证、公开路由不动。

## 行为影响
**对现有角色零变化**（admin/operator/viewer/legacy user 均持全部读取能力）。价值：
1. 矩阵成为访问控制单一事实来源；
2. 为 Phase 2（对象级 network scope）的读取过滤铺路；
3. 未来"缺读取能力的自定义角色"自动 fail-closed。

## 测试
- `capability_boundary_test.go`：扩展读取层（10 条代表路由 × 5 角色），全角色过、anon 401；原 `RequireAuthReadsRemainOpen` 重命名为 `SelfServiceRoutesAreRequireAuth`，锁定自助路由刻意保留 RequireAuth。
- `newTestConfig` 抬高 `GlobalPerMinute`/`LoginPerMinute`：默认 100/min 突发 100 会被 ~135 个 boundary 请求打爆返回 429，与断言的 401/403 无关（rate-limit 行为在 `middleware/` 独立测试，不受影响）。
- `go test ./...` 全绿；`gofmt`/`goimports`/`go vet` 干净。

## Stack
**Base: #227**（Phase 1c）。合并 #227 后本 PR 自动 retarget 到 main。