### PR TITLE
feat(rbac): 对象级 network scope 基础 + 设备域闭环（#138 Phase 2, closed-mode 预览）

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -54,6 +54,23 @@ center:
 security:
   master_key: ""
 
+rbac:
+  # Object-level network scope for non-admin roles (#138 Phase 2).
+  #   open  (default): a non-admin user sees every network (current behavior;
+  #                    network grants are recorded but not enforced).
+  #   closed          : a non-admin user sees only networks they hold a grant
+  #                    for (MSP / multi-tenant isolation). Admin always bypasses.
+  # PREVIEW (v1): "closed" currently scopes the device browse surface — the
+  # device LIST (GET /devices) and device detail + per-device sub-resources
+  # (GET/PUT/DELETE /devices/{id} and /devices/{id}/{neighbors,certificates,
+  # configs,systems,heartbeat-*,documents}) enforce the granted-network set.
+  # Topology, change log, dashboard, device stats/export, and scanner
+  # results/runs/tasks are NOT yet network-scoped (#138 Phase 2b — the scanner
+  # tables also lack a network_id column) and remain visible across networks
+  # until then. Do not enable "closed" for strict multi-tenant isolation until
+  # 2b lands; "open" is fully safe (no behavior change).
+  scope_default: "open"
+
 auth:
   jwt_secret: "change-me-in-production"  # REQUIRED — must change, minimum 32 characters
   token_expiry: "24h"

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -688,3 +688,21 @@ CREATE TABLE IF NOT EXISTS ssh_credentials (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- user_network_grants: object-level network scope for non-admin roles (#138
+-- Phase 2). A grant lets a user see/operate the devices of a given network.
+-- admin bypasses scope entirely (sees all networks); a non-admin user's
+-- effective scope is the set of network_ids they hold a grant for. The scope
+-- mode (open/closed) is config-driven (rbac.scope_default): in "open" (default)
+-- a non-admin with NO grants still sees everything (preserves single-team
+-- deployments); in "closed" a non-admin sees only granted networks (MSP /
+-- multi-tenant). UNIQUE(user_id, network_id) makes a grant idempotent.
+CREATE TABLE IF NOT EXISTS user_network_grants (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    network_id INTEGER NOT NULL REFERENCES networks(id) ON DELETE CASCADE,
+    granted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, network_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_network_grants_user ON user_network_grants(user_id);
+

--- a/internal/api/handler/device.go
+++ b/internal/api/handler/device.go
@@ -129,6 +129,12 @@ func (h *DeviceHandler) List(w http.ResponseWriter, r *http.Request) {
 			filter.NetworkID = &id
 		}
 	}
+	// Object-level network scope (#138 Phase 2): a restricted caller only sees
+	// their granted networks. Applied in addition to any explicit network_id.
+	if scope := domain.ScopeFromContext(r.Context()); !scope.IsGlobal() {
+		filter.ScopeRestricted = true
+		filter.ScopeNetworkIDs = scope.NetworkIDs
+	}
 
 	resp, err := h.svc.List(r.Context(), filter)
 	if err != nil {

--- a/internal/api/middleware/scope.go
+++ b/internal/api/middleware/scope.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package middleware
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"mibee-steward/internal/authz/scoperesolver"
+	"mibee-steward/internal/domain"
+)
+
+// NetworkScope resolves the authenticated user's object-level network scope and
+// injects it into the request context (domain.ContextKeyUserScope) for the
+// inventory query paths and ValidateDeviceScope (#138 Phase 2).
+//
+// It wraps Authenticator (house style — cf. RequireCapability) so it works in
+// any middleware position. On an unauthenticated request (no user in context)
+// it simply forwards without injecting a scope; the downstream RequireCapability
+// gate will 401. Admin and open-mode resolve to a Global scope; closed-mode
+// non-admin resolves to the granted network set (resolver caches + fails open).
+func NetworkScope(resolver *scoperesolver.Resolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return Authenticator(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID, role, ok := GetUserFromContext(r)
+			if !ok {
+				next.ServeHTTP(w, r) // no user → let the auth gate 401
+				return
+			}
+			scope := resolver.Resolve(r.Context(), userID, domain.UserRole(role))
+			ctx := context.WithValue(r.Context(), domain.ContextKeyUserScope, scope)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		}))
+	}
+}
+
+// ValidateDeviceScope gates any /devices/{id} route (and its sub-resources:
+// neighbors, certificates, configs, systems, heartbeat, documents) on the
+// caller's network scope. A Global scope (admin / open mode) always passes. A
+// restricted scope passes only if the device's network_id is in the allowed
+// set; otherwise 403. A missing or malformed id is forwarded to the handler
+// (which renders its own 404/400) so this middleware never masks handler errors.
+//
+// Must run AFTER NetworkScope (so the scope is in context). Place it via
+// r.Use on every /devices/{id}… route group; a nil db disables the check.
+func ValidateDeviceScope(db *sql.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			scope := domain.ScopeFromContext(r.Context())
+			if scope.IsGlobal() {
+				next.ServeHTTP(w, r)
+				return
+			}
+			idStr := chi.URLParam(r, "id")
+			id, err := strconv.ParseInt(idStr, 10, 64)
+			if err != nil {
+				next.ServeHTTP(w, r) // malformed id → handler 404/400
+				return
+			}
+			var networkID sql.NullInt64
+			err = db.QueryRowContext(r.Context(),
+				`SELECT network_id FROM devices WHERE id = ?`, id).Scan(&networkID)
+			if err != nil {
+				next.ServeHTTP(w, r) // not found / error → handler 404
+				return
+			}
+			// A device with no assigned network is visible to no restricted scope.
+			if !networkID.Valid || !scope.AllowsNetwork(networkID.Int64) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"forbidden: device out of network scope"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -24,6 +24,7 @@ import (
 
 	"mibee-steward/internal/api/handler"
 	"mibee-steward/internal/api/middleware"
+	"mibee-steward/internal/authz/scoperesolver"
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/crypto"
@@ -163,6 +164,12 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// heartbeat.db after the time-series split; the main DB's copy is stale).
 	exportHandler := handler.NewExportHandler(service.NewExportService(db.New(dbConn), hbStore.Queries()))
 
+	// Object-level network scope resolver (#138 Phase 2). Resolves a user's
+	// granted network set (closed mode) or Global (admin / open mode). Consumed
+	// by NetworkScope (injects scope into context) and the device/topology/
+	// changes query paths.
+	scopeResolver := scoperesolver.New(dbConn, domain.ScopeMode(cfg.RBAC.ScopeDefault))
+
 	// Device routes
 	deviceRepo := service.NewDeviceRepository(dbConn)
 	deviceSvc := service.NewDeviceService(deviceRepo, heartbeatSvc)
@@ -170,16 +177,18 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	r.Route("/api/v1/devices", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapDeviceRead))
+			r.Use(middleware.NetworkScope(scopeResolver))
 			r.Get("/export", exportHandler.ExportDevices)
 			r.Get("/", deviceHandler.List)
 			r.Get("/stats", deviceHandler.GetStats)
-			r.Get("/{id}", deviceHandler.Get)
+			r.With(middleware.ValidateDeviceScope(dbConn)).Get("/{id}", deviceHandler.Get)
 		})
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapDeviceWrite))
+			r.Use(middleware.NetworkScope(scopeResolver))
 			r.Post("/", deviceHandler.Create)
-			r.Put("/{id}", deviceHandler.Update)
-			r.Delete("/{id}", deviceHandler.Delete)
+			r.With(middleware.ValidateDeviceScope(dbConn)).Put("/{id}", deviceHandler.Update)
+			r.With(middleware.ValidateDeviceScope(dbConn)).Delete("/{id}", deviceHandler.Delete)
 			r.Post("/batch-delete", batchHandler.BatchDeleteDevices)
 			r.Post("/batch-update-status", batchHandler.BatchUpdateDeviceStatus)
 		})
@@ -675,6 +684,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	deviceSystemSvc := service.NewDeviceSystemService(deviceSystemRepo)
 	deviceSystemHandler := handler.NewDeviceSystemHandler(deviceSystemSvc)
 	r.Route("/api/v1/devices/{id}/systems", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 			r.Get("/", deviceSystemHandler.ListByDevice)
@@ -691,6 +702,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Device L2 neighbors (Bridge-MIB / LLDP / CDP / ARP) — read-only. Feeds
 	// the detail-page Neighbors panel.
 	r.Route("/api/v1/devices/{id}/neighbors", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 		r.Get("/", neighborHandler.ListByDevice)
 	})
@@ -699,6 +712,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// detail-page TLS Certificates sub-panel and the per-port certificate Modal
 	// (full chain + PEM).
 	r.Route("/api/v1/devices/{id}/certificates", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Use(middleware.RequireCapability(domain.CapDeviceRead))
 		r.Get("/", tlsCertHandler.ListByDevice)
 	})
@@ -708,6 +723,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Registered before /{configId} so the static /diff segment wins over the
 	// param (chi prefers literal over wildcard).
 	r.Route("/api/v1/devices/{id}/configs", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Use(middleware.RequireCapability(domain.CapConfigRead))
 		r.Get("/", deviceConfigHandler.List)
 		r.Get("/diff", deviceConfigHandler.Diff)
@@ -755,6 +772,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Device heartbeat configs
 	r.Route("/api/v1/devices/{id}/heartbeat-configs", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 			r.Get("/", heartbeatHandler.ListConfigs)
@@ -774,6 +793,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Heartbeat results
 	r.Route("/api/v1/devices/{id}/heartbeat-results", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 		r.Get("/export", exportHandler.ExportHeartbeatResults)
 		r.Get("/", heartbeatHandler.ListResults)
@@ -781,6 +802,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 
 	// Heartbeat history and stats
 	r.Group(func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Use(middleware.RequireCapability(domain.CapHeartbeatRead))
 		r.Get("/api/v1/devices/{id}/heartbeat-history", heartbeatHandler.ListHistory)
 		r.Get("/api/v1/devices/{id}/heartbeat-stats", heartbeatHandler.GetStats)
@@ -807,6 +830,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Device-Document linking routes
 	linkHandler := handler.NewLinkHandler(dbConn, auditRepo)
 	r.Route("/api/v1/devices/{id}/documents", func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.ValidateDeviceScope(dbConn))
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapDocumentRead))
 			r.Get("/", linkHandler.GetDeviceDocuments)

--- a/internal/api/routes/scanner_integration_test.go
+++ b/internal/api/routes/scanner_integration_test.go
@@ -8,6 +8,8 @@ import (
 	_ "modernc.org/sqlite"
 
 	"mibee-steward/internal/config"
+
+	dbsql "mibee-steward/db"
 )
 
 func newTestConfig() *config.Config {
@@ -41,199 +43,25 @@ func newTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("failed to open in-memory db: %v", err)
 	}
+	// modernc's ":memory:" gives each connection its OWN private in-memory DB.
+	// NewRouter spawns background goroutines (scheduler/heartbeat/cleanup) that
+	// open separate connections, and the request handlers draw from the same
+	// pool — so a per-test seed created on one connection would be invisible on
+	// another. Pin the pool to a single connection so the seed, schema, and all
+	// queries share one in-memory DB. (modernc serializes access; busy_timeout
+	// keeps the short-lived background queries from blocking tests.)
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { db.Close() })
 
-	// Apply schema
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS devices (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			device_uuid TEXT NOT NULL DEFAULT '',
-			name TEXT NOT NULL,
-			ip_address TEXT,
-			type TEXT DEFAULT 'unknown',
-			brand TEXT DEFAULT '',
-			model TEXT DEFAULT '',
-			location TEXT DEFAULT '',
-			purpose TEXT DEFAULT '',
-			description TEXT DEFAULT '',
-			status TEXT DEFAULT 'unknown',
-			mac_address TEXT DEFAULT '',
-			serial_number TEXT DEFAULT '',
-			purchase_date TEXT DEFAULT '',
-			warranty_expiry TEXT DEFAULT '',
-			tags TEXT DEFAULT '',
-			network_id INTEGER,
-			first_seen TIMESTAMP,
-			last_seen TIMESTAMP,
-			offline_since TIMESTAMP,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
-		CREATE TABLE IF NOT EXISTS scan_tasks (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL,
-			targets TEXT NOT NULL,
-			cron_expr TEXT DEFAULT '',
-			pipeline_config TEXT DEFAULT '{}',
-			global_labels TEXT DEFAULT '',
-			timeout INTEGER DEFAULT 300,
-			concurrent_hosts INTEGER DEFAULT 50,
-			enabled INTEGER DEFAULT 1,
-			last_run_status TEXT DEFAULT '',
-			last_run_at TIMESTAMP DEFAULT NULL,
-			next_run_at TIMESTAMP DEFAULT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
-		CREATE TABLE IF NOT EXISTS scan_task_runs (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			task_id INTEGER NOT NULL,
-			status TEXT DEFAULT 'running',
-			total_hosts INTEGER DEFAULT 0,
-			alive_hosts INTEGER DEFAULT 0,
-			new_hosts INTEGER DEFAULT 0,
-			updated_hosts INTEGER DEFAULT 0,
-			duration_ms INTEGER DEFAULT 0,
-			error_message TEXT DEFAULT '',
-			started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			finished_at TIMESTAMP DEFAULT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (task_id) REFERENCES scan_tasks(id)
-		);
-		CREATE TABLE IF NOT EXISTS scan_results (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			task_id INTEGER NOT NULL,
-			run_id INTEGER DEFAULT NULL,
-			ip TEXT NOT NULL,
-			alive INTEGER DEFAULT 0,
-			rtt_ms INTEGER DEFAULT 0,
-			ports TEXT DEFAULT '[]',
-			services TEXT DEFAULT '{}',
-			snmp_data TEXT DEFAULT '{}',
-			prometheus_detected INTEGER DEFAULT 0,
-			prometheus_url TEXT DEFAULT '',
-			node_exporter_detected INTEGER DEFAULT 0,
-			node_exporter_url TEXT DEFAULT '',
-			node_exporter_data TEXT DEFAULT '',
-			scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (task_id) REFERENCES scan_tasks(id),
-			FOREIGN KEY (run_id) REFERENCES scan_task_runs(id)
-		);
-		CREATE TABLE IF NOT EXISTS users (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			username TEXT NOT NULL UNIQUE,
-			email TEXT NOT NULL UNIQUE,
-			password_hash TEXT NOT NULL,
-			role TEXT DEFAULT 'user',
-			must_change_password INTEGER DEFAULT 0,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
-		CREATE TABLE IF NOT EXISTS audit_logs (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			user_id INTEGER,
-			action TEXT NOT NULL,
-			resource_type TEXT DEFAULT '',
-			resource_id INTEGER DEFAULT 0,
-			details TEXT DEFAULT '',
-			ip_address TEXT DEFAULT '',
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (user_id) REFERENCES users(id)
-		);
-		CREATE TABLE IF NOT EXISTS device_systems (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			device_id INTEGER NOT NULL,
-			name TEXT NOT NULL,
-			system_type TEXT DEFAULT 'other',
-			entry_url TEXT DEFAULT '',
-			description TEXT DEFAULT '',
-			FOREIGN KEY (device_id) REFERENCES devices(id)
-		);
-		CREATE TABLE IF NOT EXISTS documents (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL,
-			type TEXT DEFAULT 'file',
-			content TEXT DEFAULT '',
-			device_id INTEGER DEFAULT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (device_id) REFERENCES devices(id)
-		);
-		CREATE TABLE IF NOT EXISTS device_documents (
-			device_id INTEGER NOT NULL,
-			document_id INTEGER NOT NULL,
-			PRIMARY KEY (device_id, document_id),
-			FOREIGN KEY (device_id) REFERENCES devices(id),
-			FOREIGN KEY (document_id) REFERENCES documents(id)
-		);
-		CREATE TABLE IF NOT EXISTS heartbeat_configs (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			device_id INTEGER NOT NULL UNIQUE,
-			interval_seconds INTEGER DEFAULT 60,
-			method TEXT DEFAULT 'icmp',
-			timeout INTEGER DEFAULT 5,
-			port INTEGER DEFAULT 0,
-			enabled INTEGER DEFAULT 1,
-			failure_threshold INTEGER DEFAULT 3,
-			community TEXT DEFAULT 'public',
-			oid TEXT DEFAULT '1.3.6.1.2.1.1.0',
-			url TEXT DEFAULT '',
-			expected_status INTEGER DEFAULT 200,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (device_id) REFERENCES devices(id)
-		);
-		CREATE TABLE IF NOT EXISTS heartbeat_results (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			config_id INTEGER NOT NULL,
-			device_id INTEGER NOT NULL,
-			status TEXT DEFAULT 'unknown',
-			latency_ms INTEGER DEFAULT 0,
-			error_message TEXT DEFAULT '',
-			checked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (config_id) REFERENCES heartbeat_configs(id),
-			FOREIGN KEY (device_id) REFERENCES devices(id)
-		);
-		CREATE TABLE IF NOT EXISTS notification_channels (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL,
-			type TEXT NOT NULL,
-			config TEXT DEFAULT '{}',
-			enabled INTEGER DEFAULT 1,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
-		CREATE TABLE IF NOT EXISTS alert_rules (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL,
-			channel_id INTEGER NOT NULL,
-			condition TEXT DEFAULT '{}',
-			enabled INTEGER DEFAULT 1,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (channel_id) REFERENCES notification_channels(id)
-		);
-		CREATE TABLE IF NOT EXISTS notification_logs (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			channel_id INTEGER,
-			rule_id INTEGER,
-			device_id INTEGER,
-			status TEXT DEFAULT '',
-			message TEXT DEFAULT '',
-			error TEXT DEFAULT '',
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			FOREIGN KEY (channel_id) REFERENCES notification_channels(id),
-			FOREIGN KEY (rule_id) REFERENCES alert_rules(id),
-			FOREIGN KEY (device_id) REFERENCES devices(id)
-		);
-		CREATE TABLE IF NOT EXISTS dashboard_configs (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL UNIQUE,
-			config TEXT NOT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
-	`)
+	// Apply the production schema (db/schema.sql, embedded). The earlier
+	// hand-maintained inline schema drifted from the real devices table
+	// (missing scan_source/scan_attributes/... columns the list query
+	// SELECTs), which broke any test that exercised GET /devices for
+	// real. Using the canonical schema keeps the test DB in lockstep with
+	// production (all tables/columns, CREATE TABLE IF NOT EXISTS).
+	if _, err = db.Exec(dbsql.SchemaSQL); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}

--- a/internal/api/routes/scope_isolation_test.go
+++ b/internal/api/routes/scope_isolation_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package routes
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/jwtauth/v5"
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/config"
+	"mibee-steward/internal/domain"
+)
+
+// tokenForUser signs a JWT carrying a specific user_id + role (tokenForRole in
+// scanner_rbac_test.go pins user_id=1; the scope tests need user_id=2 for the
+// seeded admin).
+func tokenForUser(t *testing.T, secret string, userID int64, role string) string {
+	t.Helper()
+	auth := jwtauth.New("HS256", []byte(secret), nil)
+	_, token, err := auth.Encode(map[string]any{"user_id": float64(userID), "role": role})
+	require.NoError(t, err)
+	return token
+}
+
+// These tests pin object-level network scope (#138 Phase 2): in closed mode a
+// non-admin user sees only the devices on networks they hold a grant for
+// (device list filtered; device detail/sub-resources 403 out of scope), while
+// admin and open mode are unrestricted. They exercise the REAL NewRouter with a
+// closed-mode config and a seeded grant.
+
+// scopeTestDB seeds two networks, a device on each, a viewer user, and (when
+// granted) a grant for network 1 only.
+func scopeTestDB(t *testing.T, grantNetwork1 bool) *sql.DB {
+	t.Helper()
+	db := newTestDB(t)
+	_, err := db.Exec(`
+		INSERT INTO networks (id, name, cidr) VALUES (1, 'lan-1', '10.0.1.0/24'), (2, 'lan-2', '10.0.2.0/24');
+		INSERT INTO devices (id, name, ip_address, type, status, network_id) VALUES
+			(10, 'dev-in-net1', '10.0.1.5', 'pc', 'online', 1),
+			(20, 'dev-in-net2', '10.0.2.5', 'pc', 'online', 2);
+		INSERT INTO users (id, username, email, password_hash, role) VALUES
+			(1, 'viewer1', 'v1@example.com', 'x', 'viewer'),
+			(2, 'admin1', 'a1@example.com', 'x', 'admin');
+	`)
+	require.NoError(t, err)
+	if grantNetwork1 {
+		_, err = db.Exec(`INSERT INTO user_network_grants (user_id, network_id) VALUES (1, 1)`)
+		require.NoError(t, err)
+	}
+	return db
+}
+
+func closedTestConfig() *config.Config {
+	cfg := newTestConfig()
+	cfg.RBAC.ScopeDefault = string(domain.ScopeModeClosed)
+	return cfg
+}
+
+type deviceListJSON struct {
+	Devices []struct {
+		ID        int64  `json:"id"`
+		NetworkID *int64 `json:"network_id"`
+	} `json:"devices"`
+	Total int `json:"total"`
+}
+
+// TestScope_ClosedMode_ViewerSeesOnlyGrantedNetwork: a viewer granted network 1
+// lists only network-1 devices and is 403'd on a network-2 device.
+func TestScope_ClosedMode_ViewerSeesOnlyGrantedNetwork(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, true)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	tok := tokenForRole(t, cfg.Auth.JWTSecret, "viewer") // user_id=1, role=viewer
+
+	// List: only the network-1 device (id 10) should appear.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equalf(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+
+	var body deviceListJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 1, body.Total, "scoped viewer should see exactly 1 device (network 1)")
+	require.Len(t, body.Devices, 1)
+	require.Equal(t, int64(10), body.Devices[0].ID)
+
+	// In-scope device detail: passes the gate (handler then 200s).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/devices/10", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.NotEqual(t, http.StatusForbidden, rec.Code)
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code)
+
+	// Out-of-scope device detail: 403.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/devices/20", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code, "scoped viewer must be 403 on network-2 device")
+
+	// Out-of-scope sub-resource: also 403 (ValidateDeviceScope covers sub-resources).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/devices/20/neighbors", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code, "scoped viewer must be 403 on network-2 sub-resource")
+}
+
+// TestScope_ClosedMode_ViewerWithNoGrantsSeesNothing: closed mode + no grants →
+// the device list is empty (fail-closed, not fail-open).
+func TestScope_ClosedMode_ViewerWithNoGrantsSeesNothing(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, false) // no grants
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	tok := tokenForRole(t, cfg.Auth.JWTSecret, "viewer")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body deviceListJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 0, body.Total, "closed-mode viewer with no grants sees no devices")
+}
+
+// TestScope_AdminBypassesScope: even in closed mode, admin sees every device.
+func TestScope_AdminBypassesScope(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, true)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	// admin1 is user_id=2 in the seed.
+	tok := tokenForUser(t, cfg.Auth.JWTSecret, 2, "admin")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body deviceListJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 2, body.Total, "admin bypasses scope — sees both networks' devices")
+}
+
+// TestScope_OpenMode_ViewerSeesEverything: open mode (default) ignores grants —
+// a viewer sees all devices regardless of grants. Backward-compatible default.
+func TestScope_OpenMode_ViewerSeesEverything(t *testing.T) {
+	cfg := newTestConfig() // open mode (default)
+	cfg.RBAC.ScopeDefault = string(domain.ScopeModeOpen)
+	db := scopeTestDB(t, false)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	tok := tokenForRole(t, cfg.Auth.JWTSecret, "viewer")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body deviceListJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 2, body.Total, "open mode: viewer sees all devices")
+}

--- a/internal/authz/scoperesolver/resolver.go
+++ b/internal/authz/scoperesolver/resolver.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package scoperesolver
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"mibee-steward/internal/domain"
+)
+
+const cacheTTL = 30 * time.Second
+
+// Resolver caches each user's granted network_ids for cacheTTL, then re-reads.
+// It resolves a (userID, role) pair to a domain.Scope:
+//   - admin role → Global (bypasses scope),
+//   - open mode → Global (non-admin sees everything; default, no behavior change),
+//   - closed mode + non-admin → Restricted(granted network_ids); no grants → empty
+//     (sees nothing).
+//
+// A nil *Resolver resolves to Global everywhere (scope disabled / not wired).
+type Resolver struct {
+	db    *sql.DB
+	mode  domain.ScopeMode
+	cache map[int64]cacheEntry
+	mu    sync.Mutex
+}
+
+type cacheEntry struct {
+	ids []int64
+	at  time.Time
+}
+
+// New constructs a resolver. mode is the canonical rbac.scope_default
+// (domain.ScopeModeOpen / ScopeModeClosed).
+func New(db *sql.DB, mode domain.ScopeMode) *Resolver {
+	return &Resolver{db: db, mode: mode, cache: make(map[int64]cacheEntry)}
+}
+
+// Mode reports the configured scope mode.
+func (r *Resolver) Mode() domain.ScopeMode {
+	if r == nil {
+		return domain.ScopeModeOpen
+	}
+	return r.mode
+}
+
+// Resolve returns the effective network scope for a user. It never returns an
+// error: on DB failure it fails OPEN (Global) so a transient DB hiccup cannot
+// lock users out of inventory (fail-safe for availability; logged by caller if
+// needed). Admin and open-mode always short-circuit without touching the DB.
+func (r *Resolver) Resolve(ctx context.Context, userID int64, role domain.UserRole) domain.Scope {
+	if r == nil {
+		return domain.Scope{Global: true}
+	}
+	// Admin always bypasses object scope.
+	if role == domain.RoleAdmin {
+		return domain.Scope{Global: true}
+	}
+	// Open mode: no enforcement (default; preserves existing single-team installs).
+	if r.mode != domain.ScopeModeClosed {
+		return domain.Scope{Global: true}
+	}
+	// Closed mode + non-admin: restrict to granted networks.
+	ids, ok := r.cached(userID)
+	if !ok {
+		var err error
+		ids, err = NetworkIDsByUser(ctx, r.db, userID)
+		if err != nil {
+			// Fail open on DB error (availability over strictness); cache nothing.
+			return domain.Scope{Global: true}
+		}
+		r.store(userID, ids)
+	}
+	return domain.Scope{Global: false, NetworkIDs: ids}
+}
+
+func (r *Resolver) cached(userID int64) ([]int64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.cache[userID]; ok && time.Since(e.at) < cacheTTL {
+		return e.ids, true
+	}
+	return nil, false
+}
+
+func (r *Resolver) store(userID int64, ids []int64) {
+	r.mu.Lock()
+	r.cache[userID] = cacheEntry{ids: ids, at: time.Now()}
+	r.mu.Unlock()
+}
+
+// Invalidate drops the cached scope for one user. The grants management handler
+// MUST call this after any create/delete affecting that user.
+func (r *Resolver) Invalidate(userID int64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	delete(r.cache, userID)
+	r.mu.Unlock()
+}
+
+// InvalidateAll drops every cached scope (e.g. on a scope-mode change or bulk
+// grant operation).
+func (r *Resolver) InvalidateAll() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.cache = make(map[int64]cacheEntry)
+	r.mu.Unlock()
+}

--- a/internal/authz/scoperesolver/store.go
+++ b/internal/authz/scoperesolver/store.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+// Package scoperesolver resolves a user's object-level network scope (#138
+// Phase 2): the set of network_ids a non-admin user is granted visibility into.
+// It is the read side of the user_network_grants table, with a short TTL cache
+// (mirrors internal/service/scannerv2/credresolver). Grants are stored as raw
+// SQL (not sqlc) for parity with the other credential-adjacent tables and to
+// avoid the sqlc version-drift regen.
+package scoperesolver
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is returned by Get when no row matches.
+var ErrNotFound = errors.New("network grant not found")
+
+// Grant is one user↔network row.
+type Grant struct {
+	ID        int64
+	UserID    int64
+	NetworkID int64
+	GrantedAt string
+}
+
+// ListByUser returns every grant for a user (the network_ids they may see).
+func ListByUser(ctx context.Context, db *sql.DB, userID int64) ([]Grant, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, network_id, granted_at
+		FROM user_network_grants
+		WHERE user_id = ?
+		ORDER BY network_id`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list network grants for user %d: %w", userID, err)
+	}
+	defer rows.Close()
+	var out []Grant
+	for rows.Next() {
+		var g Grant
+		if err := rows.Scan(&g.ID, &g.UserID, &g.NetworkID, &g.GrantedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+// NetworkIDsByUser returns just the granted network_ids for a user.
+func NetworkIDsByUser(ctx context.Context, db *sql.DB, userID int64) ([]int64, error) {
+	grants, err := ListByUser(ctx, db, userID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(grants))
+	for _, g := range grants {
+		ids = append(ids, g.NetworkID)
+	}
+	return ids, nil
+}
+
+// ListAll returns every grant, joined to usernames/network names for the admin
+// management surface (Phase 3). Paginated by limit/offset.
+type GrantDetail struct {
+	ID          int64
+	UserID      int64
+	Username    string
+	NetworkID   int64
+	NetworkName string
+	GrantedAt   string
+}
+
+func ListAll(ctx context.Context, db *sql.DB, limit, offset int) ([]GrantDetail, int, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var total int64
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM user_network_grants`).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT g.id, g.user_id, COALESCE(u.username, ''), g.network_id, COALESCE(n.name, ''), g.granted_at
+		FROM user_network_grants g
+		LEFT JOIN users u ON u.id = g.user_id
+		LEFT JOIN networks n ON n.id = g.network_id
+		ORDER BY u.username, n.name
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list all network grants: %w", err)
+	}
+	defer rows.Close()
+	var out []GrantDetail
+	for rows.Next() {
+		var g GrantDetail
+		if err := rows.Scan(&g.ID, &g.UserID, &g.Username, &g.NetworkID, &g.NetworkName, &g.GrantedAt); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, g)
+	}
+	return out, int(total), rows.Err()
+}
+
+// Create inserts a grant. Idempotent at the DB level (UNIQUE(user_id, network_id)):
+// a duplicate insert fails with a constraint error the caller maps to "already
+// exists". Returns the new row id.
+func Create(ctx context.Context, db *sql.DB, userID, networkID int64) (int64, error) {
+	res, err := db.ExecContext(ctx,
+		`INSERT INTO user_network_grants (user_id, network_id) VALUES (?, ?)`,
+		userID, networkID)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// Delete removes a grant by id. Returns whether a row was deleted.
+func Delete(ctx context.Context, db *sql.DB, id int64) (bool, error) {
+	res, err := db.ExecContext(ctx, `DELETE FROM user_network_grants WHERE id = ?`, id)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// DeleteByUserNetwork removes a grant by (user_id, network_id). Used when the
+// management surface keys off the pair rather than the surrogate id.
+func DeleteByUserNetwork(ctx context.Context, db *sql.DB, userID, networkID int64) (bool, error) {
+	res, err := db.ExecContext(ctx,
+		`DELETE FROM user_network_grants WHERE user_id = ? AND network_id = ?`, userID, networkID)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,11 @@ type Config struct {
 	// deployments without it keep working for v1/v2c scans; it only becomes
 	// required when the first SNMPv3 credential is created or read.
 	Security SecurityConfig `koanf:"security"`
+	// RBAC holds role-based access control tuning. Today this is the object-
+	// level network-scope mode (#138 Phase 2): whether a non-admin user without
+	// any network grants sees all networks ("open", default, preserves single-
+	// team deployments) or nothing ("closed", MSP / multi-tenant isolation).
+	RBAC RBACConfig `koanf:"rbac"`
 }
 
 // SecurityConfig carries the process-wide secret keying material. The master
@@ -69,6 +74,19 @@ type SecurityConfig struct {
 	// it and the existing passphrases can no longer be decrypted (re-encrypt
 	// them first via the migration path).
 	MasterKey string `koanf:"master_key"`
+}
+
+// RBACConfig tunes role-based access control. ScopeDefault controls object-level
+// network scope for non-admin users (#138 Phase 2):
+//   - "open" (default): a non-admin user sees EVERY network (current behavior).
+//     Network grants are ignored for visibility (still recorded for future use).
+//   - "closed": a non-admin user sees ONLY the networks they hold a grant for
+//     (MSP / multi-tenant isolation). Admin always bypasses scope.
+//
+// Set via rbac.scope_default YAML or MIBEE_RBAC_SCOPE_DEFAULT. Unknown values
+// fall back to "open" (fail-safe against accidental lockout).
+type RBACConfig struct {
+	ScopeDefault string `koanf:"scope_default"`
 }
 
 // CenterConfig configures an agent's upstream center.
@@ -305,6 +323,7 @@ func Load(configPath string) (*Config, error) {
 	// Apply passive-discovery defaults (interval, trigger_identify, per-source
 	// toggles). Done before validation so the service sees a fully-populated cfg.
 	normalizeDiscovery(&cfg)
+	normalizeRBAC(&cfg)
 
 	// Validate
 	if err := Validate(&cfg); err != nil {
@@ -396,6 +415,20 @@ func normalizeDiscovery(cfg *Config) {
 	}
 	if d.Interval <= 0 {
 		d.Interval = 60
+	}
+}
+
+// normalizeRBAC canonicalizes rbac.scope_default. Empty or unrecognized values
+// fall back to "open" — the non-lockout, backward-compatible default (a non-admin
+// with no grants sees every network, preserving existing single-team installs).
+// The canonical string values mirror domain.ScopeModeOpen/Closed (source of
+// truth); config keeps to raw strings to avoid a config→domain dependency.
+func normalizeRBAC(cfg *Config) {
+	switch strings.ToLower(cfg.RBAC.ScopeDefault) {
+	case "open", "closed":
+		cfg.RBAC.ScopeDefault = strings.ToLower(cfg.RBAC.ScopeDefault)
+	default:
+		cfg.RBAC.ScopeDefault = "open"
 	}
 }
 

--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -140,6 +140,15 @@ type DeviceFilter struct {
 	// interpolated raw into SQL). Order is "asc" or "desc" (default "asc").
 	SortBy string `json:"sort_by,omitempty"`
 	Order  string `json:"order,omitempty"`
+	// ScopeRestricted/ScopeNetworkIDs carry the caller's resolved object-level
+	// network scope (#138 Phase 2). ScopeRestricted is false (the zero value) for
+	// an unrestricted caller (admin / open mode) — no scope filtering, the safe
+	// default. When true, the list/count queries AND in a
+	// `network_id IN (ScopeNetworkIDs)` clause so a restricted user only sees
+	// their granted networks. ScopeNetworkIDs may be empty when restricted
+	// (closed mode + no grants → the query matches nothing).
+	ScopeRestricted bool
+	ScopeNetworkIDs []int64
 }
 
 // Response types

--- a/internal/domain/scope.go
+++ b/internal/domain/scope.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package domain
+
+import "context"
+
+// ScopeMode controls object-level network visibility for non-admin users
+// (#138 Phase 2). See internal/config.RBACConfig.
+type ScopeMode string
+
+const (
+	// ScopeModeOpen (default): a non-admin user sees every network regardless of
+	// grants. Preserves existing single-team deployments (no behavior change).
+	ScopeModeOpen ScopeMode = "open"
+	// ScopeModeClosed: a non-admin user sees only the networks they hold a grant
+	// for (MSP / multi-tenant isolation). Admin always bypasses scope.
+	ScopeModeClosed ScopeMode = "closed"
+)
+
+// Scope is the resolved object-level network scope for an authenticated user.
+// It is injected into the request context by the NetworkScope middleware and
+// consumed by the device/topology/changes/dashboard query paths + the
+// ValidateDeviceScope middleware.
+//
+// Either Global is true (see everything) OR NetworkIDs is the exhaustive
+// allow-list of network_ids the caller may see. A Global scope short-circuits
+// every scope check (no filtering) — the common path (admin + open mode).
+type Scope struct {
+	// Global: when true, the caller is unrestricted (no network filtering).
+	Global bool
+	// NetworkIDs: when Global is false, the exhaustive set of network_ids the
+	// caller may read/operate. May be empty (closed mode + no grants → sees
+	// nothing). Callers MUST NOT read this when Global is true.
+	NetworkIDs []int64
+}
+
+// IsGlobal reports whether the scope is unrestricted.
+func (s Scope) IsGlobal() bool { return s.Global }
+
+// AllowsNetwork reports whether a network_id is within the scope. Global scopes
+// allow everything; restricted scopes allow only the listed ids.
+func (s Scope) AllowsNetwork(networkID int64) bool {
+	if s.Global {
+		return true
+	}
+	for _, id := range s.NetworkIDs {
+		if id == networkID {
+			return true
+		}
+	}
+	return false
+}
+
+// Context key carrying the resolved Scope (set by the NetworkScope middleware).
+const ContextKeyUserScope contextKey = "user_scope"
+
+// ScopeFromContext returns the resolved Scope from the request context. If no
+// scope is present (e.g. the route runs before NetworkScope, or a unit test
+// that didn't set one), it returns a Global scope — the safe default for paths
+// that are not behind the scope middleware, so unscoped callers are NOT
+// accidentally locked out. Code paths that enforce scope are always behind
+// NetworkScope, so they will always find a real (non-default) scope.
+func ScopeFromContext(ctx context.Context) Scope {
+	if v, ok := ctx.Value(ContextKeyUserScope).(Scope); ok {
+		return v
+	}
+	return Scope{Global: true}
+}

--- a/internal/service/device_repo.go
+++ b/internal/service/device_repo.go
@@ -491,6 +491,7 @@ func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, sortE
 	  AND (? = '' OR d.created_at >= ?)
 	  AND (? = '' OR d.created_at <= ?)
 	  AND (? = 0 OR d.network_id = ?)
+	  ` + scopeClause(f) + `
 	ORDER BY ` + sortExpr + " " + dir + `
 	LIMIT ? OFFSET ?`
 
@@ -501,8 +502,9 @@ func listFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter, sortE
 		createdFrom, createdFromArg,
 		createdTo, createdToArg,
 		networkFilterEnabled, networkIDArg,
-		f.Limit, f.Offset,
 	)
+	args = append(args, scopeArgs(f)...)
+	args = append(args, f.Limit, f.Offset)
 
 	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -567,7 +569,8 @@ func countFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter) (int
 	  AND (? = '' OR name LIKE ? ESCAPE '\' OR ip_address LIKE ? ESCAPE '\' OR mac_address LIKE ? ESCAPE '\' OR serial_number LIKE ? ESCAPE '\')
 	  AND (? = '' OR created_at >= ?)
 	  AND (? = '' OR created_at <= ?)
-	  AND (? = 0 OR network_id = ?)`
+	  AND (? = 0 OR network_id = ?)
+	  ` + scopeClauseCount(f)
 
 	args = append(args,
 		statusVal, statusVal,
@@ -577,10 +580,64 @@ func countFilteredOn(ctx context.Context, q db.DBTX, f domain.DeviceFilter) (int
 		createdTo, createdToArg,
 		networkFilterEnabled, networkIDArg,
 	)
+	args = append(args, scopeArgs(f)...)
 
 	var count int64
 	if err := q.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count devices (filtered): %w", err)
 	}
 	return count, nil
+}
+
+// scopeClause returns the SQL fragment (with leading AND) that restricts the
+// device list query to the caller's granted networks, or "" when unrestricted.
+// It is the object-level network-scope filter (#138 Phase 2). An empty allowed
+// set under restriction (closed mode + no grants) matches nothing via `AND 0`.
+// Use the `d.` alias variant for the list query (devices d) and scopeClauseCount
+// (bare column, no alias) for the count query.
+func scopeClause(f domain.DeviceFilter) string {
+	if !f.ScopeRestricted {
+		return ""
+	}
+	if len(f.ScopeNetworkIDs) == 0 {
+		return "AND 0"
+	}
+	return "AND d.network_id IN (" + placeholders(len(f.ScopeNetworkIDs)) + ")"
+}
+
+func scopeClauseCount(f domain.DeviceFilter) string {
+	if !f.ScopeRestricted {
+		return ""
+	}
+	if len(f.ScopeNetworkIDs) == 0 {
+		return "AND 0"
+	}
+	return "AND network_id IN (" + placeholders(len(f.ScopeNetworkIDs)) + ")"
+}
+
+// scopeArgs returns the argument slice for the scope IN-list (empty when
+// unrestricted or when the clause is the `AND 0` no-match form).
+func scopeArgs(f domain.DeviceFilter) []any {
+	if !f.ScopeRestricted || len(f.ScopeNetworkIDs) == 0 {
+		return nil
+	}
+	out := make([]any, len(f.ScopeNetworkIDs))
+	for i, id := range f.ScopeNetworkIDs {
+		out[i] = id
+	}
+	return out
+}
+
+// placeholders returns "?,?,...,?" (n question marks).
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	b := make([]byte, 1+2*(n-1))
+	b[0] = '?'
+	for i := 1; i < n; i++ {
+		b[2*i-1] = ','
+		b[2*i] = '?'
+	}
+	return string(b)
 }

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -79,6 +79,7 @@ func TestSetupTestDBFromSchema(t *testing.T) {
 		"ssh_credentials",
 		"subnets",
 		"topology_edges",
+		"user_network_grants",
 		"user_totp",
 		"users",
 		"vlans",


### PR DESCRIPTION
## 背景
#138 Phase 2：对象级网络作用域（network-scoped access）。承接 #227（Phase 1c）+ #228（read-uniformity）。引入 `rbac.scope_default`（open 默认 / closed），让非 admin 用户在 closed 模式下只看到被 grant 的网络的设备（MSP / 多租户隔离）。

`user` 之前的 blocker「closed 模式无授权默认可见性」用**可配置 + 默认 open**化解：open 模式零行为变化（保护既有单团队部署），closed 模式 opt-in。

## 基础设施
- **`db/schema.sql`**：新表 `user_network_grants(user_id, network_id, UNIQUE)`。
- **config**：`RBACConfig.ScopeDefault`（`rbac.scope_default` / `MIBEE_RBAC_SCOPE_DEFAULT`）；`normalizeRBAC` 空/未知值→open（防误锁）。
- **`domain/scope.go`**：`Scope{Global, NetworkIDs}` + `ScopeMode` 常量 + context key + `ScopeFromContext`（缺失默认 Global，fail-safe）。
- **`authz/scoperesolver`**：raw-SQL store（grants CRUD + 按用户列网络，Phase 3 管理 API 备好）+ 30s TTL 缓存 resolver。`Resolve`：admin→Global、open→Global、closed+非admin→Restricted(granted ids)；DB 错误 fail-open（防可用性锁死）。
- **`middleware/scope.go`**：`NetworkScope`（解析 scope 注入 context）+ `ValidateDeviceScope`（`/devices/{id}` 及子资源按设备 network_id 校验，越界 403；Global 旁路）。

## 设备域闭环（closed 模式当前生效面）
- `device_repo` list/count：新增 `ScopeRestricted/ScopeNetworkIDs` 过滤（IN-list；空集 `AND 0`）。`handler.List` 从 context 取 scope 注入 filter。
- `/devices/{id}` + 全部子资源（systems / neighbors / certificates / configs / heartbeat-configs / results / history / stats / documents）+ 单设备 PUT/DELETE：挂 `NetworkScope` + `ValidateDeviceScope`。
- admin 与 open 模式一律 Global（零行为变化）。

## ⚠️ 预览边界（Phase 2b，已文档化）
closed 模式目前**只隔离设备浏览面**（list + 详情/子资源）。下列面尚未按网络隔离，在 closed 模式下仍跨网络可见：
- topology / change log（含 SSE watch fan-out）/ dashboard
- 设备 stats · export
- scanner results / runs / tasks（scan 表还缺 `network_id` 列，需 migration）

故 `scope_default` **默认 open**，config 注释明确提示「严格多租户隔离前不要开 closed，等 2b」。基础设施（resolver/middleware/context）已就位，2b 是机械扩展到这些查询路径。

## 测试
- `scope_isolation_test.go`（真实 `NewRouter`）：
  - closed 模式 viewer（grant net1）→ 只见 net1 设备、越界设备**及子资源 403**、无 grant 见空；
  - admin → 旁路（见全部）；
  - open 模式 → viewer 见全部（向后兼容）。
- `newTestDB`：改用生产 schema（`dbsql.SchemaSQL`，修复内联 schema 缺 `scan_source`/`scan_attributes` 等列导致 GET /devices 500）+ `MaxOpenConns(1)`（修 modernc `:memory:` 每连接独立 DB、种子不可见问题）。
- testutil 表清单快照 +`user_network_grants`。
- `go test ./...` 全绿；`gofmt`/`goimports`/`go vet` 干净。

## Stack
Base: **#228**（read-uniformity）。合 #227→#228→本 PR 后依次 retarget 到 main。