### PR TITLE
feat(rbac): network-grant 管理 API（#138 Phase 3 后端）

### DIFF
--- a/internal/api/handler/network_grant.go
+++ b/internal/api/handler/network_grant.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"mibee-steward/internal/authz/scoperesolver"
+)
+
+// NetworkGrantHandler is the admin management surface for object-level network
+// scope (#138 Phase 2/3): create/list/delete user↔network grants. All routes are
+// gated by CapUserManage (admin-only). Each mutation invalidates the scope
+// resolver's cache for the affected user so the change takes effect immediately.
+type NetworkGrantHandler struct {
+	db       *sql.DB
+	resolver *scoperesolver.Resolver
+}
+
+func NewNetworkGrantHandler(db *sql.DB, resolver *scoperesolver.Resolver) *NetworkGrantHandler {
+	return &NetworkGrantHandler{db: db, resolver: resolver}
+}
+
+type networkGrantRequest struct {
+	UserID    int64 `json:"user_id"`
+	NetworkID int64 `json:"network_id"`
+}
+
+type networkGrantResponse struct {
+	ID          int64  `json:"id"`
+	UserID      int64  `json:"user_id"`
+	Username    string `json:"username,omitempty"`
+	NetworkID   int64  `json:"network_id"`
+	NetworkName string `json:"network_name,omitempty"`
+	GrantedAt   string `json:"granted_at"`
+}
+
+// Create handles POST /api/v1/network-grants {user_id, network_id}. Validates
+// that both the user and network exist (otherwise 400) so grants can't dangle.
+// A duplicate (user,network) returns 409.
+func (h *NetworkGrantHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req networkGrantRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.UserID <= 0 || req.NetworkID <= 0 {
+		Error(w, http.StatusBadRequest, "user_id and network_id are required")
+		return
+	}
+	if !rowExists(r.Context(), h.db, `SELECT 1 FROM users WHERE id = ?`, req.UserID) {
+		Error(w, http.StatusBadRequest, "user not found")
+		return
+	}
+	if !rowExists(r.Context(), h.db, `SELECT 1 FROM networks WHERE id = ?`, req.NetworkID) {
+		Error(w, http.StatusBadRequest, "network not found")
+		return
+	}
+	id, err := scoperesolver.Create(r.Context(), h.db, req.UserID, req.NetworkID)
+	if err != nil {
+		if isUniqueConstraintErr(err) {
+			Error(w, http.StatusConflict, "grant already exists")
+			return
+		}
+		slog.Error("network grant: create", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to create grant")
+		return
+	}
+	h.resolver.Invalidate(req.UserID)
+	Created(w, networkGrantResponse{ID: id, UserID: req.UserID, NetworkID: req.NetworkID})
+}
+
+// List handles GET /api/v1/network-grants (admin view of every grant, joined to
+// username + network name). Paginated by limit/offset.
+func (h *NetworkGrantHandler) List(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
+	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
+	grants, total, err := scoperesolver.ListAll(r.Context(), h.db, int(limit), int(offset))
+	if err != nil {
+		slog.Error("network grant: list", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to list grants")
+		return
+	}
+	out := make([]networkGrantResponse, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, networkGrantResponse{
+			ID: g.ID, UserID: g.UserID, Username: g.Username,
+			NetworkID: g.NetworkID, NetworkName: g.NetworkName, GrantedAt: g.GrantedAt,
+		})
+	}
+	Success(w, map[string]any{"grants": out, "total": total})
+}
+
+// ListByUser handles GET /api/v1/users/{id}/network-grants — the networks a user
+// is granted (used by the user-edit form to show/edit scope).
+func (h *NetworkGrantHandler) ListByUser(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || userID <= 0 {
+		Error(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	grants, err := scoperesolver.ListByUser(r.Context(), h.db, userID)
+	if err != nil {
+		slog.Error("network grant: list for user", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to list grants")
+		return
+	}
+	out := make([]networkGrantResponse, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, networkGrantResponse{ID: g.ID, UserID: g.UserID, NetworkID: g.NetworkID, GrantedAt: g.GrantedAt})
+	}
+	Success(w, map[string]any{"grants": out, "total": len(out)})
+}
+
+// Delete handles DELETE /api/v1/network-grants/{id}. Looks up the grant first so
+// the resolver can be invalidated for the right user.
+func (h *NetworkGrantHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		Error(w, http.StatusBadRequest, "invalid grant id")
+		return
+	}
+	var userID int64
+	err = h.db.QueryRowContext(r.Context(),
+		`SELECT user_id FROM user_network_grants WHERE id = ?`, id).Scan(&userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		Error(w, http.StatusNotFound, "grant not found")
+		return
+	}
+	if err != nil {
+		slog.Error("network grant: lookup", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to delete grant")
+		return
+	}
+	ok, err := scoperesolver.Delete(r.Context(), h.db, id)
+	if err != nil {
+		slog.Error("network grant: delete", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to delete grant")
+		return
+	}
+	if !ok {
+		Error(w, http.StatusNotFound, "grant not found")
+		return
+	}
+	h.resolver.Invalidate(userID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// rowExists reports whether a scalar SELECT-y query returns at least one row.
+// Used for existence checks (user/network) before inserting a grant.
+func rowExists(ctx context.Context, db *sql.DB, query string, args ...any) bool {
+	var tmp any
+	err := db.QueryRowContext(ctx, query, args...).Scan(&tmp)
+	return err == nil
+}

--- a/internal/api/routes/network_grant_test.go
+++ b/internal/api/routes/network_grant_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the network-grant management API (#138 Phase 3): admin can
+// create/list/delete grants; a duplicate is 409; a non-admin is 403; deleting
+// invalidates the scope so the user's visibility changes immediately.
+
+func TestNetworkGrants_AdminCRUD(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, false) // no grants seeded
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	admin := tokenForUser(t, cfg.Auth.JWTSecret, 2, "admin") // user_id=2 admin
+	viewer := tokenForUser(t, cfg.Auth.JWTSecret, 1, "viewer")
+
+	// Non-admin cannot create a grant.
+	rec := postJSON(t, handler, "/api/v1/network-grants", `{"user_id":1,"network_id":1}`, viewer)
+	require.Equal(t, http.StatusForbidden, rec.Code, "viewer must be 403 on grant create")
+
+	// Admin creates a grant (user 1 → network 1).
+	rec = postJSON(t, handler, "/api/v1/network-grants", `{"user_id":1,"network_id":1}`, admin)
+	require.Equal(t, http.StatusCreated, rec.Code, "body=%s", rec.Body.String())
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	require.NotZero(t, created.ID)
+
+	// Duplicate → 409.
+	rec = postJSON(t, handler, "/api/v1/network-grants", `{"user_id":1,"network_id":1}`, admin)
+	require.Equal(t, http.StatusConflict, rec.Code)
+
+	// Unknown user/network → 400.
+	rec = postJSON(t, handler, "/api/v1/network-grants", `{"user_id":999,"network_id":1}`, admin)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	rec = postJSON(t, handler, "/api/v1/network-grants", `{"user_id":1,"network_id":999}`, admin)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// List all grants includes the created one.
+	rec = getAuth(handler, "/api/v1/network-grants", admin)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list struct {
+		Grants []struct {
+			UserID    int64  `json:"user_id"`
+			NetworkID int64  `json:"network_id"`
+			Username  string `json:"username"`
+		} `json:"grants"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Equal(t, 1, list.Total)
+	require.Equal(t, int64(1), list.Grants[0].UserID)
+	require.Equal(t, int64(1), list.Grants[0].NetworkID)
+	require.Equal(t, "viewer1", list.Grants[0].Username, "list should join username")
+
+	// Per-user list.
+	rec = getAuth(handler, "/api/v1/users/1/network-grants", admin)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Grant now takes effect: viewer (user 1) in closed mode sees only network 1.
+	rec = getAuth(handler, "/api/v1/devices", viewer)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var devs deviceListJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &devs))
+	require.Equal(t, 1, devs.Total, "viewer now scoped to network 1 only")
+
+	// Delete the grant → 204.
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/network-grants/"+strconv.FormatInt(created.ID, 10), nil)
+	req.Header.Set("Authorization", "Bearer "+admin)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Cache invalidated → viewer now sees nothing again (no grants).
+	rec = getAuth(handler, "/api/v1/devices", viewer)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &devs))
+	require.Equal(t, 0, devs.Total, "after grant deletion viewer sees no devices")
+}
+
+func postJSON(t *testing.T, h http.Handler, path, body, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func getAuth(h http.Handler, path, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -139,6 +139,16 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		})
 	})
 
+	// Object-level network scope resolver (#138 Phase 2). Resolves a user's
+	// granted network set (closed mode) or Global (admin / open mode). Consumed
+	// by NetworkScope (injects scope into context), the device query paths, and
+	// the network-grant management handler (Phase 3, for cache invalidation).
+	scopeResolver := scoperesolver.New(dbConn, domain.ScopeMode(cfg.RBAC.ScopeDefault))
+	// Network-grant management handler (#138 Phase 3): admin assigns/removes a
+	// user's network scope. CapUserManage = admin-only. The handler invalidates
+	// the scope resolver cache per affected user so changes apply immediately.
+	networkGrantHandler := handler.NewNetworkGrantHandler(dbConn, scopeResolver)
+
 	// User management — admin-only (#138 CapUserManage; admin is the only role
 	// that holds it, so this preserves the prior RequireAdmin semantics while
 	// expressing the gate through the capability matrix).
@@ -147,6 +157,16 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Get("/", userHandler.ListUsers)
 		r.Post("/batch-delete", batchHandler.BatchDeleteUsers)
 		r.Post("/{id}/reset-password", userHandler.AdminResetPassword)
+		// Per-user network grants (#138 Phase 3) — list the networks a user is
+		// scoped to (closed mode). The create/delete surface is /network-grants.
+		r.Get("/{id}/network-grants", networkGrantHandler.ListByUser)
+	})
+
+	r.Route("/api/v1/network-grants", func(r chi.Router) {
+		r.Use(middleware.RequireCapability(domain.CapUserManage))
+		r.Get("/", networkGrantHandler.List)
+		r.Post("/", networkGrantHandler.Create)
+		r.Delete("/{id}", networkGrantHandler.Delete)
 	})
 	// Heartbeat service + its dedicated time-series store. heartbeat_results
 	// lives in a separate SQLite file (data/heartbeat.db) so its high write
@@ -163,12 +183,6 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// dedicated heartbeat store for heartbeat_results (which lives in
 	// heartbeat.db after the time-series split; the main DB's copy is stale).
 	exportHandler := handler.NewExportHandler(service.NewExportService(db.New(dbConn), hbStore.Queries()))
-
-	// Object-level network scope resolver (#138 Phase 2). Resolves a user's
-	// granted network set (closed mode) or Global (admin / open mode). Consumed
-	// by NetworkScope (injects scope into context) and the device/topology/
-	// changes query paths.
-	scopeResolver := scoperesolver.New(dbConn, domain.ScopeMode(cfg.RBAC.ScopeDefault))
 
 	// Device routes
 	deviceRepo := service.NewDeviceRepository(dbConn)


### PR DESCRIPTION
## 背景
承接 #229（Phase 2 对象级 scope 基础 + 设备域闭环）。本 PR 补上 closed 模式的**管理面**：admin 可经 API 给用户分配/撤销网络作用域（否则只能直改 DB）。

## API（均 `CapUserManage` = admin-only）
| Method | Path | 说明 |
|---|---|---|
| POST | `/api/v1/network-grants` | `{user_id, network_id}` → 201；校验 user/network 存在（防悬空 FK）；重复 409 |
| GET | `/api/v1/network-grants` | 列全部（JOIN username + network_name，分页） |
| GET | `/api/v1/users/{id}/network-grants` | 列某用户的授予网络（用户编辑表单用） |
| DELETE | `/api/v1/network-grants/{id}` | → 204（先查 user_id 以失效其缓存） |

## 实现
`handler/network_grant.go` 照搬 ssh_credential handler 风格（raw-SQL store、`slog`、复用 `network.go` 的 `isUniqueConstraintErr`）。复用 Phase 2 的 `scoperesolver` store（Create/ListAll/ListByUser/Delete 已就绪）+ resolver；每次写操作 `resolver.Invalidate(userID)` 保证**变更即时生效**。

## 测试
`network_grant_test.go`（真实 `NewRouter`，closed 模式）：
- viewer POST → **403**；admin POST → **201**；重复 → **409**；未知 user/network → **400**；
- 列表 JOIN username 正确；
- **端到端**：建 grant → viewer 设备列表立刻只剩该网络；删 grant → 立刻归零（锁住缓存失效路径）。
- `go test ./...` 全绿；`gofmt`/`goimports`/`go vet` 干净。

## Stack / 后续
Base: **#229**（Phase 2）。前端 grants 管理 UI（用户编辑表单里的网络分配）见后续 PR。