### PR TITLE
feat(rbac): closed-mode 作用域扩展到全部读取面（#138 Phase 2b）

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -60,15 +60,16 @@ rbac:
   #                    network grants are recorded but not enforced).
   #   closed          : a non-admin user sees only networks they hold a grant
   #                    for (MSP / multi-tenant isolation). Admin always bypasses.
-  # PREVIEW (v1): "closed" currently scopes the device browse surface — the
-  # device LIST (GET /devices) and device detail + per-device sub-resources
+  # "closed" scopes the device inventory read surfaces: device LIST (GET
+  # /devices) + device detail and per-device sub-resources
   # (GET/PUT/DELETE /devices/{id} and /devices/{id}/{neighbors,certificates,
-  # configs,systems,heartbeat-*,documents}) enforce the granted-network set.
-  # Topology, change log, dashboard, device stats/export, and scanner
-  # results/runs/tasks are NOT yet network-scoped (#138 Phase 2b — the scanner
-  # tables also lack a network_id column) and remain visible across networks
-  # until then. Do not enable "closed" for strict multi-tenant isolation until
-  # 2b lands; "open" is fully safe (no behavior change).
+  # configs,systems,heartbeat-*,documents}), device STATS (GET /devices/stats),
+  # device EXPORT (GET /devices/export), the TOPOLOGY graph (GET /topology), the
+  # CHANGE log list + SSE stream (GET /changes, /changes/watch), and the
+  # DASHBOARD overview device aggregates (GET /dashboard/overview) all enforce
+  # the granted-network set. The dashboard's recent-scan-activity section and
+  # scanner results/runs/tasks are NOT yet network-scoped (#138 Phase 2c — the
+  # scanner tables lack a network_id column) and remain visible across networks.
   scope_default: "open"
 
 auth:

--- a/internal/api/handler/changes.go
+++ b/internal/api/handler/changes.go
@@ -10,6 +10,8 @@
 package handler
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -17,8 +19,10 @@ import (
 	"strconv"
 	"time"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 )
 
 // ChangeLogEntry is one row of the change history, JSON-tagged for the API.
@@ -46,11 +50,15 @@ type ChangeLogResponse struct {
 // ChangeLogHandler serves the change-history query API.
 type ChangeLogHandler struct {
 	queries *db.Queries
+	dbConn  *sql.DB // raw connection for the scope-restricted list/count
+	// (sqlc can't express a variable IN-list, so the closed-mode path builds the
+	// WHERE with scopeql.NetworkPredicate and runs it directly).
 }
 
-// NewChangeLogHandler constructs the handler.
-func NewChangeLogHandler(queries *db.Queries) *ChangeLogHandler {
-	return &ChangeLogHandler{queries: queries}
+// NewChangeLogHandler constructs the handler. dbConn powers the object-scope
+// (closed-mode) list/count; it may be nil when scope is never enforced.
+func NewChangeLogHandler(queries *db.Queries, dbConn *sql.DB) *ChangeLogHandler {
+	return &ChangeLogHandler{queries: queries, dbConn: dbConn}
 }
 
 // List handles GET /api/v1/changes — paginated change history, newest first.
@@ -95,6 +103,22 @@ func (h *ChangeLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	// Search: substring across change_type/entity_type. Empty ⇒ no filter.
 	searchVal := q.Get("search")
+
+	// Object-level network scope (#138 Phase 2b): closed-mode non-admin callers
+	// see only changes on their granted networks. The global path (admin / open
+	// mode) keeps the existing sqlc query; the restricted path builds a raw
+	// WHERE with scopeql.NetworkPredicate (sqlc can't express a variable IN-list).
+	scope := domain.ScopeFromContext(r.Context())
+	if !scope.IsGlobal() && h.dbConn != nil {
+		out, total, err := h.listScopedChanges(r.Context(), scope, networkID,
+			changeType, entityType, searchVal, limit, offset)
+		if err != nil {
+			Error(w, http.StatusInternalServerError, "failed to list changes")
+			return
+		}
+		Success(w, ChangeLogResponse{Changes: out, Total: int(total)})
+		return
+	}
 
 	rows, err := h.queries.ListChangeLog(r.Context(), db.ListChangeLogParams{
 		Column1:    netSentinel,
@@ -144,6 +168,79 @@ func (h *ChangeLogHandler) List(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	Success(w, ChangeLogResponse{Changes: out, Total: int(total)})
+}
+
+// listScopedChanges runs the scope-restricted change-history query (closed mode).
+// It mirrors the ListChangeLog/CountChangeLog sqlc shape exactly (same filters,
+// ordering, pagination) but swaps the single-network filter for the caller's
+// granted-network IN-list via scopeql.NetworkPredicate. The optional network_id
+// param still narrows within the scope (a network_id outside the scope is
+// already excluded by the IN-list). Returns the page + total count.
+func (h *ChangeLogHandler) listScopedChanges(
+	ctx context.Context, scope domain.Scope, networkID *int64,
+	changeType, entityType, searchVal string, limit, offset int64,
+) ([]ChangeLogEntry, int64, error) {
+	netPred, netArgs := scopeql.NetworkPredicate(scope, "")
+
+	typeSentinel := ""
+	if changeType != "" {
+		typeSentinel = "1"
+	}
+	entitySentinel := ""
+	if entityType != "" {
+		entitySentinel = "1"
+	}
+	searchSentinel := ""
+	if searchVal != "" {
+		searchSentinel = "1"
+	}
+	netSentinel := 0
+	var netVal int64
+	if networkID != nil {
+		netSentinel = 1
+		netVal = *networkID
+	}
+
+	// WHERE common to both the list and the count.
+	where := "WHERE " + netPred +
+		" AND (? = 0 OR network_id = ?)" +
+		" AND (? = '' OR change_type = ?)" +
+		" AND (? = '' OR entity_type = ?)" +
+		" AND (? = '' OR INSTR(lower(change_type), lower(?)) > 0 OR INSTR(lower(entity_type), lower(?)) > 0)"
+
+	countArgs := make([]any, 0, len(netArgs)+10)
+	countArgs = append(countArgs, netArgs...)
+	countArgs = append(countArgs, netSentinel, netVal,
+		typeSentinel, changeType, entitySentinel, entityType,
+		searchSentinel, searchVal, searchVal)
+
+	var total int64
+	if err := h.dbConn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM change_log "+where, countArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	listArgs := make([]any, 0, len(countArgs)+2)
+	listArgs = append(listArgs, countArgs...)
+	listArgs = append(listArgs, limit, offset)
+	rows, err := h.dbConn.QueryContext(ctx,
+		"SELECT id, agent_id, network_id, change_type, entity_type, entity_id, before_data, after_data, detected_at "+
+			"FROM change_log "+where+" ORDER BY detected_at DESC LIMIT ? OFFSET ?", listArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := make([]ChangeLogEntry, 0)
+	for rows.Next() {
+		var e ChangeLogEntry
+		if err := rows.Scan(&e.ID, &e.AgentID, &e.NetworkID, &e.ChangeType,
+			&e.EntityType, &e.EntityID, &e.BeforeData, &e.AfterData, &e.DetectedAt); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, e)
+	}
+	return out, total, rows.Err()
 }
 
 // ChangeWatchHandler streams change events to clients via Server-Sent Events
@@ -238,6 +335,10 @@ func (h *ChangeWatchHandler) Watch(w http.ResponseWriter, r *http.Request) {
 	rc.Flush()
 
 	ctx := r.Context()
+	// Object-level network scope (#138 Phase 2b): a restricted caller's stream
+	// must not leak change events from networks they hold no grant for. Events
+	// are filtered per-row here (the Watcher fans out to every subscriber).
+	scope := domain.ScopeFromContext(r.Context())
 	for {
 		select {
 		case <-ctx.Done():
@@ -253,6 +354,11 @@ func (h *ChangeWatchHandler) Watch(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				// Channel closed (server shutting down).
 				return
+			}
+			// Restricted scope: drop events whose network is out of scope (a
+			// change with no network_id is hidden — conservative for isolation).
+			if !scope.IsGlobal() && (row.NetworkID == nil || !scope.AllowsNetwork(*row.NetworkID)) {
+				continue
 			}
 			data, err := json.Marshal(ChangeLogEntry{
 				ID:         row.ID,

--- a/internal/api/handler/dashboard.go
+++ b/internal/api/handler/dashboard.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service"
 )
 
@@ -45,7 +46,7 @@ func (h *DashboardHandler) ListConfigs(w http.ResponseWriter, r *http.Request) {
 // powers the default dashboard (device totals/distributions, recent scan
 // activity, offline-device list). Computed server-side over the full dataset.
 func (h *DashboardHandler) Overview(w http.ResponseWriter, r *http.Request) {
-	resp, err := h.svc.Overview(r.Context())
+	resp, err := h.svc.Overview(r.Context(), domain.ScopeFromContext(r.Context()))
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to load dashboard overview")
 		return

--- a/internal/api/handler/device.go
+++ b/internal/api/handler/device.go
@@ -217,7 +217,7 @@ func (h *DeviceHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 			networkID = &id
 		}
 	}
-	resp, err := h.svc.GetStats(r.Context(), networkID)
+	resp, err := h.svc.GetStats(r.Context(), networkID, domain.ScopeFromContext(r.Context()))
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to get device stats")
 		return

--- a/internal/api/handler/export.go
+++ b/internal/api/handler/export.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service"
 )
 
@@ -48,7 +49,7 @@ func (h *ExportHandler) ExportDevices(w http.ResponseWriter, r *http.Request) {
 		f.Flush()
 	}
 
-	if err := h.svc.Devices(r.Context(), format, w); err != nil {
+	if err := h.svc.Devices(r.Context(), format, w, domain.ScopeFromContext(r.Context())); err != nil {
 		Error(w, http.StatusInternalServerError, "export failed")
 	}
 }

--- a/internal/api/handler/topology.go
+++ b/internal/api/handler/topology.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 )
 
 // TopologyHandler serves the network-level topology graph: device nodes + L2
@@ -105,6 +106,37 @@ func (h *TopologyHandler) Graph(w http.ResponseWriter, r *http.Request) {
 			LocalPort:    e.LocalPort,
 			RemotePort:   e.RemotePort,
 		})
+	}
+
+	// Object-level network scope (#138 Phase 2b): a restricted (non-admin, closed
+	// mode) caller sees only their granted networks. The sqlc fetch above already
+	// honored an explicit ?network_id= param; here we additionally intersect with
+	// the caller's scope. If the caller passed a network_id they hold no grant
+	// for, the node set becomes empty (correct — deny). Nodes with no assigned
+	// network are hidden from restricted scopes (conservative for isolation).
+	// Edges are kept only when their origin device survived the node filter.
+	scope := domain.ScopeFromContext(r.Context())
+	if !scope.IsGlobal() {
+		allowed := make(map[int64]bool, len(scope.NetworkIDs))
+		for _, id := range scope.NetworkIDs {
+			allowed[id] = true
+		}
+		scopedNodes := make([]topoNode, 0, len(nodes))
+		allowedDevices := make(map[int64]bool, len(nodes))
+		for _, n := range nodes {
+			if n.NetworkID != nil && allowed[*n.NetworkID] {
+				scopedNodes = append(scopedNodes, n)
+				allowedDevices[n.ID] = true
+			}
+		}
+		scopedEdges := make([]topoEdge, 0, len(edges))
+		for _, e := range edges {
+			if allowedDevices[e.FromDeviceID] {
+				scopedEdges = append(scopedEdges, e)
+			}
+		}
+		nodes = scopedNodes
+		edges = scopedEdges
 	}
 
 	Success(w, map[string]any{

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -182,7 +182,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Export handler — bound to the main DB for devices/audit, and to the
 	// dedicated heartbeat store for heartbeat_results (which lives in
 	// heartbeat.db after the time-series split; the main DB's copy is stale).
-	exportHandler := handler.NewExportHandler(service.NewExportService(db.New(dbConn), hbStore.Queries()))
+	exportHandler := handler.NewExportHandler(service.NewExportService(db.New(dbConn), hbStore.Queries(), dbConn))
 
 	// Device routes
 	deviceRepo := service.NewDeviceRepository(dbConn)
@@ -634,10 +634,11 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// filterable by network_id / change_type / entity_type. This is the
 	// queryable view on top of change_log; the in-process Watcher (changeWatcher
 	// above) is the foundation for a future /watch SSE push endpoint.
-	changeLogHandler := handler.NewChangeLogHandler(scanQueries)
+	changeLogHandler := handler.NewChangeLogHandler(scanQueries, dbConn)
 	changeWatchHandler := handler.NewChangeWatchHandler(changeWatcher, slog.Default())
 	r.Route("/api/v1/changes", func(r chi.Router) {
 		r.Use(middleware.RequireCapability(domain.CapChangesRead))
+		r.Use(middleware.NetworkScope(scopeResolver))
 		r.Get("/", changeLogHandler.List)
 		r.Get("/watch", changeWatchHandler.Watch)
 	})
@@ -749,6 +750,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Read-only. Feeds the /topology page.
 	r.Route("/api/v1/topology", func(r chi.Router) {
 		r.Use(middleware.RequireCapability(domain.CapTopologyRead))
+		r.Use(middleware.NetworkScope(scopeResolver))
 		r.Get("/", topologyHandler.Graph)
 	})
 
@@ -828,6 +830,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	r.Route("/api/v1/dashboard", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireCapability(domain.CapDashboardRead))
+			r.Use(middleware.NetworkScope(scopeResolver))
 			r.Get("/configs", dashHandler.ListConfigs)
 			r.Get("/overview", dashHandler.Overview)
 			r.Get("/query", dashHandler.Query)

--- a/internal/api/routes/scope_isolation_test.go
+++ b/internal/api/routes/scope_isolation_test.go
@@ -181,3 +181,129 @@ func TestScope_OpenMode_ViewerSeesEverything(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Equal(t, 2, body.Total, "open mode: viewer sees all devices")
 }
+
+// authedGet fires an authenticated GET through the router and returns the recorder.
+func authedGet(t *testing.T, h http.Handler, token, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestScope_ClosedMode_ReadSurfacesScoped pins the Phase 2b surfaces: in closed
+// mode a viewer granted network 1 sees ONLY network-1 data across topology,
+// changes, dashboard overview, device stats, and device export — while admin is
+// unrestricted. This closes the object-scope loop on every read surface that
+// joins the devices/change_log tables by network_id.
+func TestScope_ClosedMode_ReadSurfacesScoped(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, true) // grant user1 → network 1
+	// Richer seed: net2 device offline (so dashboard offline-list + stats differ
+	// by network) + a change_log row on each network.
+	_, err := db.Exec(`
+		UPDATE devices SET status='offline' WHERE id=20;
+		INSERT INTO change_log (network_id, change_type, entity_type, entity_id, detected_at) VALUES
+			(1, 'device_added', 'device', 10, '2026-01-01T00:00:00Z'),
+			(2, 'device_added', 'device', 20, '2026-01-02T00:00:00Z');
+	`)
+	require.NoError(t, err)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	viewer := tokenForRole(t, cfg.Auth.JWTSecret, "viewer") // user_id=1, granted net1
+	admin := tokenForUser(t, cfg.Auth.JWTSecret, 2, "admin")
+
+	// --- topology: scoped viewer sees only the net-1 node (device 10) ---
+	topoFor := func(tok string) (ids []int64) {
+		rec := authedGet(t, handler, tok, "/api/v1/topology")
+		require.Equalf(t, http.StatusOK, rec.Code, "topology body=%s", rec.Body.String())
+		var body struct {
+			Nodes []struct {
+				ID        int64  `json:"id"`
+				NetworkID *int64 `json:"network_id"`
+			} `json:"nodes"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		for _, n := range body.Nodes {
+			ids = append(ids, n.ID)
+		}
+		return ids
+	}
+	require.ElementsMatch(t, []int64{10}, topoFor(viewer), "scoped viewer topology: only net-1 device")
+	require.ElementsMatch(t, []int64{10, 20}, topoFor(admin), "admin topology: both devices")
+
+	// --- changes: scoped viewer sees only the net-1 change ---
+	changesFor := func(tok string) (total int, nets []int64) {
+		rec := authedGet(t, handler, tok, "/api/v1/changes")
+		require.Equalf(t, http.StatusOK, rec.Code, "changes body=%s", rec.Body.String())
+		var body struct {
+			Changes []struct {
+				NetworkID *int64 `json:"network_id"`
+			} `json:"changes"`
+			Total int `json:"total"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		for _, c := range body.Changes {
+			if c.NetworkID != nil {
+				nets = append(nets, *c.NetworkID)
+			}
+		}
+		return body.Total, nets
+	}
+	vTotal, vNets := changesFor(viewer)
+	require.Equal(t, 1, vTotal, "scoped viewer changes: only net-1 change")
+	require.ElementsMatch(t, []int64{1}, vNets)
+	aTotal, _ := changesFor(admin)
+	require.Equal(t, 2, aTotal, "admin changes: both networks")
+
+	// --- dashboard overview: scoped total == 1, offline == 0; admin total == 2, offline == 1 ---
+	overviewFor := func(tok string) (total, offline int64) {
+		rec := authedGet(t, handler, tok, "/api/v1/dashboard/overview")
+		require.Equalf(t, http.StatusOK, rec.Code, "overview body=%s", rec.Body.String())
+		var body struct {
+			Devices struct {
+				Total   int64 `json:"total"`
+				Offline int64 `json:"offline"`
+			} `json:"devices"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		return body.Devices.Total, body.Devices.Offline
+	}
+	vTotal2, vOffline := overviewFor(viewer)
+	require.Equal(t, int64(1), vTotal2, "scoped dashboard total: only net-1 device")
+	require.Equal(t, int64(0), vOffline, "scoped dashboard offline: net2 offline device hidden")
+	aTotal2, aOffline := overviewFor(admin)
+	require.Equal(t, int64(2), aTotal2)
+	require.Equal(t, int64(1), aOffline)
+
+	// --- device stats: scoped by_status reflects only net1 (online:1); admin sees online:1+offline:1 ---
+	statsFor := func(tok string) map[string]int64 {
+		rec := authedGet(t, handler, tok, "/api/v1/devices/stats")
+		require.Equalf(t, http.StatusOK, rec.Code, "stats body=%s", rec.Body.String())
+		var body struct {
+			ByStatus map[string]int64 `json:"by_status"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		return body.ByStatus
+	}
+	require.Equal(t, map[string]int64{"online": 1}, statsFor(viewer), "scoped stats: only net-1 (online) device")
+	require.Equal(t, map[string]int64{"online": 1, "offline": 1}, statsFor(admin), "admin stats: both")
+
+	// --- device export: scoped CSV contains only net-1 IP; admin contains both ---
+	exportFor := func(tok string) string {
+		rec := authedGet(t, handler, tok, "/api/v1/devices/export?format=csv")
+		require.Equalf(t, http.StatusOK, rec.Code, "export body=%s", rec.Body.String())
+		return rec.Body.String()
+	}
+	vExport := exportFor(viewer)
+	require.Contains(t, vExport, "10.0.1.5", "scoped export includes net-1 device IP")
+	require.NotContains(t, vExport, "10.0.2.5", "scoped export excludes net-2 device IP")
+	aExport := exportFor(admin)
+	require.Contains(t, aExport, "10.0.1.5")
+	require.Contains(t, aExport, "10.0.2.5")
+}

--- a/internal/authz/scopeql/scopeql.go
+++ b/internal/authz/scopeql/scopeql.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. A commercial license is available for use cases
+// the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+// Package scopeql provides the shared SQL primitive that restricts an inventory
+// query to the networks in a resolved object-level Scope (#138 Phase 2b). The
+// device list has its own parallel impl in internal/service/device_repo.go
+// (scopeClause, tied to DeviceFilter); this package is the general-purpose
+// version the other read surfaces (changes, dashboard, stats, export) share so
+// the "restricted + no grants → sees nothing" rule lives in exactly one place.
+package scopeql
+
+import (
+	"strings"
+
+	"mibee-steward/internal/domain"
+)
+
+// NetworkPredicate returns a SQL predicate (no leading AND/WHERE) plus bind args
+// that test network_id membership against s:
+//   - Global scope → ("1=1", nil): no restriction. Safe to AND into any WHERE
+//     and to use as a sole predicate ("WHERE 1=1").
+//   - Restricted, non-empty → ("<alias>.network_id IN (?,?,...)", args).
+//   - Restricted, empty (closed mode, no grants) → ("0", nil): matches nothing,
+//     so the whole row set is empty without extra special-casing.
+//
+// alias prefixes the network_id column (e.g. "d" → "d.network_id"); pass "" for
+// a bare column reference.
+func NetworkPredicate(s domain.Scope, alias string) (predicate string, args []any) {
+	if s.IsGlobal() {
+		return "1=1", nil
+	}
+	col := "network_id"
+	if alias != "" {
+		col = alias + ".network_id"
+	}
+	if len(s.NetworkIDs) == 0 {
+		return "0", nil
+	}
+	marks := make([]string, len(s.NetworkIDs))
+	args = make([]any, len(s.NetworkIDs))
+	for i, id := range s.NetworkIDs {
+		marks[i] = "?"
+		args[i] = id
+	}
+	return col + " IN (" + strings.Join(marks, ",") + ")", args
+}

--- a/internal/authz/scopeql/scopeql_test.go
+++ b/internal/authz/scopeql/scopeql_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package scopeql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/domain"
+)
+
+func TestNetworkPredicate(t *testing.T) {
+	cases := []struct {
+		name     string
+		scope    domain.Scope
+		alias    string
+		wantPred string
+		wantArgs []any
+	}{
+		{
+			name:     "global is no-op 1=1",
+			scope:    domain.Scope{Global: true},
+			wantPred: "1=1",
+			wantArgs: []any(nil),
+		},
+		{
+			name:     "restricted empty matches nothing",
+			scope:    domain.Scope{Global: false, NetworkIDs: nil},
+			wantPred: "0",
+			wantArgs: []any(nil),
+		},
+		{
+			name:     "restricted single network bare column",
+			scope:    domain.Scope{Global: false, NetworkIDs: []int64{7}},
+			wantPred: "network_id IN (?)",
+			wantArgs: []any{int64(7)},
+		},
+		{
+			name:     "restricted multiple networks with alias",
+			scope:    domain.Scope{Global: false, NetworkIDs: []int64{1, 2, 3}},
+			alias:    "d",
+			wantPred: "d.network_id IN (?,?,?)",
+			wantArgs: []any{int64(1), int64(2), int64(3)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred, args := NetworkPredicate(tc.scope, tc.alias)
+			require.Equal(t, tc.wantPred, pred)
+			require.Equal(t, tc.wantArgs, args)
+		})
+	}
+}

--- a/internal/service/dashboard.go
+++ b/internal/service/dashboard.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"time"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
@@ -151,49 +152,77 @@ func (e *UpstreamError) Error() string {
 // activity, and the offline-device list. The default dashboard front-end
 // consumes this single call instead of pulling /devices?limit=200 and computing
 // pie charts in the browser (which capped at 200 rows and skewed the picture).
-func (s *DashboardService) Overview(ctx context.Context) (*domain.DashboardOverviewResponse, error) {
+//
+// scope (#138 Phase 2b): the device aggregates (status/type/location/offline)
+// honor object-level network scope — a closed-mode non-admin caller sees counts
+// only for their granted networks. The scanning section (recent tasks/runs) is
+// cross-network discovery metadata and is intentionally NOT scoped (it has no
+// per-network association until scan_tasks.network_id lands).
+func (s *DashboardService) Overview(ctx context.Context, scope domain.Scope) (*domain.DashboardOverviewResponse, error) {
 	out := &domain.DashboardOverviewResponse{Generated: time.Now()}
+	// pred is "1=1" for a global scope (no filtering) — so the same raw query
+	// serves both the admin/open path and the closed-mode restricted path.
+	pred, predArgs := scopeql.NetworkPredicate(scope, "")
 
-	// --- 1. Device totals + by_status (reuse the existing GROUP BY queries) ---
-	statusRows, err := s.queries.CountByStatus(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("overview: count by status: %w", err)
-	}
 	dev := domain.OverviewDevices{
 		ByType:     map[string]int64{},
 		ByLocation: map[string]int64{},
 	}
-	for _, r := range statusRows {
-		dev.Total += r.Count
-		switch r.Status {
-		case "online":
-			dev.Online = r.Count
-		case "offline":
-			dev.Offline = r.Count
-		case "unknown":
-			dev.Unknown = r.Count
+
+	// --- 1. Device totals + by_status ---
+	statusRows, err := s.dbConn.QueryContext(ctx,
+		`SELECT status, COUNT(*) FROM devices WHERE `+pred+` GROUP BY status`, predArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("overview: count by status: %w", err)
+	}
+	for statusRows.Next() {
+		var status string
+		var c int64
+		if err := statusRows.Scan(&status, &c); err != nil {
+			statusRows.Close()
+			return nil, fmt.Errorf("overview: scan status: %w", err)
 		}
+		dev.Total += c
+		switch status {
+		case "online":
+			dev.Online = c
+		case "offline":
+			dev.Offline = c
+		case "unknown":
+			dev.Unknown = c
+		}
+	}
+	statusRows.Close()
+	if err := statusRows.Err(); err != nil {
+		return nil, fmt.Errorf("overview: status rows: %w", err)
 	}
 	if dev.Total > 0 {
 		dev.OnlineRate = float64(dev.Online) / float64(dev.Total)
 	}
 
 	// --- 2. by_type (full population, not a 200-row sample) ---
-	typeRows, err := s.queries.CountDevicesByType(ctx)
+	typeRows, err := s.dbConn.QueryContext(ctx,
+		`SELECT COALESCE(NULLIF(type,''),'unknown'), COUNT(*) FROM devices WHERE `+pred+` GROUP BY type`, predArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("overview: count by type: %w", err)
 	}
-	for _, r := range typeRows {
-		key := r.Type
-		if key == "" {
-			key = "unknown"
+	for typeRows.Next() {
+		var t string
+		var c int64
+		if err := typeRows.Scan(&t, &c); err != nil {
+			typeRows.Close()
+			return nil, fmt.Errorf("overview: scan type: %w", err)
 		}
-		dev.ByType[key] = r.Count
+		dev.ByType[t] = c
+	}
+	typeRows.Close()
+	if err := typeRows.Err(); err != nil {
+		return nil, fmt.Errorf("overview: type rows: %w", err)
 	}
 
 	// --- 3. by_location (raw GROUP BY — no sqlc query exists for it) ---
 	locRows, err := s.dbConn.QueryContext(ctx,
-		`SELECT COALESCE(NULLIF(location,''),'unknown') AS loc, COUNT(*) FROM devices GROUP BY loc`)
+		`SELECT COALESCE(NULLIF(location,''),'unknown') AS loc, COUNT(*) FROM devices WHERE `+pred+` GROUP BY loc`, predArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("overview: count by location: %w", err)
 	}
@@ -212,7 +241,7 @@ func (s *DashboardService) Overview(ctx context.Context) (*domain.DashboardOverv
 	}
 	out.Devices = dev
 
-	// --- 4. Recent scan tasks + runs + run-status distribution ---
+	// --- 4. Recent scan tasks + runs + run-status distribution (cross-network; NOT scoped) ---
 	scan, err := s.overviewScanning(ctx)
 	if err != nil {
 		return nil, err
@@ -220,11 +249,12 @@ func (s *DashboardService) Overview(ctx context.Context) (*domain.DashboardOverv
 	out.Scanning = scan
 
 	// --- 5. Abnormal device list (offline, most-recently-scanned first) ---
+	offlineArgs := append(append([]any{}, predArgs...), 10)
 	offline, err := s.dbConn.QueryContext(ctx, `
 		SELECT id, name, ip_address, type, status, last_scanned_at
-		FROM devices WHERE status='offline'
+		FROM devices WHERE status='offline' AND `+pred+`
 		ORDER BY COALESCE(last_scanned_at, '1970-01-01') DESC, id DESC
-		LIMIT 10`)
+		LIMIT ?`, offlineArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("overview: list offline: %w", err)
 	}

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -246,14 +246,23 @@ func (s *DeviceService) Delete(ctx context.Context, id int64) error {
 
 // GetStats returns device statistics grouped by status and type. When networkID
 // is non-nil the counts are scoped to that network (multi-LAN dashboards); nil
-// spans all networks.
-func (s *DeviceService) GetStats(ctx context.Context, networkID *int64) (*domain.DeviceStatsResponse, error) {
+// spans all networks. scope (#138 Phase 2b) is the authoritative object-level
+// boundary: a restricted scope filters to its granted networks (intersected with
+// networkID when both apply — a networkID outside the scope yields empty stats,
+// not a leak). A global scope leaves the networkID semantics unchanged.
+func (s *DeviceService) GetStats(ctx context.Context, networkID *int64, scope domain.Scope) (*domain.DeviceStatsResponse, error) {
 	var (
 		statusRows []db.CountByStatusRow
 		typeRows   []db.CountDevicesByTypeRow
 		err        error
 	)
-	if networkID != nil {
+
+	switch {
+	case !scope.IsGlobal() && networkID != nil && !scope.AllowsNetwork(*networkID):
+		// Requested a network outside the caller's scope → empty (zero counts,
+		// not a leak of existence).
+	case !scope.IsGlobal() && networkID != nil:
+		// One in-scope network: reuse the single-network repo path.
 		sRows, sErr := s.repo.CountByStatusForNetwork(ctx, networkID)
 		if sErr != nil {
 			return nil, fmt.Errorf("failed to get device stats: %w", sErr)
@@ -262,15 +271,38 @@ func (s *DeviceService) GetStats(ctx context.Context, networkID *int64) (*domain
 		if tErr != nil {
 			return nil, fmt.Errorf("failed to get device stats by type: %w", tErr)
 		}
-		// Normalize the network-scoped row types into the global shapes so the
-		// response assembly below is identical.
 		for _, r := range sRows {
 			statusRows = append(statusRows, db.CountByStatusRow(r))
 		}
 		for _, r := range tRows {
 			typeRows = append(typeRows, db.CountDevicesByTypeRow(r))
 		}
-	} else {
+	case !scope.IsGlobal():
+		// Restricted scope, no network picked → all granted networks.
+		statusRows, err = s.repo.CountByStatusScoped(ctx, scope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get device stats: %w", err)
+		}
+		typeRows, err = s.repo.CountByTypeScoped(ctx, scope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get device stats by type: %w", err)
+		}
+	case networkID != nil:
+		sRows, sErr := s.repo.CountByStatusForNetwork(ctx, networkID)
+		if sErr != nil {
+			return nil, fmt.Errorf("failed to get device stats: %w", sErr)
+		}
+		tRows, tErr := s.repo.CountByTypeForNetwork(ctx, networkID)
+		if tErr != nil {
+			return nil, fmt.Errorf("failed to get device stats by type: %w", tErr)
+		}
+		for _, r := range sRows {
+			statusRows = append(statusRows, db.CountByStatusRow(r))
+		}
+		for _, r := range tRows {
+			typeRows = append(typeRows, db.CountDevicesByTypeRow(r))
+		}
+	default:
 		statusRows, err = s.repo.CountByStatus(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get device stats: %w", err)

--- a/internal/service/device_repo.go
+++ b/internal/service/device_repo.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
 )
@@ -239,6 +240,52 @@ func (r *DeviceRepository) CountByTypeForNetwork(ctx context.Context, networkID 
 		return nil, fmt.Errorf("failed to count devices by type (network): %w", err)
 	}
 	return rows, nil
+}
+
+// CountByStatusScoped returns device counts grouped by status, restricted to the
+// networks in scope (object-level network scope, #138 Phase 2b). A global scope
+// returns counts across all networks. The returned row shape matches the global
+// CountByStatus so callers can treat them uniformly.
+func (r *DeviceRepository) CountByStatusScoped(ctx context.Context, scope domain.Scope) ([]db.CountByStatusRow, error) {
+	pred, args := scopeql.NetworkPredicate(scope, "")
+	rows, err := r.dbConn.QueryContext(ctx,
+		`SELECT status, COUNT(*) as count FROM devices WHERE `+pred+` GROUP BY status`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count devices by status (scoped): %w", err)
+	}
+	defer rows.Close()
+	out := make([]db.CountByStatusRow, 0)
+	for rows.Next() {
+		var row db.CountByStatusRow
+		if err := rows.Scan(&row.Status, &row.Count); err != nil {
+			return nil, fmt.Errorf("scan status (scoped): %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// CountByTypeScoped returns device counts grouped by type, restricted to the
+// networks in scope (#138 Phase 2b). A global scope returns counts across all
+// networks.
+func (r *DeviceRepository) CountByTypeScoped(ctx context.Context, scope domain.Scope) ([]db.CountDevicesByTypeRow, error) {
+	pred, args := scopeql.NetworkPredicate(scope, "")
+	rows, err := r.dbConn.QueryContext(ctx,
+		`SELECT COALESCE(NULLIF(type,''),'unknown') as type, COUNT(*) as count FROM devices WHERE `+
+			pred+` GROUP BY type`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count devices by type (scoped): %w", err)
+	}
+	defer rows.Close()
+	out := make([]db.CountDevicesByTypeRow, 0)
+	for rows.Next() {
+		var row db.CountDevicesByTypeRow
+		if err := rows.Scan(&row.Type, &row.Count); err != nil {
+			return nil, fmt.Errorf("scan type (scoped): %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
 }
 
 // sortWhitelist maps a client-supplied sort token to the real column name. Any

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -248,7 +248,7 @@ func TestDevice_GetStats(t *testing.T) {
 	_, err = db.Exec("UPDATE devices SET status = 'offline' WHERE name = 'Dev-B'")
 	require.NoError(t, err)
 
-	stats, err := svc.GetStats(ctx, nil)
+	stats, err := svc.GetStats(ctx, nil, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 

--- a/internal/service/export.go
+++ b/internal/service/export.go
@@ -11,6 +11,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -18,38 +19,108 @@ import (
 	"strconv"
 	"time"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 )
 
 const exportChunkSize = 1000
 
 // ExportService handles data export for devices, heartbeat results, and audit logs.
 type ExportService struct {
-	db *db.Queries // main DB (devices, audit logs)
-	hb *db.Queries // dedicated heartbeat store (heartbeat_results) — nil falls back to db
+	db     *db.Queries // main DB (devices, audit logs)
+	hb     *db.Queries // dedicated heartbeat store (heartbeat_results) — nil falls back to db
+	dbConn *sql.DB     // raw connection for the scope-restricted device export (closed mode)
 }
 
 // NewExportService creates a new ExportService bound to the main DB.
 // Heartbeat results are read from hb when set (the dedicated heartbeat store);
 // if hb is nil, heartbeat export falls back to the main DB (legacy behavior).
-func NewExportService(db *db.Queries, hb *db.Queries) *ExportService {
-	return &ExportService{db: db, hb: hb}
+// dbConn powers the object-scope device export path; it may be nil when scope is
+// never enforced.
+func NewExportService(db *db.Queries, hb *db.Queries, dbConn *sql.DB) *ExportService {
+	return &ExportService{db: db, hb: hb, dbConn: dbConn}
 }
 
-// Devices streams all device data in the specified format (csv or json).
-func (s *ExportService) Devices(ctx context.Context, format string, w io.Writer) error {
+// exportDevice is the flat row the device export emits (the subset of columns in
+// the export header), shared by the JSON and CSV streaming paths so the global
+// (sqlc) and scope-restricted (raw SQL) fetches map into one shape.
+type exportDevice struct {
+	ID          int64
+	Name        string
+	Type        string
+	Status      string
+	IPAddress   string
+	MACAddress  string
+	Brand       string
+	Model       string
+	Location    string
+	Purpose     string
+	Description string
+	Tags        string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// fetchDevices returns one export batch (ordered by id, paged by offset). A
+// global scope uses the sqlc ListDevices query (unchanged path); a restricted
+// scope filters to its granted networks via scopeql (#138 Phase 2b).
+func (s *ExportService) fetchDevices(ctx context.Context, offset int64, scope domain.Scope) ([]exportDevice, error) {
+	if scope.IsGlobal() {
+		rows, err := s.db.ListDevices(ctx, db.ListDevicesParams{
+			Column1: "",
+			Status:  "",
+			Column3: "",
+			Type:    "",
+			Limit:   exportChunkSize,
+			Offset:  offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := make([]exportDevice, len(rows))
+		for i, d := range rows {
+			out[i] = exportDevice{
+				ID: d.ID, Name: d.Name, Type: d.Type, Status: d.Status,
+				IPAddress: d.IpAddress, MACAddress: d.MacAddress, Brand: d.Brand,
+				Model: d.Model, Location: d.Location, Purpose: d.Purpose,
+				Description: d.Description, Tags: d.Tags,
+				CreatedAt: d.CreatedAt, UpdatedAt: d.UpdatedAt,
+			}
+		}
+		return out, nil
+	}
+
+	pred, args := scopeql.NetworkPredicate(scope, "")
+	args = append(args, exportChunkSize, offset)
+	rows, err := s.dbConn.QueryContext(ctx,
+		`SELECT id, name, type, status, ip_address, mac_address, brand, model, location, purpose, description, tags, created_at, updated_at `+
+			`FROM devices WHERE `+pred+` ORDER BY id LIMIT ? OFFSET ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]exportDevice, 0, exportChunkSize)
+	for rows.Next() {
+		var d exportDevice
+		if err := rows.Scan(&d.ID, &d.Name, &d.Type, &d.Status, &d.IPAddress, &d.MACAddress,
+			&d.Brand, &d.Model, &d.Location, &d.Purpose, &d.Description, &d.Tags,
+			&d.CreatedAt, &d.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// Devices streams all device data in the specified format (csv or json). scope
+// (#138 Phase 2b) restricts a closed-mode caller to their granted networks.
+func (s *ExportService) Devices(ctx context.Context, format string, w io.Writer, scope domain.Scope) error {
 	headers := []string{"id", "name", "type", "status", "ip_address", "mac_address", "brand", "model", "location", "purpose", "description", "tags", "created_at", "updated_at"}
 
 	if format == "json" {
 		return s.streamJSON(ctx, w, func(offset int64) ([]map[string]interface{}, error) {
-			rows, err := s.db.ListDevices(ctx, db.ListDevicesParams{
-				Column1: "",
-				Status:  "",
-				Column3: "",
-				Type:    "",
-				Limit:   exportChunkSize,
-				Offset:  offset,
-			})
+			rows, err := s.fetchDevices(ctx, offset, scope)
 			if err != nil {
 				return nil, err
 			}
@@ -60,8 +131,8 @@ func (s *ExportService) Devices(ctx context.Context, format string, w io.Writer)
 					"name":        d.Name,
 					"type":        d.Type,
 					"status":      d.Status,
-					"ip_address":  d.IpAddress,
-					"mac_address": d.MacAddress,
+					"ip_address":  d.IPAddress,
+					"mac_address": d.MACAddress,
 					"brand":       d.Brand,
 					"model":       d.Model,
 					"location":    d.Location,
@@ -78,14 +149,7 @@ func (s *ExportService) Devices(ctx context.Context, format string, w io.Writer)
 
 	// Default: CSV
 	return s.streamCSV(ctx, w, headers, func(offset int64) ([][]string, error) {
-		rows, err := s.db.ListDevices(ctx, db.ListDevicesParams{
-			Column1: "",
-			Status:  "",
-			Column3: "",
-			Type:    "",
-			Limit:   exportChunkSize,
-			Offset:  offset,
-		})
+		rows, err := s.fetchDevices(ctx, offset, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -96,8 +160,8 @@ func (s *ExportService) Devices(ctx context.Context, format string, w io.Writer)
 				d.Name,
 				d.Type,
 				d.Status,
-				d.IpAddress,
-				d.MacAddress,
+				d.IPAddress,
+				d.MACAddress,
 				d.Brand,
 				d.Model,
 				d.Location,

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
 
 	_ "modernc.org/sqlite"
 )
@@ -102,7 +103,7 @@ func setupExportTest(t *testing.T) (*ExportService, *sql.DB) {
 	require.NoError(t, err)
 
 	queries := db.New(dbConn)
-	svc := NewExportService(queries, nil) // nil hb → falls back to main DB (test uses one DB)
+	svc := NewExportService(queries, nil, dbConn) // nil hb → falls back to main DB (test uses one DB)
 	return svc, dbConn
 }
 
@@ -160,7 +161,7 @@ func TestExport_Devices_CSV(t *testing.T) {
 	exportSeedDevices(t, dbConn, 3)
 
 	var buf bytes.Buffer
-	err := svc.Devices(context.Background(), "csv", &buf)
+	err := svc.Devices(context.Background(), "csv", &buf, domain.Scope{Global: true})
 	require.NoError(t, err)
 
 	// Check UTF-8 BOM
@@ -196,7 +197,7 @@ func TestExport_Devices_JSON(t *testing.T) {
 	exportSeedDevices(t, dbConn, 2)
 
 	var buf bytes.Buffer
-	err := svc.Devices(context.Background(), "json", &buf)
+	err := svc.Devices(context.Background(), "json", &buf, domain.Scope{Global: true})
 	require.NoError(t, err)
 
 	// Should be a valid JSON array
@@ -211,7 +212,7 @@ func TestExport_Devices_Empty(t *testing.T) {
 	svc, _ := setupExportTest(t)
 
 	var buf bytes.Buffer
-	err := svc.Devices(context.Background(), "csv", &buf)
+	err := svc.Devices(context.Background(), "csv", &buf, domain.Scope{Global: true})
 	require.NoError(t, err)
 
 	// Should have BOM + header only
@@ -225,7 +226,7 @@ func TestExport_Devices_StreamChunks(t *testing.T) {
 	exportSeedDevices(t, dbConn, 2500)
 
 	var buf bytes.Buffer
-	err := svc.Devices(context.Background(), "csv", &buf)
+	err := svc.Devices(context.Background(), "csv", &buf, domain.Scope{Global: true})
 	require.NoError(t, err)
 
 	// Skip BOM and header
@@ -365,7 +366,7 @@ func TestExport_InvalidFormat_DefaultsToCSV(t *testing.T) {
 	exportSeedDevices(t, dbConn, 1)
 
 	var buf bytes.Buffer
-	err := svc.Devices(context.Background(), "yaml", &buf)
+	err := svc.Devices(context.Background(), "yaml", &buf, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.True(t, bytes.HasPrefix(buf.Bytes(), []byte{0xEF, 0xBB, 0xBF}), "invalid format should default to CSV")
 }


### PR DESCRIPTION
## 背景

#138 Phase 2（#229）把对象级 network scope 落到**设备域**（list / detail / sub-resource），closed-mode 只闭合了设备浏览面。本 PR 把 closed-mode 扩展到剩余的 inventory 读取面，让 MSP 多租户隔离真正闭环。

## 改动

| 读取面 | 路由 | 实现 |
|---|---|---|
| 拓扑图 | `GET /topology` | 节点按 `network_id` 过滤、边按存活节点过滤（in-Go） |
| 变更历史 | `GET /changes` | raw SQL 范围查询（sqlc 无法表达变长 IN-list） |
| 变更 SSE | `GET /changes/watch` | 按事件 `network_id` 逐条丢弃越权事件 |
| Dashboard 总览 | `GET /dashboard/overview` | 设备聚合（status/type/location/offline）走 `scopeql` 谓词 |
| 设备统计 | `GET /devices/stats` | repo 新增 `CountByStatusScoped` / `CountByTypeScoped` |
| 设备导出 | `GET /devices/export` | `ExportService` 走 `scopeql` raw SQL 范围导出 |

**新增** `internal/authz/scopeql`（`NetworkPredicate`：global→`1=1` / 受限非空→`IN(...)` / 受限空→`0`）—— changes / dashboard / stats / export 共享的「受限 + 无授权 = 看不到」单一事实来源（device list 自身的并行实现保留不动）。所有新增面挂在 `NetworkScope` 中间件后，scope 从 context 注入；`ScopeFromContext` 默认 Global，所以漏接线的面 fail-open（不会被误锁）。

## 仍未筛（Phase 2c）

- **scanner results/runs/tasks**：`scan_results` 无 `network_id` 列，需 schema 迁移。
- **dashboard recent-scan 段**：跨网元数据，保留不筛（同上）。
- **audit_logs**：跨网系统日志，无 `network_id`，按系统语义保留。

`config.example.yaml` 的 closed-mode 注释已同步更新为当前覆盖面。

## 测试

- `scope_isolation_test` 新增 `TestScope_ClosedMode_ReadSurfacesScoped`：topology / changes / dashboard / stats / export 五面，viewer（grant net1）只见 net1、admin 见全部。
- `go vet` / `gofmt` / `goimports` / `go test ./...` 全绿。

## 关联

- 依赖栈：#227 → #228 → #229 → #230 → **本 PR**（base = #230）。
- 纯后端，无需浏览器测试。

Closes #138 Phase 2b.