### PR TITLE
feat(web): 用户网络作用域授权管理 UI（#138 Phase 3 前端）

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -686,7 +686,16 @@
 		"Password Reset Success": "Password reset successfully. The user must change it on next login.",
 		"Password Required": "Password is required",
 		"Created": "User created",
-		"Deleted": "User deleted"
+		"Deleted": "User deleted",
+		"Network Scope": "Network Scope",
+		"Network Scope Help": "In closed mode, this user sees only the networks granted below (admin always bypasses scope). Has no effect in open mode.",
+		"No Grants": "No networks granted — in closed mode this user sees nothing.",
+		"Grant Network": "Grant network",
+		"Select Network": "Select a network…",
+		"Add": "Add",
+		"Grant Added": "Network grant added",
+		"Grant Removed": "Network grant removed",
+		"All Networks Granted": "All networks are already granted."
 	},
 	"notifications": {
 		"Notifications": "Notifications",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -686,7 +686,16 @@
 		"Password Reset Success": "密码重置成功，用户下次登录时需要修改密码",
 		"Password Required": "密码为必填项",
 		"Created": "用户已创建",
-		"Deleted": "用户已删除"
+		"Deleted": "用户已删除",
+		"Network Scope": "网络作用域",
+		"Network Scope Help": "在 closed 模式下，此用户只能看到下方授权的网络（管理员始终不受作用域限制）。在 open 模式下无效。",
+		"No Grants": "未授权任何网络——在 closed 模式下此用户什么都看不到。",
+		"Grant Network": "授权网络",
+		"Select Network": "选择网络…",
+		"Add": "添加",
+		"Grant Added": "已添加网络授权",
+		"Grant Removed": "已移除网络授权",
+		"All Networks Granted": "所有网络均已授权。"
 	},
 	"notifications": {
 		"Notifications": "通知管理",

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -25,7 +25,7 @@
 	import Pagination from '$lib/components/Pagination.svelte';
 	import PageSkeleton from '$lib/components/PageSkeleton.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
-	import { Users as UsersIcon } from '@lucide/svelte';
+	import { Users as UsersIcon, X } from '@lucide/svelte';
 
 	interface User {
 		id: number;
@@ -33,6 +33,21 @@
 		email: string;
 		role: string;
 		created_at: string;
+	}
+
+	// Network reference + grant row for the per-user object-scope modal (#138
+	// Phase 3). Grants are an immediate-CRUD resource (POST/DELETE
+	// /network-grants), so each add/remove applies at once — no Save/discard.
+	interface NetworkRef {
+		id: number;
+		name: string;
+		cidr?: string;
+	}
+	interface Grant {
+		id: number;
+		user_id: number;
+		network_id: number;
+		granted_at: string;
 	}
 
 	let users = $state<User[]>([]);
@@ -256,6 +271,75 @@
 		fetchUsers();
 	}
 
+	// --- Network scope grants (#138 Phase 3) ---
+	let scopeTarget = $state<User | null>(null);
+	let scopeModalOpen = $state(false);
+	let grants = $state<Grant[]>([]);
+	let networks = $state<NetworkRef[]>([]);
+	let scopeLoading = $state(false);
+	let addNetworkId = $state<number | null>(null);
+	let grantBusy = $state(false);
+
+	// Networks the target already holds — the add-dropdown omits these.
+	let grantedNetIds = $derived(new Set(grants.map((g) => g.network_id)));
+	let availableNetworks = $derived(networks.filter((n) => !grantedNetIds.has(n.id)));
+
+	function networkLabel(id: number): string {
+		const n = networks.find((x) => x.id === id);
+		return n ? (n.cidr ? `${n.name} (${n.cidr})` : n.name) : `#${id}`;
+	}
+
+	async function openScope(user: User) {
+		scopeTarget = user;
+		scopeModalOpen = true;
+		addNetworkId = null;
+		grants = [];
+		networks = [];
+		scopeLoading = true;
+		try {
+			const [grantRes, netRes] = await Promise.all([
+				api.get<{ grants: Grant[] }>(`/users/${user.id}/network-grants`),
+				api.get<NetworkRef[]>('/networks')
+			]);
+			grants = grantRes.grants || [];
+			networks = netRes || [];
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+		} finally {
+			scopeLoading = false;
+		}
+	}
+
+	async function addGrant() {
+		if (!scopeTarget || addNetworkId === null) return;
+		grantBusy = true;
+		try {
+			await api.post('/network-grants', {
+				user_id: scopeTarget.id,
+				network_id: addNetworkId
+			});
+			addToast('success', m["users.Grant Added"]());
+			addNetworkId = null;
+			const res = await api.get<{ grants: Grant[] }>(`/users/${scopeTarget.id}/network-grants`);
+			grants = res.grants || [];
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+		} finally {
+			grantBusy = false;
+		}
+	}
+
+	async function removeGrant(id: number) {
+		if (!scopeTarget) return;
+		try {
+			await api.delete(`/network-grants/${id}`);
+			addToast('success', m["users.Grant Removed"]());
+			grants = grants.filter((g) => g.id !== id);
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+		}
+	}
+
 	// Admin-only guard
 	let isAdmin = $derived($auth.user?.role === 'admin');
 
@@ -367,6 +451,12 @@
 								{@const user = users.find((u) => u.id === row.id)}
 								{#if user}
 									<div class="flex items-center gap-2">
+										{#if user.role !== 'admin'}
+											<button
+												onclick={() => openScope(user)}
+												class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10 transition-colors"
+											>{m["users.Network Scope"]()}</button>
+										{/if}
 										<button
 											onclick={() => openReset(user)}
 											class="text-xs px-2 py-1 rounded text-primary hover:bg-primary/10 transition-colors"
@@ -532,4 +622,81 @@
 			</button>
 		</div>
 	</form>
+</Modal>
+
+<!-- Network Scope (grants) Modal — manage a user's object-level network grants -->
+<Modal
+	bind:open={scopeModalOpen}
+	title={scopeTarget ? `${m["users.Network Scope"]()} — ${scopeTarget.username}` : m["users.Network Scope"]()}
+	maxWidth="34rem"
+>
+	<div class="space-y-4">
+		<p class="text-xs text-text-muted">{m["users.Network Scope Help"]()}</p>
+
+		{#if scopeLoading}
+			<p class="text-sm text-text-muted">{m["common.Loading"]()}</p>
+		{:else}
+			<!-- Current grants -->
+			{#if grants.length === 0}
+				<p class="text-xs italic text-text-muted">{m["users.No Grants"]()}</p>
+			{:else}
+				<div class="space-y-2">
+					{#each grants as g (g.id)}
+						<div class="flex items-center justify-between px-3 py-2 bg-bg border border-border rounded-lg">
+							<span class="text-sm text-text">{networkLabel(g.network_id)}</span>
+							<button
+								onclick={() => removeGrant(g.id)}
+								class="text-error hover:bg-error/10 rounded p-1 transition-colors"
+								title={m["common.Delete"]()}
+								aria-label={m["common.Delete"]()}
+							>
+								<X class="w-4 h-4" />
+							</button>
+						</div>
+					{/each}
+				</div>
+			{/if}
+
+			<!-- Add grant -->
+			<div class="pt-2 border-t border-border">
+				{#if availableNetworks.length > 0}
+					<div class="flex items-end gap-2">
+						<div class="flex-1">
+							<label class="block text-xs text-text-muted mb-1">{m["users.Grant Network"]()}</label>
+							<select
+								bind:value={addNetworkId}
+								class="w-full px-3 py-2 bg-bg border border-border rounded-lg text-sm text-text
+									focus:border-primary focus:outline-none"
+							>
+								<option value={null}>{m["users.Select Network"]()}</option>
+								{#each availableNetworks as n (n.id)}
+									<option value={n.id}>{n.name}{n.cidr ? ` (${n.cidr})` : ''}</option>
+								{/each}
+							</select>
+						</div>
+						<LoadingButton
+							type="button"
+							loading={grantBusy}
+							disabled={addNetworkId === null}
+							variant="primary"
+							label={m["users.Add"]()}
+							onclick={addGrant}
+						/>
+					</div>
+				{:else if grants.length > 0}
+					<p class="text-xs text-text-muted">{m["users.All Networks Granted"]()}</p>
+				{/if}
+			</div>
+		{/if}
+
+		<div class="flex justify-end pt-2">
+			<button
+				type="button"
+				onclick={() => { scopeModalOpen = false; scopeTarget = null; }}
+				class="btn btn-secondary"
+			>
+				{m["common.Close"]()}
+			</button>
+		</div>
+	</div>
 </Modal>


### PR DESCRIPTION
## 背景

#230 落了 grants 管理 API（`GET /users/{id}/network-grants`、`POST/DELETE /network-grants`）。本 PR 补前端：让 admin 在用户管理页给非 admin 用户管理可见的网络集合（对象级 network scope 的管理面）。

## 改动

用户管理页（`web/src/routes/users/+page.svelte`）新增「网络作用域」入口：

- **入口**：每行操作列新增「网络作用域」按钮，**仅对非 admin 用户显示**（admin 始终绕过作用域，给它授权无意义）。
- **弹窗**：`Modal`「网络作用域 — {username}」，含 closed-mode 语义说明。
  - 列出当前授权（network 名 + 移除按钮）；空态提示「closed 模式下看不到任何网络」。
  - 下拉选择未授权网络 + 添加按钮；**已授权网络自动从下拉剔除**（`availableNetworks` derived）。
  - 每次增删即时落库（`POST/DELETE /network-grants`，解析器缓存即时失效）——无 Save/discard，操作即生效。
- 复用 house style：`Modal` + `LoadingButton` + `addToast`；i18n 走 paraglide（`en.json`/`zh.json` 新增 `users.*` 9 个 key）。

## 行为

- **open 模式（默认）**：授权可增删但不强制（向后兼容，无行为变化）。
- **closed 模式**：授权即生效——用户只能看到已授权网络的设备/拓扑/变更/dashboard/统计/导出（见 #231）。

## 验证

- `npm run build` ✅、`npm test`（Vitest 195）✅。
- **浏览器实测**（部署全栈到 63.101）：
  - viewer 行显示「网络作用域」按钮，admin 行不显示 ✅
  - 弹窗打开 → 添加 lan-63 授权（API 落库 + 下拉剔除 lan-63）✅
  - 移除授权（API 清空 + 下拉恢复 lan-63）✅
  - 全程无 console error ✅

## 关联

依赖 #230 grants API；base = #231（线性栈 #227→#228→#229→#230→#231→**本 PR**）。

Closes #138 Phase 3 前端.