### PR TITLE
feat(rbac): scanner 面对象级作用域 — scan_tasks.network_id（#138 Phase 2c）

### DIFF
--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	dbsql "mibee-steward/db"
+	"mibee-steward/internal/service/scannerv2/taskservice"
 )
 
 func runMigrations(db *sql.DB, dbPath string) error {
@@ -114,6 +115,11 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		// snmp_credentials table itself is created via schema.sql's CREATE TABLE
 		// IF NOT EXISTS above (run before this loop), so the FK target exists.
 		"ALTER TABLE scan_tasks ADD COLUMN credential_id INTEGER REFERENCES snmp_credentials(id) ON DELETE SET NULL",
+		// Object-level scope key for the scanner surfaces (#138 Phase 2c).
+		// Nullable; stamped at task create/update when the targets resolve to a
+		// single networks.cidr, and backfilled below. Runs and results scope
+		// through their task — they carry no network_id of their own.
+		"ALTER TABLE scan_tasks ADD COLUMN network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL",
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m); err != nil {
@@ -247,6 +253,19 @@ func runMigrations(db *sql.DB, dbPath string) error {
 	// Purely additive — no route grants the new roles new access yet.
 	if err := extendUsersRoleCheck(context.Background(), db); err != nil {
 		return fmt.Errorf("users role-check migration: %w", err)
+	}
+
+	// #138 Phase 2c: backfill scan_tasks.network_id from targets→networks.cidr
+	// so existing tasks slot into the object-level scope. Idempotent —
+	// unresolvable tasks (multi-CIDR/range/hostname targets) stay NULL on
+	// every run, harmlessly. The network_id index is created here too (after
+	// the ALTER above), not in schema.sql — on old DBs scan_tasks lacks the
+	// column until this point, so an index in schema.sql would fail to apply.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_scan_tasks_network ON scan_tasks(network_id)`); err != nil {
+		return fmt.Errorf("scan-tasks network index: %w", err)
+	}
+	if err := backfillScanTaskNetworks(context.Background(), db); err != nil {
+		return fmt.Errorf("scan-task network backfill: %w", err)
 	}
 
 	// Distributed-identity index migration: replace the legacy global-unique
@@ -595,6 +614,61 @@ func extendUsersRoleCheck(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("commit role-check rebuild: %w", err)
 	}
 	slog.Info("users role CHECK widened (operator, viewer added)")
+	return nil
+}
+
+// backfillScanTaskNetworks resolves scan_tasks.network_id for existing tasks
+// (#138 Phase 2c): each NULL-network task's targets go through the same
+// ResolveNetworkFromTargets the create/update path uses — a single CIDR
+// exactly matching a networks.cidr resolves to that network's id; anything
+// else (multi-CIDR lists, IP ranges, hostnames, no match) stays NULL, which
+// means cross-network/unresolved (admins see it, restricted scopes don't).
+// Idempotent: resolvable rows are stamped once; the rest re-resolve cheaply
+// on every startup (scan_tasks is a small table).
+func backfillScanTaskNetworks(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, `SELECT id, targets FROM scan_tasks WHERE network_id IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select scan_tasks for network backfill: %w", err)
+	}
+	type pending struct {
+		id      int64
+		targets string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.targets); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan scan_tasks row for network backfill: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate scan_tasks for network backfill: %w", err)
+	}
+
+	stamped := 0
+	for _, p := range batch {
+		netID, err := taskservice.ResolveNetworkFromTargets(ctx, db, p.targets)
+		if err != nil {
+			// Best-effort by design: a failed lookup leaves the task NULL
+			// (unscoped) rather than failing the whole migration.
+			slog.Warn("scan-task network backfill: resolve failed", "task_id", p.id, "error", err)
+			continue
+		}
+		if !netID.Valid {
+			continue
+		}
+		if _, err := db.ExecContext(ctx,
+			`UPDATE scan_tasks SET network_id = ? WHERE id = ?`, netID.Int64, p.id); err != nil {
+			return fmt.Errorf("stamp scan_task %d network: %w", p.id, err)
+		}
+		stamped++
+	}
+	if stamped > 0 {
+		slog.Info("scan_tasks network_id backfilled", "tasks", stamped)
+	}
 	return nil
 }
 

--- a/cmd/server/migrations_test.go
+++ b/cmd/server/migrations_test.go
@@ -146,3 +146,74 @@ func TestExtendUsersRoleCheck_RebuildsFromNarrowCheck(t *testing.T) {
 	// Idempotent: re-running is a no-op (the probe short-circuits).
 	require.NoError(t, extendUsersRoleCheck(ctx, db))
 }
+
+// TestBackfillScanTaskNetworks verifies the #138 Phase 2c migration: an
+// old-shape scan_tasks table (no network_id column) gets the column added by
+// runMigrations, and existing tasks are backfilled — a single-CIDR targets
+// string exactly matching a networks.cidr resolves to that network, while
+// multi-CIDR/unmatched targets stay NULL (cross-network).
+func TestBackfillScanTaskNetworks(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "backfill.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	// Old shape: scan_tasks WITHOUT network_id (pre-2c). runMigrations adds it.
+	_, err = db.Exec(`CREATE TABLE scan_tasks (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		targets TEXT NOT NULL,
+		cron_expr TEXT NOT NULL DEFAULT '0 */6 * * *',
+		pipeline_config TEXT NOT NULL DEFAULT '{}',
+		global_labels TEXT NOT NULL DEFAULT '{}',
+		timeout INTEGER NOT NULL DEFAULT 300,
+		concurrent_hosts INTEGER NOT NULL DEFAULT 50,
+		enabled INTEGER NOT NULL DEFAULT 1,
+		last_run_at TIMESTAMP,
+		next_run_at TIMESTAMP,
+		last_run_status TEXT,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`)
+	require.NoError(t, err)
+	// networks + three tasks: single-CIDR match, non-canonical raw match, and
+	// a multi-CIDR cross-network task.
+	_, err = db.Exec(`CREATE TABLE networks (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL UNIQUE,
+		cidr TEXT,
+		site TEXT,
+		agent_id TEXT,
+		metadata TEXT NOT NULL DEFAULT '{}',
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO networks (id, name, cidr) VALUES
+		(1, 'lan-1', '10.0.1.0/24'),
+		(2, 'lan-2', '10.0.2.0/24')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO scan_tasks (id, name, targets) VALUES
+		(1, 'task-match', '10.0.1.0/24'),
+		(2, 'task-multi', '10.0.1.0/24,10.0.2.0/24'),
+		(3, 'task-nomatch', '172.16.0.0/24')`)
+	require.NoError(t, err)
+
+	require.NoError(t, runMigrations(db, dbPath))
+
+	var net1, net2, net3 sql.NullInt64
+	require.NoError(t, db.QueryRow(`SELECT network_id FROM scan_tasks WHERE id = 1`).Scan(&net1))
+	require.NoError(t, db.QueryRow(`SELECT network_id FROM scan_tasks WHERE id = 2`).Scan(&net2))
+	require.NoError(t, db.QueryRow(`SELECT network_id FROM scan_tasks WHERE id = 3`).Scan(&net3))
+	require.True(t, net1.Valid, "single-CIDR task must resolve to its network")
+	require.EqualValues(t, 1, net1.Int64)
+	require.False(t, net2.Valid, "multi-CIDR task stays NULL (cross-network)")
+	require.False(t, net3.Valid, "unmatched CIDR stays NULL")
+
+	// Idempotent: re-running keeps the same values.
+	require.NoError(t, backfillScanTaskNetworks(ctx, db))
+	require.NoError(t, db.QueryRow(`SELECT network_id FROM scan_tasks WHERE id = 1`).Scan(&net1))
+	require.EqualValues(t, 1, net1.Int64)
+}

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -65,11 +65,15 @@ rbac:
   # (GET/PUT/DELETE /devices/{id} and /devices/{id}/{neighbors,certificates,
   # configs,systems,heartbeat-*,documents}), device STATS (GET /devices/stats),
   # device EXPORT (GET /devices/export), the TOPOLOGY graph (GET /topology), the
-  # CHANGE log list + SSE stream (GET /changes, /changes/watch), and the
-  # DASHBOARD overview device aggregates (GET /dashboard/overview) all enforce
-  # the granted-network set. The dashboard's recent-scan-activity section and
-  # scanner results/runs/tasks are NOT yet network-scoped (#138 Phase 2c — the
-  # scanner tables lack a network_id column) and remain visible across networks.
+  # CHANGE log list + SSE stream (GET /changes, /changes/watch), the DASHBOARD
+  # overview (device aggregates + scan-activity section), and the SCANNER read
+  # surfaces (tasks/runs/results lists, details and export — scoped via
+  # scan_tasks.network_id, resolved from a task's single-CIDR targets). Tasks
+  # whose targets don't resolve to one network (multi-CIDR/range/hostname) are
+  # cross-network: visible to admins, hidden from restricted scopes. Audit logs
+  # are deliberately NOT network-scoped (cross-network system log of user
+  # actions). Scanner writes (task CRUD/trigger) stay capability-gated — grants
+  # isolate visibility, not operation.
   scope_default: "open"
 
 auth:

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -352,6 +352,14 @@ CREATE TABLE IF NOT EXISTS scan_tasks (
     -- v3 credential. Added by issue #135 (SNMPv3); backfilled onto existing
     -- DBs by the runMigrations ALTER TABLE below.
     credential_id INTEGER REFERENCES snmp_credentials(id) ON DELETE SET NULL,
+    -- network_id: the object-level network this task's targets resolve to
+    -- (#138 Phase 2c). Stamped at task create/update when the targets are a
+    -- single CIDR exactly matching a networks.cidr row; NULL = cross-network
+    -- or unresolved (visible to admins, hidden from restricted scopes).
+    -- Runs (scan_task_runs) and results (scan_results) scope through their
+    -- task via this column — they have no network_id of their own. Backfilled
+    -- onto existing DBs by runMigrations.
+    network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL,
     enabled INTEGER NOT NULL DEFAULT 1,
     last_run_at TIMESTAMP,
     next_run_at TIMESTAMP,
@@ -359,6 +367,9 @@ CREATE TABLE IF NOT EXISTS scan_tasks (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+-- idx_scan_tasks_network is created by runMigrations (after the ALTER that adds
+-- network_id to pre-existing tables) — creating it here would fail on old DBs
+-- where CREATE TABLE IF NOT EXISTS leaves scan_tasks without the column.
 
 CREATE TABLE IF NOT EXISTS scan_results (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/api/handler/scanner_result.go
+++ b/internal/api/handler/scanner_result.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
 )
@@ -48,6 +49,25 @@ var scanResultSortWhitelist = map[string]string{
 	"ip":     "ip",
 	"status": "alive",                    // the "Status" column reflects the alive flag
 	"ports":  "json_array_length(ports)", // the "Ports Count" column renders ports.length
+}
+
+// taskInScope reports whether the given scan task's network falls within the
+// caller's object-level scope (#138 Phase 2c). Global scopes always pass; a
+// restricted scope passes only when the task carries a resolved network_id in
+// the granted set (NULL = cross-network → hidden). A missing task returns
+// false — callers map that onto their not-found path (404) so out-of-scope
+// resources are indistinguishable from absent ones.
+func (h *ScannerResultHandler) taskInScope(ctx context.Context, taskID int64, scope domain.Scope) bool {
+	if scope.IsGlobal() {
+		return true
+	}
+	var netID sql.NullInt64
+	err := h.conn.QueryRowContext(ctx,
+		`SELECT network_id FROM scan_tasks WHERE id = ?`, taskID).Scan(&netID)
+	if err != nil {
+		return false
+	}
+	return netID.Valid && scope.AllowsNetwork(netID.Int64)
 }
 
 // ListResults handles GET /api/v1/scanner/results
@@ -96,10 +116,30 @@ func (h *ScannerResultHandler) ListResults(w http.ResponseWriter, r *http.Reques
 	sortBy := q.Get("sort")
 	order := q.Get("order")
 
+	// Object-level scope (#138 Phase 2c): a restricted caller's results list
+	// joins scan_tasks and keeps only rows whose task network is in the granted
+	// set (task with NULL network = cross-network → hidden).
+	scope := domain.ScopeFromContext(r.Context())
+
 	var (
 		results []db.ScanResult
 		err     error
 	)
+	if !scope.IsGlobal() {
+		var total int64
+		results, total, err = h.listResultsScoped(r.Context(), scope, taskID, ipFilter,
+			aliveSentinel, aliveVal, sortBy, order, limit, offset)
+		if err != nil {
+			slog.Error("scoped ListScanResults failed", "task_id", taskID, "ip", ipFilter, "error", err)
+			Error(w, http.StatusInternalServerError, "failed to list scan results")
+			return
+		}
+		Success(w, domain.ScanResultListResponse{
+			Results: toScanResultResponses(results),
+			Total:   int(total),
+		})
+		return
+	}
 	if sortBy != "" {
 		results, err = h.listResultsSorted(r.Context(), taskID, ipFilter, aliveSentinel, aliveVal, sortBy, order, limit, offset)
 	} else {
@@ -219,6 +259,81 @@ func (h *ScannerResultHandler) listResultsSorted(
 	return items, rows.Err()
 }
 
+// listResultsScoped is the restricted-scope variant of ListResults +
+// CountScanResults + listResultsSorted combined: it joins scan_tasks and ANDs
+// the scope predicate into the same filters (task/ip/alive), supports the same
+// whitelist-controlled sort tokens (empty sortBy = default scanned_at DESC),
+// and returns the page + total so pagination totals match the visible set.
+// SELECT column order MUST match db.ScanResult's Scan order.
+func (h *ScannerResultHandler) listResultsScoped(
+	ctx context.Context, scope domain.Scope,
+	taskID int64, ipFilter string, aliveSentinel, aliveVal int64,
+	sortBy, order string, limit, offset int64,
+) ([]db.ScanResult, int64, error) {
+	pred, predArgs := scopeql.NetworkPredicate(scope, "t")
+
+	col := "scanned_at"
+	if c, ok := scanResultSortWhitelist[sortBy]; ok {
+		col = c
+	}
+	dir := "ASC"
+	if order == "desc" || sortBy == "" {
+		// No sort token → the sqlc default (scanned_at DESC); explicit desc
+		// → DESC; explicit asc → ASC.
+		dir = "DESC"
+	}
+
+	where := `FROM scan_results r JOIN scan_tasks t ON r.task_id = t.id
+		WHERE ` + pred + `
+		  AND (? = 0 OR r.task_id = ?)
+		  AND (? = '' OR r.ip LIKE ?)
+		  AND (? < 0 OR r.alive = ?)`
+
+	filterArgs := append(append([]any{}, predArgs...),
+		taskID, taskID,
+		ipFilter, ipFilter,
+		aliveSentinel, aliveVal)
+
+	var total int64
+	if err := h.conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) `+where, filterArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := h.conn.QueryContext(ctx,
+		`SELECT r.id, r.task_id, r.run_id, r.ip, r.alive, r.rtt_ms, r.ports, r.services, r.snmp_data,
+			r.prometheus_detected, r.prometheus_url, r.node_exporter_detected, r.node_exporter_url, r.node_exporter_data, r.scanned_at `+
+			where+` ORDER BY `+col+` `+dir+` LIMIT ? OFFSET ?`,
+		append(append([]any{}, filterArgs...), limit, offset)...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	items := []db.ScanResult{}
+	for rows.Next() {
+		var i db.ScanResult
+		if err := rows.Scan(
+			&i.ID, &i.TaskID, &i.RunID, &i.Ip, &i.Alive, &i.RttMs, &i.Ports,
+			&i.Services, &i.SnmpData, &i.PrometheusDetected, &i.PrometheusUrl,
+			&i.NodeExporterDetected, &i.NodeExporterUrl, &i.NodeExporterData, &i.ScannedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		items = append(items, i)
+	}
+	return items, total, rows.Err()
+}
+
+// toScanResultResponses converts a batch of db.ScanResult rows.
+func toScanResultResponses(results []db.ScanResult) []domain.ScanResultResponse {
+	resp := make([]domain.ScanResultResponse, 0, len(results))
+	for _, r := range results {
+		resp = append(resp, toScanResultResponse(r))
+	}
+	return resp
+}
+
 // GetResult handles GET /api/v1/scanner/results/{id}
 func (h *ScannerResultHandler) GetResult(w http.ResponseWriter, r *http.Request) {
 	id, err := parseScanID(w, r)
@@ -236,6 +351,12 @@ func (h *ScannerResultHandler) GetResult(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Out-of-scope results are indistinguishable from absent ones (#138 2c).
+	if !h.taskInScope(r.Context(), result.TaskID, domain.ScopeFromContext(r.Context())) {
+		Error(w, http.StatusNotFound, "scan result not found")
+		return
+	}
+
 	Success(w, toScanResultResponse(result))
 }
 
@@ -249,6 +370,23 @@ func (h *ScannerResultHandler) ListRuns(w http.ResponseWriter, r *http.Request) 
 	var taskID int64
 	if q.Get("task_id") != "" {
 		taskID, _ = strconv.ParseInt(q.Get("task_id"), 10, 64)
+	}
+
+	// Object-level scope (#138 Phase 2c): the restricted runs list joins
+	// scan_tasks and keeps only runs whose task network is in the granted set.
+	scope := domain.ScopeFromContext(r.Context())
+	if !scope.IsGlobal() {
+		runs, total, err := h.listRunsScoped(r.Context(), scope, taskID, limit, offset)
+		if err != nil {
+			Error(w, http.StatusInternalServerError, "failed to list scan task runs")
+			return
+		}
+		resp := make([]domain.ScanRunResponse, 0, len(runs))
+		for _, run := range runs {
+			resp = append(resp, toScanRunResponse(run))
+		}
+		Success(w, domain.ScanRunListResponse{Runs: resp, Total: int(total)})
+		return
 	}
 
 	runs, err := h.queries.ListScanTaskRuns(r.Context(), db.ListScanTaskRunsParams{
@@ -303,7 +441,57 @@ func (h *ScannerResultHandler) GetRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Out-of-scope runs are indistinguishable from absent ones (#138 2c).
+	if !h.taskInScope(r.Context(), run.TaskID, domain.ScopeFromContext(r.Context())) {
+		Error(w, http.StatusNotFound, "scan task run not found")
+		return
+	}
+
 	Success(w, toScanRunResponse(run))
+}
+
+// listRunsScoped mirrors ListScanTaskRuns/CountScanTaskRuns with the
+// network-scope predicate joined through scan_tasks. SELECT column order MUST
+// match db.ScanTaskRun's Scan order.
+func (h *ScannerResultHandler) listRunsScoped(
+	ctx context.Context, scope domain.Scope, taskID, limit, offset int64,
+) ([]db.ScanTaskRun, int64, error) {
+	pred, predArgs := scopeql.NetworkPredicate(scope, "t")
+
+	where := `FROM scan_task_runs r JOIN scan_tasks t ON r.task_id = t.id
+		WHERE ` + pred + ` AND (? = 0 OR r.task_id = ?)`
+
+	filterArgs := append(append([]any{}, predArgs...), taskID, taskID)
+
+	var total int64
+	if err := h.conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) `+where, filterArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := h.conn.QueryContext(ctx,
+		`SELECT r.id, r.task_id, r.status, r.total_hosts, r.alive_hosts, r.new_hosts, r.updated_hosts,
+			r.duration_ms, r.error_message, r.started_at, r.finished_at, r.created_at `+
+			where+` ORDER BY r.id DESC LIMIT ? OFFSET ?`,
+		append(append([]any{}, filterArgs...), limit, offset)...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	runs := []db.ScanTaskRun{}
+	for rows.Next() {
+		var run db.ScanTaskRun
+		if err := rows.Scan(
+			&run.ID, &run.TaskID, &run.Status, &run.TotalHosts, &run.AliveHosts,
+			&run.NewHosts, &run.UpdatedHosts, &run.DurationMs, &run.ErrorMessage,
+			&run.StartedAt, &run.FinishedAt, &run.CreatedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, total, rows.Err()
 }
 
 // BulkDeleteResults handles DELETE /api/v1/scanner/results
@@ -351,6 +539,12 @@ func (h *ScannerResultHandler) ExportScanResults(w http.ResponseWriter, r *http.
 	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
 	if err != nil || taskID <= 0 {
 		Error(w, http.StatusBadRequest, "invalid task_id")
+		return
+	}
+
+	// Out-of-scope exports are indistinguishable from absent tasks (#138 2c).
+	if !h.taskInScope(r.Context(), taskID, domain.ScopeFromContext(r.Context())) {
+		Error(w, http.StatusNotFound, "scan task not found")
 		return
 	}
 

--- a/internal/api/handler/scanner_task.go
+++ b/internal/api/handler/scanner_task.go
@@ -56,7 +56,7 @@ func (h *ScannerTaskHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
 	search := q.Get("search")
 
-	tasks, total, err := h.service.ListTasks(r.Context(), search, int(limit), int(offset))
+	tasks, total, err := h.service.ListTasks(r.Context(), search, int(limit), int(offset), domain.ScopeFromContext(r.Context()))
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "failed to list scan tasks")
 		return
@@ -75,7 +75,7 @@ func (h *ScannerTaskHandler) GetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.service.GetTask(r.Context(), id)
+	resp, err := h.service.GetTask(r.Context(), id, domain.ScopeFromContext(r.Context()))
 	if err != nil {
 		if errors.Is(err, taskservice.ErrScanTaskNotFound) {
 			Error(w, http.StatusNotFound, "scan task not found")
@@ -199,8 +199,12 @@ func (h *ScannerTaskHandler) GetTaskRuns(w http.ResponseWriter, r *http.Request)
 	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
 
-	runs, total, err := h.service.GetTaskRuns(r.Context(), int(id), int(limit), int(offset))
+	runs, total, err := h.service.GetTaskRuns(r.Context(), int(id), int(limit), int(offset), domain.ScopeFromContext(r.Context()))
 	if err != nil {
+		if errors.Is(err, taskservice.ErrScanTaskNotFound) {
+			Error(w, http.StatusNotFound, "scan task not found")
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to list scan task runs")
 		return
 	}
@@ -222,8 +226,12 @@ func (h *ScannerTaskHandler) GetTaskResults(w http.ResponseWriter, r *http.Reque
 	limit, _ := strconv.ParseInt(q.Get("limit"), 10, 64)
 	offset, _ := strconv.ParseInt(q.Get("offset"), 10, 64)
 
-	results, total, err := h.service.GetTaskResults(r.Context(), int(id), int(limit), int(offset))
+	results, total, err := h.service.GetTaskResults(r.Context(), int(id), int(limit), int(offset), domain.ScopeFromContext(r.Context()))
 	if err != nil {
+		if errors.Is(err, taskservice.ErrScanTaskNotFound) {
+			Error(w, http.StatusNotFound, "scan task not found")
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to list scan task results")
 		return
 	}

--- a/internal/api/handler/scanner_task_test.go
+++ b/internal/api/handler/scanner_task_test.go
@@ -33,7 +33,7 @@ func setupScannerTaskHandler(t *testing.T) (*ScannerTaskHandler, *db.Queries) {
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 	queries := db.New(conn)
-	return NewScannerTaskHandler(taskservice.New(queries, nil)), queries
+	return NewScannerTaskHandler(taskservice.New(queries, conn, nil)), queries
 }
 
 func TestScannerTaskHandler_CreateThenGet(t *testing.T) {

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -500,7 +500,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		scanScheduler = nil
 	}
 
-	scanTaskService := scannerv2task.New(scanQueries, scanScheduler)
+	scanTaskService := scannerv2task.New(scanQueries, dbConn, scanScheduler)
 	scannerHandler := handler.NewScannerHandler(v2Engine, scanRunner)
 	scannerTaskHandler := handler.NewScannerTaskHandler(scanTaskService)
 	scannerResultHandler := handler.NewScannerResultHandler(scanQueries, dbConn)
@@ -512,6 +512,13 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		// endpoints). Each tier is its own group so the capability matches the
 		// action (reads → discovery:read, triggers → scan:trigger, task CRUD +
 		// bulk delete → scan:manage, add-devices → device:write).
+		//
+		// #138 Phase 2c: the READ surfaces are additionally object-level scoped
+		// — a closed-mode non-admin sees only tasks/runs/results whose
+		// scan_tasks.network_id is in their granted set (details return 404).
+		// Writes (task CRUD/trigger) stay capability-gated only: operators are
+		// trusted to aim scans; grants isolate visibility, not operation.
+		r.Use(middleware.NetworkScope(scopeResolver))
 
 		// Reads: discovery:read (viewer+). Scan results, task lists, runs.
 		r.Group(func(r chi.Router) {

--- a/internal/api/routes/scope_isolation_test.go
+++ b/internal/api/routes/scope_isolation_test.go
@@ -307,3 +307,147 @@ func TestScope_ClosedMode_ReadSurfacesScoped(t *testing.T) {
 	require.Contains(t, aExport, "10.0.1.5")
 	require.Contains(t, aExport, "10.0.2.5")
 }
+
+// scannerSeedData adds scan_tasks/runs/results on both networks (plus one
+// cross-network task) so the scanner scope test has data to filter. Task 101 →
+// net 1, task 202 → net 2, task 303 → NULL (multi-CIDR targets, unscoped).
+func scannerSeedData(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO scan_tasks (id, name, targets, network_id, enabled) VALUES
+			(101, 'task-net1', '10.0.1.0/24', 1, 1),
+			(202, 'task-net2', '10.0.2.0/24', 2, 1),
+			(303, 'task-cross', '10.0.1.0/24,10.0.2.0/24', NULL, 1);
+		INSERT INTO scan_task_runs (id, task_id, status, total_hosts, alive_hosts) VALUES
+			(11, 101, 'completed', 1, 1),
+			(22, 202, 'completed', 1, 1);
+		INSERT INTO scan_results (id, task_id, run_id, ip, alive) VALUES
+			(1001, 101, 11, '10.0.1.5', 1),
+			(2002, 202, 22, '10.0.2.5', 1);
+	`)
+	require.NoError(t, err)
+}
+
+// TestScope_ClosedMode_ScannerSurfacesScoped pins the Phase 2c surfaces: in
+// closed mode a viewer granted network 1 sees ONLY net-1 tasks/runs/results —
+// out-of-scope details return 404 (indistinguishable from absent), and the
+// NULL-network (cross-network) task is hidden. Admin sees everything.
+func TestScope_ClosedMode_ScannerSurfacesScoped(t *testing.T) {
+	cfg := closedTestConfig()
+	db := scopeTestDB(t, true) // grant user1 → network 1
+	scannerSeedData(t, db)
+	handler, heartbeatSvc, shutdown := NewRouter(db, cfg)
+	require.NotNil(t, handler)
+	t.Cleanup(func() { heartbeatSvc.Stop(); shutdown() })
+
+	viewer := tokenForRole(t, cfg.Auth.JWTSecret, "viewer") // user_id=1, granted net1
+	admin := tokenForUser(t, cfg.Auth.JWTSecret, 2, "admin")
+
+	// --- tasks list: only the net-1 task (cross/NULL task hidden) ---
+	tasksFor := func(tok string) (total int, ids []int64) {
+		rec := authedGet(t, handler, tok, "/api/v1/scanner/tasks")
+		require.Equalf(t, http.StatusOK, rec.Code, "tasks body=%s", rec.Body.String())
+		var body struct {
+			Tasks []struct {
+				ID int64 `json:"id"`
+			} `json:"tasks"`
+			Total int `json:"total"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		for _, tk := range body.Tasks {
+			ids = append(ids, tk.ID)
+		}
+		return body.Total, ids
+	}
+	vTotal, vIDs := tasksFor(viewer)
+	require.Equal(t, 1, vTotal, "scoped viewer tasks: only net-1 task")
+	require.ElementsMatch(t, []int64{101}, vIDs)
+	aTotal, aIDs := tasksFor(admin)
+	require.Equal(t, 3, aTotal, "admin tasks: all three")
+	require.ElementsMatch(t, []int64{101, 202, 303}, aIDs)
+
+	// --- task detail / sub-resources: out-of-scope → 404, in-scope → 200 ---
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/202").Code)
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/303").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/101").Code)
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/202/runs").Code)
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/202/results").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, viewer, "/api/v1/scanner/tasks/101/runs").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, admin, "/api/v1/scanner/tasks/202/runs").Code)
+
+	// --- results list: only the net-1 result row ---
+	resultsFor := func(tok string) (total int, ips []string) {
+		rec := authedGet(t, handler, tok, "/api/v1/scanner/results")
+		require.Equalf(t, http.StatusOK, rec.Code, "results body=%s", rec.Body.String())
+		var body struct {
+			Results []struct {
+				IP string `json:"ip"`
+			} `json:"results"`
+			Total int `json:"total"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		for _, res := range body.Results {
+			ips = append(ips, res.IP)
+		}
+		return body.Total, ips
+	}
+	vrTotal, vrIPs := resultsFor(viewer)
+	require.Equal(t, 1, vrTotal, "scoped viewer results: only net-1 row")
+	require.ElementsMatch(t, []string{"10.0.1.5"}, vrIPs)
+	arTotal, _ := resultsFor(admin)
+	require.Equal(t, 2, arTotal, "admin results: both rows")
+
+	// sorted variant goes through the same scoped path
+	rec := authedGet(t, handler, viewer, "/api/v1/scanner/results?sort=ip&order=asc")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "10.0.1.5")
+	require.NotContains(t, rec.Body.String(), "10.0.2.5")
+
+	// --- result detail: out-of-scope → 404 ---
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/results/2002").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, viewer, "/api/v1/scanner/results/1001").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, admin, "/api/v1/scanner/results/2002").Code)
+
+	// --- runs list + detail ---
+	runsFor := func(tok string) (total int, ids []int64) {
+		rec := authedGet(t, handler, tok, "/api/v1/scanner/runs?limit=20")
+		require.Equalf(t, http.StatusOK, rec.Code, "runs body=%s", rec.Body.String())
+		var body struct {
+			Runs []struct {
+				ID int64 `json:"id"`
+			} `json:"runs"`
+			Total int `json:"total"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		for _, rn := range body.Runs {
+			ids = append(ids, rn.ID)
+		}
+		return body.Total, ids
+	}
+	vrnTotal, vrnIDs := runsFor(viewer)
+	require.Equal(t, 1, vrnTotal, "scoped viewer runs: only net-1 run")
+	require.ElementsMatch(t, []int64{11}, vrnIDs)
+	arnTotal, _ := runsFor(admin)
+	require.Equal(t, 2, arnTotal)
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/runs/22").Code)
+	require.Equal(t, http.StatusOK, authedGet(t, handler, viewer, "/api/v1/scanner/runs/11").Code)
+
+	// --- export: out-of-scope task → 404; in-scope → 200 CSV ---
+	require.Equal(t, http.StatusNotFound, authedGet(t, handler, viewer, "/api/v1/scanner/results/export?task_id=202").Code)
+	rec = authedGet(t, handler, viewer, "/api/v1/scanner/results/export?task_id=101")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "10.0.1.5")
+
+	// --- dashboard scanning section reflects the scope ---
+	rec = authedGet(t, handler, viewer, "/api/v1/dashboard/overview")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var ov struct {
+		Scanning struct {
+			TasksTotal int64 `json:"tasks_total"`
+			RunsTotal  int64 `json:"runs_total"`
+		} `json:"scanning"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ov))
+	require.Equal(t, int64(1), ov.Scanning.TasksTotal, "scoped dashboard scanning: 1 task")
+	require.Equal(t, int64(1), ov.Scanning.RunsTotal, "scoped dashboard scanning: 1 run")
+}

--- a/internal/service/dashboard.go
+++ b/internal/service/dashboard.go
@@ -242,7 +242,7 @@ func (s *DashboardService) Overview(ctx context.Context, scope domain.Scope) (*d
 	out.Devices = dev
 
 	// --- 4. Recent scan tasks + runs + run-status distribution (cross-network; NOT scoped) ---
-	scan, err := s.overviewScanning(ctx)
+	scan, err := s.overviewScanning(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -276,29 +276,48 @@ func (s *DashboardService) Overview(ctx context.Context, scope domain.Scope) (*d
 
 // overviewScanning gathers recent scan tasks/runs and the run-status
 // distribution so the dashboard reflects discovery activity, not just device
-// counts.
-func (s *DashboardService) overviewScanning(ctx context.Context) (domain.OverviewScanning, error) {
+// counts. scope (#138 Phase 2c) restricts every aggregate to tasks whose
+// network_id is in the granted set — runs scope through their task.
+func (s *DashboardService) overviewScanning(ctx context.Context, scope domain.Scope) (domain.OverviewScanning, error) {
 	out := domain.OverviewScanning{RunsByStatus: map[string]int64{}}
 
-	tasksTotal, err := s.queries.CountScanTasks(ctx)
-	if err != nil {
+	// taskPred scopes the scan_tasks table; runJoin scopes run aggregates
+	// through the task. Both are no-ops ("1=1") for a global scope.
+	taskPred, taskArgs := scopeql.NetworkPredicate(scope, "")
+	runJoin := `FROM scan_task_runs r JOIN scan_tasks t ON r.task_id = t.id WHERE ` + taskPred
+	runArgs := taskArgs
+
+	if err := s.dbConn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scan_tasks WHERE `+taskPred, taskArgs...).Scan(&out.TasksTotal); err != nil {
 		return out, fmt.Errorf("overview: count tasks: %w", err)
 	}
-	out.TasksTotal = tasksTotal
 
-	runsTotal, err := s.queries.CountScanTaskRuns(ctx, db.CountScanTaskRunsParams{Column1: 0, TaskID: 0})
-	if err != nil {
+	if err := s.dbConn.QueryRowContext(ctx,
+		`SELECT COUNT(*) `+runJoin, runArgs...).Scan(&out.RunsTotal); err != nil {
 		return out, fmt.Errorf("overview: count runs: %w", err)
 	}
-	out.RunsTotal = runsTotal
 
-	// Recent tasks (last 5 by id desc).
-	tasks, err := s.queries.ListScanTasks(ctx, db.ListScanTasksParams{Limit: 5, Offset: 0})
+	// Recent tasks (last 5 by id desc). Initialized to empty (not nil) so the
+	// JSON keeps rendering [] on an empty DB (matches the previous sqlc path).
+	out.RecentTasks = make([]domain.OverviewScanTask, 0)
+	taskRows, err := s.dbConn.QueryContext(ctx, `SELECT id, name, targets, enabled, last_run_at, last_run_status
+		FROM scan_tasks WHERE `+taskPred+` ORDER BY id DESC LIMIT 5`, taskArgs...)
 	if err != nil {
 		return out, fmt.Errorf("overview: list tasks: %w", err)
 	}
-	out.RecentTasks = make([]domain.OverviewScanTask, 0, len(tasks))
-	for _, t := range tasks {
+	for taskRows.Next() {
+		var t struct {
+			ID            int64
+			Name          string
+			Targets       string
+			Enabled       int64
+			LastRunAt     *time.Time
+			LastRunStatus *string
+		}
+		if err := taskRows.Scan(&t.ID, &t.Name, &t.Targets, &t.Enabled, &t.LastRunAt, &t.LastRunStatus); err != nil {
+			taskRows.Close()
+			return out, fmt.Errorf("overview: scan task row: %w", err)
+		}
 		ot := domain.OverviewScanTask{
 			ID:        t.ID,
 			Name:      t.Name,
@@ -311,23 +330,37 @@ func (s *DashboardService) overviewScanning(ctx context.Context) (domain.Overvie
 		}
 		out.RecentTasks = append(out.RecentTasks, ot)
 	}
+	taskRows.Close()
+	if err := taskRows.Err(); err != nil {
+		return out, fmt.Errorf("overview: task rows: %w", err)
+	}
 
-	// Recent runs across all tasks (task_id=0 ⇒ no filter), last 5.
-	runs, err := s.queries.ListScanTaskRuns(ctx, db.ListScanTaskRunsParams{
-		Column1: 0, TaskID: 0, Limit: 5, Offset: 0,
-	})
+	// Recent runs across all visible tasks, last 5 (scoped through the task).
+	out.RecentRuns = make([]domain.OverviewScanRun, 0)
+	runRows, err := s.dbConn.QueryContext(ctx, `SELECT r.id, r.task_id, r.status, r.total_hosts, r.alive_hosts, r.new_hosts, r.updated_hosts,
+		r.duration_ms, r.error_message, r.started_at, r.finished_at, r.created_at
+		`+runJoin+` ORDER BY r.id DESC LIMIT 5`, runArgs...)
 	if err != nil {
 		return out, fmt.Errorf("overview: list runs: %w", err)
 	}
-	out.RecentRuns = make([]domain.OverviewScanRun, 0, len(runs))
-	for _, r := range runs {
+	for runRows.Next() {
+		var r db.ScanTaskRun
+		if err := runRows.Scan(&r.ID, &r.TaskID, &r.Status, &r.TotalHosts, &r.AliveHosts,
+			&r.NewHosts, &r.UpdatedHosts, &r.DurationMs, &r.ErrorMessage,
+			&r.StartedAt, &r.FinishedAt, &r.CreatedAt); err != nil {
+			runRows.Close()
+			return out, fmt.Errorf("overview: scan run row: %w", err)
+		}
 		out.RecentRuns = append(out.RecentRuns, runToOverview(r))
-		// tally status distribution across ALL runs (not just recent) — cheap to
-		// derive from the recent slice would be wrong, so we do a separate query.
+	}
+	runRows.Close()
+	if err := runRows.Err(); err != nil {
+		return out, fmt.Errorf("overview: run rows: %w", err)
 	}
 
-	// Run-status distribution across all runs (raw, one GROUP BY).
-	distRows, err := s.dbConn.QueryContext(ctx, `SELECT status, COUNT(*) FROM scan_task_runs GROUP BY status`)
+	// Run-status distribution across all visible runs (raw, one GROUP BY).
+	distRows, err := s.dbConn.QueryContext(ctx,
+		`SELECT r.status, COUNT(*) `+runJoin+` GROUP BY r.status`, runArgs...)
 	if err != nil {
 		return out, fmt.Errorf("overview: runs by status: %w", err)
 	}
@@ -345,11 +378,11 @@ func (s *DashboardService) overviewScanning(ctx context.Context) (domain.Overvie
 		return out, fmt.Errorf("overview: run-status rows: %w", err)
 	}
 
-	// Most recent completed run (the latest "discovery" result).
+	// Most recent completed visible run (the latest "discovery" result).
 	completed, err := s.dbConn.QueryContext(ctx, `
-		SELECT id, task_id, status, total_hosts, alive_hosts, new_hosts, duration_ms, error_message, started_at, finished_at
-		FROM scan_task_runs WHERE status='completed'
-		ORDER BY COALESCE(finished_at, started_at, created_at) DESC LIMIT 1`)
+		SELECT r.id, r.task_id, r.status, r.total_hosts, r.alive_hosts, r.new_hosts, r.duration_ms, r.error_message, r.started_at, r.finished_at
+		`+runJoin+` AND r.status='completed'
+		ORDER BY COALESCE(r.finished_at, r.started_at, r.created_at) DESC LIMIT 1`, runArgs...)
 	if err != nil {
 		return out, fmt.Errorf("overview: last discovery: %w", err)
 	}

--- a/internal/service/scannerv2/taskservice/scheduler_test.go
+++ b/internal/service/scannerv2/taskservice/scheduler_test.go
@@ -41,7 +41,7 @@ func setupSvcWithScheduler(t *testing.T) (*Service, *db.Queries) {
 	require.NoError(t, err)
 	sched.Start(context.Background())
 	t.Cleanup(sched.Stop)
-	return New(queries, sched), queries
+	return New(queries, conn, sched), queries
 }
 
 // TestTriggerTask_WithScheduler_ReturnsTriggered verifies the happy path: an

--- a/internal/service/scannerv2/taskservice/taskservice.go
+++ b/internal/service/scannerv2/taskservice/taskservice.go
@@ -19,7 +19,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"strings"
 
+	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service/scannerv2/scheduler"
@@ -37,13 +40,89 @@ var (
 // scheduler in sync.
 type Service struct {
 	queries   *db.Queries
+	conn      db.DBTX // raw connection for the network_id stamp + scope-restricted reads (nil = skip both)
 	scheduler *scheduler.Scheduler
 }
 
-// New constructs a Service. scheduler may be nil (Trigger/Cancel return errors;
-// CRUD still works for browsing).
-func New(queries *db.Queries, sched *scheduler.Scheduler) *Service {
-	return &Service{queries: queries, scheduler: sched}
+// New constructs a Service. conn powers the scan_tasks.network_id stamping and
+// the object-scope-restricted list paths (sqlc can't express a variable
+// IN-list); it may be nil in unit tests that don't exercise those paths.
+// scheduler may be nil (Trigger/Cancel return errors; CRUD still works for
+// browsing).
+func New(queries *db.Queries, conn db.DBTX, sched *scheduler.Scheduler) *Service {
+	return &Service{queries: queries, conn: conn, scheduler: sched}
+}
+
+// ResolveNetworkFromTargets maps a scan task's targets to a networks row id
+// (#138 Phase 2c). The targets resolve when they are a SINGLE CIDR whose
+// normalized form matches one networks.cidr (the raw target string is tried
+// too, covering non-canonical stored cidrs). Comma lists, IP ranges,
+// hostnames, or no match → NULL — meaning cross-network/unresolved: visible
+// to admins/open mode, hidden from restricted scopes. Best-effort by design;
+// this is a visibility enforcement key, not an identity.
+func ResolveNetworkFromTargets(ctx context.Context, conn db.DBTX, targets string) (sql.NullInt64, error) {
+	fields := strings.FieldsFunc(targets, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == ';'
+	})
+	if len(fields) != 1 {
+		return sql.NullInt64{}, nil
+	}
+	raw := strings.TrimSpace(fields[0])
+	_, ipNet, err := net.ParseCIDR(raw)
+	if err != nil {
+		return sql.NullInt64{}, nil // ranges / single IPs / hostnames → unscoped
+	}
+	for _, candidate := range []string{ipNet.String(), raw} {
+		var id int64
+		err := conn.QueryRowContext(ctx, `SELECT id FROM networks WHERE cidr = ? LIMIT 1`, candidate).Scan(&id)
+		switch {
+		case err == nil:
+			return sql.NullInt64{Int64: id, Valid: true}, nil
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+		default:
+			return sql.NullInt64{}, err
+		}
+	}
+	return sql.NullInt64{}, nil
+}
+
+// stampTaskNetwork resolves a task's targets to a network and writes
+// scan_tasks.network_id. Best-effort: resolution/DB failures are logged and
+// leave the column NULL (unscoped), never failing the task write itself.
+func (s *Service) stampTaskNetwork(ctx context.Context, taskID int64, targets string, logger *slog.Logger) {
+	if s.conn == nil {
+		return
+	}
+	netID, err := ResolveNetworkFromTargets(ctx, s.conn, targets)
+	if err != nil {
+		logger.Warn("scan task: network resolve failed; task left unscoped", "task_id", taskID, "error", err)
+		return
+	}
+	if _, err := s.conn.ExecContext(ctx,
+		`UPDATE scan_tasks SET network_id = ? WHERE id = ?`, netID, taskID); err != nil {
+		logger.Warn("scan task: network stamp failed; task left unscoped", "task_id", taskID, "error", err)
+	}
+}
+
+// taskNetworkInScope reports whether the task's network falls within scope. A
+// global scope always passes; a restricted scope passes only when the task has
+// a resolved network_id in the granted set (NULL = cross-network → hidden).
+// A missing task returns false (callers map that to their not-found path).
+func (s *Service) taskNetworkInScope(ctx context.Context, taskID int64, scope domain.Scope) bool {
+	if scope.IsGlobal() {
+		return true
+	}
+	if s.conn == nil {
+		return true // scope disabled in this construction — fail open (tests)
+	}
+	var netID sql.NullInt64
+	err := s.conn.QueryRowContext(ctx,
+		`SELECT network_id FROM scan_tasks WHERE id = ?`, taskID).Scan(&netID)
+	if err != nil {
+		return false
+	}
+	return netID.Valid && scope.AllowsNetwork(netID.Int64)
 }
 
 // CreateTask inserts a task and registers its cron job.
@@ -78,11 +157,16 @@ func (s *Service) CreateTask(ctx context.Context, req domain.ScanTaskRequest) (d
 			return domain.ScanTaskResponse{}, fmt.Errorf("register cron job: %w", err)
 		}
 	}
+	s.stampTaskNetwork(ctx, task.ID, task.Targets, slog.Default())
 	return toTaskResponse(task), nil
 }
 
-// GetTask returns one task by ID.
-func (s *Service) GetTask(ctx context.Context, id int64) (domain.ScanTaskResponse, error) {
+// GetTask returns one task by ID. A restricted scope sees out-of-scope tasks
+// as not found (they don't exist for that caller).
+func (s *Service) GetTask(ctx context.Context, id int64, scope domain.Scope) (domain.ScanTaskResponse, error) {
+	if !s.taskNetworkInScope(ctx, id, scope) {
+		return domain.ScanTaskResponse{}, ErrScanTaskNotFound
+	}
 	task, err := s.queries.GetScanTask(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -97,7 +181,10 @@ func (s *Service) GetTask(ctx context.Context, id int64) (domain.ScanTaskRespons
 // case-insensitive substring search over name + targets. An empty search
 // string disables the filter (matches the old behaviour) — both the list and
 // the count use the same search term so pagination totals stay consistent.
-func (s *Service) ListTasks(ctx context.Context, search string, limit, offset int) ([]domain.ScanTaskResponse, int64, error) {
+// A restricted scope (#138 Phase 2c) sees only tasks whose network_id is in
+// the granted set (NULL-network tasks are cross-network → hidden); the count
+// mirrors the same WHERE.
+func (s *Service) ListTasks(ctx context.Context, search string, limit, offset int, scope domain.Scope) ([]domain.ScanTaskResponse, int64, error) {
 	if limit < 20 {
 		limit = 20
 	}
@@ -106,6 +193,9 @@ func (s *Service) ListTasks(ctx context.Context, search string, limit, offset in
 	}
 	if offset < 0 {
 		offset = 0
+	}
+	if !scope.IsGlobal() && s.conn != nil {
+		return s.listTasksScoped(ctx, search, limit, offset, scope)
 	}
 	tasks, err := s.queries.ListScanTasksSearch(ctx, db.ListScanTasksSearchParams{
 		Column1: search, // raw search term, used for the (? = '' OR ...) short-circuit
@@ -130,6 +220,45 @@ func (s *Service) ListTasks(ctx context.Context, search string, limit, offset in
 		out = append(out, toTaskResponse(t))
 	}
 	return out, total, nil
+}
+
+// listTasksScoped mirrors ListScanTasksSearch/CountScanTasksSearch with the
+// network-scope predicate ANDed in (sqlc can't express a variable IN-list).
+// The SELECT column list MUST match db.ScanTask's field order for the Scan.
+func (s *Service) listTasksScoped(ctx context.Context, search string, limit, offset int, scope domain.Scope) ([]domain.ScanTaskResponse, int64, error) {
+	pred, predArgs := scopeql.NetworkPredicate(scope, "")
+
+	where := "WHERE " + pred +
+		" AND (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)"
+
+	var total int64
+	countArgs := append(append([]any{}, predArgs...), search, search, search)
+	if err := s.conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scan_tasks `+where, countArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	listArgs := append(append([]any{}, countArgs...), limit, offset)
+	rows, err := s.conn.QueryContext(ctx, `SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+		FROM scan_tasks `+where+` ORDER BY id LIMIT ? OFFSET ?`, listArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := make([]domain.ScanTaskResponse, 0)
+	for rows.Next() {
+		var t db.ScanTask
+		if err := rows.Scan(
+			&t.ID, &t.Name, &t.Targets, &t.CronExpr, &t.PipelineConfig, &t.GlobalLabels,
+			&t.Timeout, &t.ConcurrentHosts, &t.CredentialID, &t.Enabled,
+			&t.LastRunAt, &t.NextRunAt, &t.LastRunStatus, &t.CreatedAt, &t.UpdatedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, toTaskResponse(t))
+	}
+	return out, total, rows.Err()
 }
 
 // UpdateTask applies a partial update and re-registers the cron job if the
@@ -255,6 +384,10 @@ func (s *Service) UpdateTask(ctx context.Context, id int64, req domain.UpdateSca
 	// not reflect the toggle we just applied — patch it so callers see the truth.
 	resp := toTaskResponse(task)
 	resp.Enabled = newEnabled == 1
+	// Re-resolve the network key when the targets moved (#138 Phase 2c).
+	if targetsChanged {
+		s.stampTaskNetwork(ctx, id, targets, slog.Default())
+	}
 	return resp, nil
 }
 
@@ -336,8 +469,13 @@ func (s *Service) CancelTask(ctx context.Context, id int64) error {
 	return nil
 }
 
-// GetTaskRuns returns run history for a task.
-func (s *Service) GetTaskRuns(ctx context.Context, taskID, limit, offset int) ([]domain.ScanRunResponse, int64, error) {
+// GetTaskRuns returns run history for a task. A restricted scope sees runs of
+// an out-of-scope task as not found (the sub-resources inherit the task's
+// scope — single check here covers the whole list).
+func (s *Service) GetTaskRuns(ctx context.Context, taskID, limit, offset int, scope domain.Scope) ([]domain.ScanRunResponse, int64, error) {
+	if !s.taskNetworkInScope(ctx, int64(taskID), scope) {
+		return nil, 0, ErrScanTaskNotFound
+	}
 	if limit < 20 {
 		limit = 20
 	}
@@ -361,8 +499,12 @@ func (s *Service) GetTaskRuns(ctx context.Context, taskID, limit, offset int) ([
 	return out, total, nil
 }
 
-// GetTaskResults returns per-host results for a task.
-func (s *Service) GetTaskResults(ctx context.Context, taskID, limit, offset int) ([]domain.ScanResultResponse, int64, error) {
+// GetTaskResults returns per-host results for a task (scope semantics as
+// GetTaskRuns).
+func (s *Service) GetTaskResults(ctx context.Context, taskID, limit, offset int, scope domain.Scope) ([]domain.ScanResultResponse, int64, error) {
+	if !s.taskNetworkInScope(ctx, int64(taskID), scope) {
+		return nil, 0, ErrScanTaskNotFound
+	}
 	if limit < 20 {
 		limit = 20
 	}

--- a/internal/service/scannerv2/taskservice/taskservice_test.go
+++ b/internal/service/scannerv2/taskservice/taskservice_test.go
@@ -35,7 +35,7 @@ func setupSvc(t *testing.T) (*Service, *db.Queries) {
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 	queries := db.New(conn)
-	return New(queries, nil), queries
+	return New(queries, conn, nil), queries
 }
 
 // TestCreateTask_GetTask verifies the create→read round-trip and that the
@@ -51,7 +51,7 @@ func TestCreateTask_GetTask(t *testing.T) {
 	require.Equal(t, "0 2 * * *", resp.CronExpr)
 	require.NotZero(t, resp.ID)
 
-	got, err := svc.GetTask(ctx, resp.ID)
+	got, err := svc.GetTask(ctx, resp.ID, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, resp.ID, got.ID)
 	require.Equal(t, "nightly-lan", got.Name)
@@ -88,7 +88,7 @@ func TestCreateTask_ValidationRejectsBadInput(t *testing.T) {
 // sentinel the handler switches on).
 func TestGetTask_NotFound(t *testing.T) {
 	svc, _ := setupSvc(t)
-	_, err := svc.GetTask(context.Background(), 9999)
+	_, err := svc.GetTask(context.Background(), 9999, domain.Scope{Global: true})
 	require.ErrorIs(t, err, ErrScanTaskNotFound)
 }
 
@@ -105,12 +105,12 @@ func TestListTasks_PaginationClamping(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// total reflects all 3 regardless of limit/offset.
-	tasks, total, err := svc.ListTasks(ctx, "", 5, 0) // limit<20 → clamped to 20
+	tasks, total, err := svc.ListTasks(ctx, "", 5, 0, domain.Scope{Global: true}) // limit<20 → clamped to 20
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Len(t, tasks, 3)
 	// offset beyond the set → empty page, total unchanged.
-	tasks, total, err = svc.ListTasks(ctx, "", 20, 100)
+	tasks, total, err = svc.ListTasks(ctx, "", 20, 100, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Empty(t, tasks)
@@ -138,40 +138,40 @@ func TestListTasks_Search(t *testing.T) {
 	}
 
 	// Empty search → all 3 (filter disabled).
-	tasks, total, err := svc.ListTasks(ctx, "", 20, 0)
+	tasks, total, err := svc.ListTasks(ctx, "", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(3), total)
 	require.Len(t, tasks, 3)
 
 	// Search by name substring → 1 match, total=1.
-	tasks, total, err = svc.ListTasks(ctx, "cameras", 20, 0)
+	tasks, total, err = svc.ListTasks(ctx, "cameras", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total)
 	require.Len(t, tasks, 1)
 	require.Equal(t, "weekly-cameras", tasks[0].Name)
 
 	// Search by targets substring → 1 match (the 172.16 row).
-	tasks, total, err = svc.ListTasks(ctx, "172.16", 20, 0)
+	tasks, total, err = svc.ListTasks(ctx, "172.16", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total)
 	require.Len(t, tasks, 1)
 	require.Equal(t, "iot-sweep", tasks[0].Name)
 
 	// Case-insensitive: "LAN" matches "nightly-lan".
-	tasks, total, err = svc.ListTasks(ctx, "LAN", 20, 0)
+	tasks, total, err = svc.ListTasks(ctx, "LAN", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total)
 	require.Len(t, tasks, 1)
 	require.Equal(t, "nightly-lan", tasks[0].Name)
 
 	// No match → empty page, total=0.
-	tasks, total, err = svc.ListTasks(ctx, "nonexistent-term", 20, 0)
+	tasks, total, err = svc.ListTasks(ctx, "nonexistent-term", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(0), total)
 	require.Empty(t, tasks)
 
 	// A term matching MULTIPLE columns/rows ("0.0/24" is in two targets) → total=2.
-	tasks, total, err = svc.ListTasks(ctx, "0.0/24", 20, 0)
+	tasks, total, err = svc.ListTasks(ctx, "0.0/24", 20, 0, domain.Scope{Global: true})
 	require.NoError(t, err)
 	require.Equal(t, int64(2), total)
 	require.Len(t, tasks, 2)
@@ -186,7 +186,7 @@ func TestDeleteTask(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, svc.DeleteTask(ctx, resp.ID))
-	_, err = svc.GetTask(ctx, resp.ID)
+	_, err = svc.GetTask(ctx, resp.ID, domain.Scope{Global: true})
 	require.ErrorIs(t, err, ErrScanTaskNotFound)
 }
 
@@ -217,4 +217,41 @@ func TestCancelTask_NilScheduler(t *testing.T) {
 	require.NoError(t, err)
 	err = svc.CancelTask(ctx, resp.ID)
 	require.Error(t, err)
+}
+
+// TestResolveNetworkFromTargets pins the targets→network resolution rules
+// (#138 Phase 2c): single canonical CIDR matching networks.cidr resolves;
+// single IPs, hostnames, multi-CIDR lists, and unmatched CIDRs stay NULL.
+func TestResolveNetworkFromTargets(t *testing.T) {
+	ctx := context.Background()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = conn.Exec(`INSERT INTO networks (id, name, cidr) VALUES (1, 'lan-1', '10.0.1.0/24')`)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		targets string
+		wantID  int64
+		wantOK  bool
+	}{
+		{"canonical single CIDR", "10.0.1.0/24", 1, true},
+		{"padded single CIDR", "  10.0.1.0/24  ", 1, true},
+		{"single IP", "10.0.1.5", 0, false},
+		{"hostname", "example.lan", 0, false},
+		{"multi-CIDR list", "10.0.1.0/24,10.0.2.0/24", 0, false},
+		{"unmatched CIDR", "172.16.0.0/24", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := ResolveNetworkFromTargets(ctx, conn, tc.targets)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOK, id.Valid, "valid=%v targets=%q", id.Valid, tc.targets)
+			if tc.wantOK {
+				require.EqualValues(t, tc.wantID, id.Int64)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 背景

#138 Phase 2b（#231）把 closed-mode 闭合到设备/拓扑/变更/dashboard/统计/导出后，scanner 读面（tasks/runs/results）是最后未作用域化的 inventory 面——scanner 表没有 network 归属。本 PR（Phase 2c）补上。

## 设计

**作用域键 = `scan_tasks.network_id`**（runMigrations ALTER + 回填）：任务 targets 是**单个 CIDR** 且精确匹配一行 `networks.cidr` → 解析为该网络；多 CIDR 列表 / IP range / 主机名 / 无匹配 → `NULL`（跨网任务：admin 可见、受限作用域隐藏）。runs/results 经 `task_id` JOIN 作用域化——自身不加列。

**写入**（best-effort）：`taskservice.CreateTask/UpdateTask` 在 targets 变化时打标（`ResolveNetworkFromTargets`，解析失败仅告警、不阻断任务写入）。

**读取**：
| 面 | 行为 |
|---|---|
| `GET /scanner/results`（含 `?sort=` 变体） | join scan_tasks + scopeql 谓词，count 同步 |
| `GET /scanner/runs` | 同上 |
| `GET /scanner/results/{id}`、`/runs/{id}`、`/tasks/{id}`、`/tasks/{id}/runs|results`、`/results/export` | 越权 → **404**（与不存在不可区分，scanner 域内统一） |
| `GET /scanner/tasks` | 作用域化列表 + count |
| dashboard `overviewScanning` | tasks/runs 计数、最近任务/运行、状态分布、最近完成——全部按作用域（runs 经 task join） |

**语义决策**（已写进 config 注释）：
- scanner **写面**（任务 CRUD/trigger）保持 capability 门不按网络限制——operator 是受信操作者，grants 隔离**可见性**而非操作。
- **audit_logs 刻意不做**网络作用域：它是跨网的用户操作日志（谁在什么时候改了什么），按网络切割会破坏审计完整性。
- 索引 `idx_scan_tasks_network` 在迁移后创建（放 schema.sql 会在旧库 `CREATE TABLE IF NOT EXISTS` 不生效时报 no such column——测试抓到）。

## 测试

- `scope_isolation_test` 新增 `TestScope_ClosedMode_ScannerSurfacesScoped`：闭模式 viewer（grant net1）只见 net1 任务/运行/结果；越权详情/导出 404；NULL 网络任务隐藏；admin 全见；dashboard scanning 段同步。
- `migrations_test` 新增回填测试：旧形状表 → 加列 → 回填（单 CIDR 解析 / 多 CIDR 保持 NULL）→ 幂等。
- `taskservice_test` 新增 `ResolveNetworkFromTargets` 表驱动（canonical/padded/单 IP/主机名/多 CIDR/无匹配）。
- `go vet` / `gofmt` / `goimports` / `sqlc compile` / `go test ./...` 全绿。

## 实测（63.101）

旧库部署：pre-migration VACUUM 备份 → `scan_tasks network_id backfilled tasks=1`（既有 lan-63-periodic → network_id=1）→ scanner tasks/results/runs/detail/export 全 200（admin 数据不变），dashboard scanning JSON 形状不变。

## 关联

- #229（Phase 2 设备域）→ #231（Phase 2b 全读取面）→ **本 PR（Phase 2c scanner 面）**。至此 #138 的对象级作用域在所有 inventory 面闭环。

Closes #138