### PR TITLE
fix(observability): 死指标接线 + sqlc 漂移修复 + CI 护栏（#237/#238/#239）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,23 @@ jobs:
           go-version-file: go.mod
       - name: Install sqlc
         run: |
-          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0
+          # v1.31.1 is the version the committed internal/db was generated
+          # with; a different version reformats headers and breaks the drift
+          # check below (#237).
+          go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
           sqlc version
       # `sqlc compile` validates queries against the schema locally without
       # requiring a sqlc Cloud project (which `sqlc verify` does).
       - run: sqlc compile
+      # Drift guard (#237): the committed internal/db MUST equal a fresh
+      # `sqlc generate` on the committed db/schema.sql + db/queries/. This
+      # fails when schema.sql or queries change without regenerating — the
+      # exact drift that #233 introduced and #235 had to surgically work
+      # around.
+      - name: Check generated code is in sync
+        run: |
+          sqlc generate
+          git diff --exit-code internal/db/
 
   # Validate that the container image builds (build only, no push). Catches
   # Dockerfile/docker-compose regressions before they hit a release tag — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
+
+**HeartbeatFailures was a dead alert** — `mibee_heartbeat_checks_total` (and five
+siblings) were registered at `/metrics` but never incremented in production
+code, so the alert's expression was permanently 0. Fixed by moving the
+collectors to a new neutral package and wiring the producers:
+
+- **`internal/metrics`** (new): the 7 `mibee_*` collectors moved out of
+  `internal/api/handler` so the service layer can increment them without an
+  handler→service→handler import cycle. `handler.MetricsHandler` /
+  `UpdateDeviceMetrics` unchanged in behavior.
+- **Heartbeat**: `probeAndRecord` now increments
+  `mibee_heartbeat_checks_total{status}` per recorded outcome and observes
+  `mibee_heartbeat_latency_seconds{method}` — the `HeartbeatFailures` alert
+  rule evaluates against real data.
+- **Scanner**: run completion/failure increments
+  `mibee_scanner_runs_total{status}`, observes
+  `mibee_scanner_duration_seconds`, and adds alive hosts to
+  `mibee_scanner_hosts_discovered`; `mibee_scanner_tasks_total{status}` is
+  refreshed at scheduler start and after task CRUD
+  (`metrics.RefreshScannerTaskGauges`).
+- **`prometheus.metrics_path`** now actually configures the mount point
+  (previously defined in config but hard-coded to `/metrics`; empty or
+  non-absolute values fall back to `/metrics`).
+
+### sqlc: generated code back in sync with schema.sql + CI drift guard (issue #237)
+
+The committed `internal/db` had been stale since #233 (`scan_tasks.network_id`
+landed in schema + migrations without `sqlc generate`), so any full regenerate
+emitted per-query Row structs that broke ~10 call sites — PR #235 had to
+surgically merge around it. Fixed at the root:
+
+- `db/queries/devices.sql` full-row lists now select `ssh_credential_id` (6
+  lists) and `db/queries/scan_tasks.sql` selects `network_id` (7 lists) — the
+  column sets match the tables again, so sqlc restores model reuse and NO call
+  sites needed changes. The `CreateScanTask` INSERT still does not set
+  `network_id` (stamped post-insert by raw SQL, as before).
+- Full `sqlc generate` is now idempotent against the committed tree (fresh
+  generate produces an empty diff).
+- **CI drift guard**: the `sqlc-verify` job installs sqlc **v1.31.1** (matching
+  the committed generator) and fails when `sqlc generate` produces a diff in
+  `internal/db/` — schema/query changes must ship with regenerated code.
+- Tests with hand-rolled inline `devices` schemas gained the
+  `ssh_credential_id` column.
+
+
 ### Synthetic probing / 拨测 (Phase 1)
 
 **Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured

--- a/db/queries/devices.sql
+++ b/db/queries/devices.sql
@@ -13,15 +13,15 @@ INSERT INTO devices (
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at;
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at;
 
 -- name: GetDevice :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE id = ?;
 
 -- name: ListDevices :many
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -46,7 +46,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at;
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at;
 
 -- name: UpdateUserAttributes :exec
 UPDATE devices SET user_attributes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?;
@@ -97,7 +97,7 @@ SET scan_source = ?, prometheus_labels = ?, last_scanned_at = ?, last_scan_task_
 WHERE id = ?;
 
 -- name: GetDeviceByIP :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1;
@@ -107,7 +107,7 @@ LIMIT 1;
 -- both fresh installs (which have the scan_mac generated column) and upgraded
 -- DBs (which have an expression index on json_extract instead). The expression
 -- index idx_devices_scan_mac_expr covers this WHERE clause on either shape.
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1;

--- a/db/queries/scan_tasks.sql
+++ b/db/queries/scan_tasks.sql
@@ -10,15 +10,15 @@
 -- name: CreateScanTask :one
 INSERT INTO scan_tasks (name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
-RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at;
+RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at;
 
 -- name: GetScanTask :one
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE id = ?;
 
 -- name: ListScanTasks :many
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 ORDER BY id
 LIMIT ? OFFSET ?;
@@ -30,7 +30,7 @@ LIMIT ? OFFSET ?;
 -- of LIKE so the search term needs no escaping (literal %/_ are not wildcards)
 -- and we pass the same value to both columns + the empty-check.
 -- CountScanTasksSearch below MUST use the same WHERE clause so totals match.
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)
 ORDER BY id
@@ -41,7 +41,7 @@ UPDATE scan_tasks
 SET name = ?, targets = ?, cron_expr = ?, pipeline_config = ?, global_labels = ?,
     timeout = ?, concurrent_hosts = ?, credential_id = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at;
+RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at;
 
 -- name: DeleteScanTask :execrows
 DELETE FROM scan_tasks
@@ -58,7 +58,7 @@ SET enabled = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
 
 -- name: ListEnabledScanTasks :many
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE enabled = 1;
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
+
+**HeartbeatFailures was a dead alert** — `mibee_heartbeat_checks_total` (and five
+siblings) were registered at `/metrics` but never incremented in production
+code, so the alert's expression was permanently 0. Fixed by moving the
+collectors to a new neutral package and wiring the producers:
+
+- **`internal/metrics`** (new): the 7 `mibee_*` collectors moved out of
+  `internal/api/handler` so the service layer can increment them without an
+  handler→service→handler import cycle. `handler.MetricsHandler` /
+  `UpdateDeviceMetrics` unchanged in behavior.
+- **Heartbeat**: `probeAndRecord` now increments
+  `mibee_heartbeat_checks_total{status}` per recorded outcome and observes
+  `mibee_heartbeat_latency_seconds{method}` — the `HeartbeatFailures` alert
+  rule evaluates against real data.
+- **Scanner**: run completion/failure increments
+  `mibee_scanner_runs_total{status}`, observes
+  `mibee_scanner_duration_seconds`, and adds alive hosts to
+  `mibee_scanner_hosts_discovered`; `mibee_scanner_tasks_total{status}` is
+  refreshed at scheduler start and after task CRUD
+  (`metrics.RefreshScannerTaskGauges`).
+- **`prometheus.metrics_path`** now actually configures the mount point
+  (previously defined in config but hard-coded to `/metrics`; empty or
+  non-absolute values fall back to `/metrics`).
+
+### sqlc: generated code back in sync with schema.sql + CI drift guard (issue #237)
+
+The committed `internal/db` had been stale since #233 (`scan_tasks.network_id`
+landed in schema + migrations without `sqlc generate`), so any full regenerate
+emitted per-query Row structs that broke ~10 call sites — PR #235 had to
+surgically merge around it. Fixed at the root:
+
+- `db/queries/devices.sql` full-row lists now select `ssh_credential_id` (6
+  lists) and `db/queries/scan_tasks.sql` selects `network_id` (7 lists) — the
+  column sets match the tables again, so sqlc restores model reuse and NO call
+  sites needed changes. The `CreateScanTask` INSERT still does not set
+  `network_id` (stamped post-insert by raw SQL, as before).
+- Full `sqlc generate` is now idempotent against the committed tree (fresh
+  generate produces an empty diff).
+- **CI drift guard**: the `sqlc-verify` job installs sqlc **v1.31.1** (matching
+  the committed generator) and fails when `sqlc generate` produces a diff in
+  `internal/db/` — schema/query changes must ship with regenerated code.
+- Tests with hand-rolled inline `devices` schemas gained the
+  `ssh_credential_id` column.
+
+
 ### Synthetic probing / 拨测 (Phase 1)
 
 **Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
+
+**HeartbeatFailures was a dead alert** — `mibee_heartbeat_checks_total` (and five
+siblings) were registered at `/metrics` but never incremented in production
+code, so the alert's expression was permanently 0. Fixed by moving the
+collectors to a new neutral package and wiring the producers:
+
+- **`internal/metrics`** (new): the 7 `mibee_*` collectors moved out of
+  `internal/api/handler` so the service layer can increment them without an
+  handler→service→handler import cycle. `handler.MetricsHandler` /
+  `UpdateDeviceMetrics` unchanged in behavior.
+- **Heartbeat**: `probeAndRecord` now increments
+  `mibee_heartbeat_checks_total{status}` per recorded outcome and observes
+  `mibee_heartbeat_latency_seconds{method}` — the `HeartbeatFailures` alert
+  rule evaluates against real data.
+- **Scanner**: run completion/failure increments
+  `mibee_scanner_runs_total{status}`, observes
+  `mibee_scanner_duration_seconds`, and adds alive hosts to
+  `mibee_scanner_hosts_discovered`; `mibee_scanner_tasks_total{status}` is
+  refreshed at scheduler start and after task CRUD
+  (`metrics.RefreshScannerTaskGauges`).
+- **`prometheus.metrics_path`** now actually configures the mount point
+  (previously defined in config but hard-coded to `/metrics`; empty or
+  non-absolute values fall back to `/metrics`).
+
+### sqlc: generated code back in sync with schema.sql + CI drift guard (issue #237)
+
+The committed `internal/db` had been stale since #233 (`scan_tasks.network_id`
+landed in schema + migrations without `sqlc generate`), so any full regenerate
+emitted per-query Row structs that broke ~10 call sites — PR #235 had to
+surgically merge around it. Fixed at the root:
+
+- `db/queries/devices.sql` full-row lists now select `ssh_credential_id` (6
+  lists) and `db/queries/scan_tasks.sql` selects `network_id` (7 lists) — the
+  column sets match the tables again, so sqlc restores model reuse and NO call
+  sites needed changes. The `CreateScanTask` INSERT still does not set
+  `network_id` (stamped post-insert by raw SQL, as before).
+- Full `sqlc generate` is now idempotent against the committed tree (fresh
+  generate produces an empty diff).
+- **CI drift guard**: the `sqlc-verify` job installs sqlc **v1.31.1** (matching
+  the committed generator) and fails when `sqlc generate` produces a diff in
+  `internal/db/` — schema/query changes must ship with regenerated code.
+- Tests with hand-rolled inline `devices` schemas gained the
+  `ssh_credential_id` column.
+
+
 ### Synthetic probing / 拨测 (Phase 1)
 
 **Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured

--- a/internal/api/handler/metrics.go
+++ b/internal/api/handler/metrics.go
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
 
 package handler
 
@@ -13,86 +13,16 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/metrics"
 )
 
-var (
-	// MibeeDevicesTotal tracks the total number of devices by status and type.
-	MibeeDevicesTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mibee_devices_total",
-			Help: "Total number of devices",
-		},
-		[]string{"status", "type"},
-	)
-
-	// MibeeHeartbeatChecksTotal counts heartbeat checks by status.
-	MibeeHeartbeatChecksTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "mibee_heartbeat_checks_total",
-			Help: "Total heartbeat checks",
-		},
-		[]string{"status"},
-	)
-
-	// MibeeHeartbeatLatencySeconds records heartbeat check latency.
-	MibeeHeartbeatLatencySeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "mibee_heartbeat_latency_seconds",
-			Help:    "Heartbeat check latency",
-			Buckets: prometheus.DefBuckets,
-		},
-		[]string{"method"},
-	)
-
-	// MibeeScannerTasksTotal tracks the total number of scan tasks by status.
-	MibeeScannerTasksTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "mibee_scanner_tasks_total",
-			Help: "Total number of scan tasks by status",
-		},
-		[]string{"status"},
-	)
-
-	// MibeeScannerRunsTotal counts scan runs by status.
-	MibeeScannerRunsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "mibee_scanner_runs_total",
-			Help: "Total number of scan runs by status",
-		},
-		[]string{"status"},
-	)
-
-	// MibeeScannerDurationSeconds records scan execution duration.
-	MibeeScannerDurationSeconds = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Name:    "mibee_scanner_duration_seconds",
-			Help:    "Duration of scan executions",
-			Buckets: prometheus.DefBuckets,
-		},
-	)
-
-	// MibeeScannerHostsDiscovered counts total hosts discovered by scanner.
-	MibeeScannerHostsDiscovered = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "mibee_scanner_hosts_discovered",
-			Help: "Total number of hosts discovered by scanner",
-		},
-	)
-)
-
-func init() {
-	prometheus.MustRegister(MibeeDevicesTotal)
-	prometheus.MustRegister(MibeeHeartbeatChecksTotal)
-	prometheus.MustRegister(MibeeHeartbeatLatencySeconds)
-	prometheus.MustRegister(MibeeScannerTasksTotal)
-	prometheus.MustRegister(MibeeScannerRunsTotal)
-	prometheus.MustRegister(MibeeScannerDurationSeconds)
-	prometheus.MustRegister(MibeeScannerHostsDiscovered)
-}
+// The Prometheus collectors themselves live in internal/metrics (neutral
+// package) so the service layer can increment them without an
+// handler→service→handler import cycle (#238). These aliases keep the
+// historical handler.Mibee* references working.
 
 // MetricsHandler returns an http.Handler that serves Prometheus metrics.
 func MetricsHandler() http.Handler {
@@ -110,9 +40,9 @@ func UpdateDeviceMetrics(ctx context.Context, dbtx db.DBTX) {
 
 	// Reset all device gauges before setting new values to handle
 	// label combinations that no longer exist.
-	MibeeDevicesTotal.Reset()
+	metrics.MibeeDevicesTotal.Reset()
 
 	for _, s := range statuses {
-		MibeeDevicesTotal.WithLabelValues(s.Status, "").Set(float64(s.Count))
+		metrics.MibeeDevicesTotal.WithLabelValues(s.Status, "").Set(float64(s.Count))
 	}
 }

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -954,7 +954,14 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// scrapes these endpoints without credentials, and they leak no secrets
 	// (metrics are aggregate counters; SD exposes only device IPs/labels
 	// that the scanner already published). Keep them out of RequireAuth/Admin.
-	r.Handle("/metrics", handler.MetricsHandler())
+	// prometheus.metrics_path (#239): previously defined in config but the
+	// mount was hard-coded, silently ignoring the setting. Fall back to the
+	// default for empty/malformed values (must be an absolute path).
+	metricsPath := cfg.Prometheus.MetricsPath
+	if metricsPath == "" || metricsPath[0] != '/' {
+		metricsPath = "/metrics"
+	}
+	r.Handle(metricsPath, handler.MetricsHandler())
 	sdHandler := handler.NewSDHandler(dbConn, deviceSystemRepo)
 	r.Get("/sd", sdHandler.ServeHTTP)
 

--- a/internal/db/devices.sql.go
+++ b/internal/db/devices.sql.go
@@ -193,7 +193,7 @@ INSERT INTO devices (
     status, ip_address, mac_address, serial_number,
     purchase_date, warranty_expiry, tags, user_attributes
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 `
 
 type CreateDeviceParams struct {
@@ -276,6 +276,7 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 		&i.ScanOs,
 		&i.ScanHostname,
 		&i.NetworkID,
+		&i.SshCredentialID,
 		&i.FirstSeen,
 		&i.LastSeen,
 		&i.OfflineSince,
@@ -299,7 +300,7 @@ func (q *Queries) DeleteDevice(ctx context.Context, id int64) (int64, error) {
 }
 
 const getDevice = `-- name: GetDevice :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE id = ?
 `
@@ -340,6 +341,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 		&i.ScanOs,
 		&i.ScanHostname,
 		&i.NetworkID,
+		&i.SshCredentialID,
 		&i.FirstSeen,
 		&i.LastSeen,
 		&i.OfflineSince,
@@ -350,7 +352,7 @@ func (q *Queries) GetDevice(ctx context.Context, id int64) (Device, error) {
 }
 
 const getDeviceByIP = `-- name: GetDeviceByIP :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE ip_address = ?
 LIMIT 1
@@ -392,6 +394,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 		&i.ScanOs,
 		&i.ScanHostname,
 		&i.NetworkID,
+		&i.SshCredentialID,
 		&i.FirstSeen,
 		&i.LastSeen,
 		&i.OfflineSince,
@@ -402,7 +405,7 @@ func (q *Queries) GetDeviceByIP(ctx context.Context, ipAddress string) (Device, 
 }
 
 const getDeviceByMAC = `-- name: GetDeviceByMAC :one
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE json_extract(scan_attributes, '$.mac') = ?
 LIMIT 1
@@ -448,6 +451,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 		&i.ScanOs,
 		&i.ScanHostname,
 		&i.NetworkID,
+		&i.SshCredentialID,
 		&i.FirstSeen,
 		&i.LastSeen,
 		&i.OfflineSince,
@@ -458,7 +462,7 @@ func (q *Queries) GetDeviceByMAC(ctx context.Context, scanAttributes string) (De
 }
 
 const listDevices = `-- name: ListDevices :many
-SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+SELECT id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 FROM devices
 WHERE (? = '' OR status = ?)
   AND (? = '' OR type = ?)
@@ -524,6 +528,7 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 			&i.ScanOs,
 			&i.ScanHostname,
 			&i.NetworkID,
+			&i.SshCredentialID,
 			&i.FirstSeen,
 			&i.LastSeen,
 			&i.OfflineSince,
@@ -613,7 +618,7 @@ SET name = ?, type = ?, brand = ?, model = ?, location = ?, purpose = ?, descrip
     status = ?, ip_address = ?, mac_address = ?, serial_number = ?,
     purchase_date = ?, warranty_expiry = ?, tags = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, first_seen, last_seen, offline_since, created_at, updated_at
+RETURNING id, device_uuid, name, type, brand, model, location, purpose, description, status, ip_address, mac_address, serial_number, purchase_date, warranty_expiry, tags, scan_source, prometheus_labels, last_scanned_at, last_scan_task_id, open_ports, detected_services, prometheus_url, node_exporter_url, last_scan_rtt_ms, scan_attributes, user_attributes, scan_vendor, scan_mac, scan_os, scan_hostname, network_id, ssh_credential_id, first_seen, last_seen, offline_since, created_at, updated_at
 `
 
 type UpdateDeviceParams struct {
@@ -689,6 +694,7 @@ func (q *Queries) UpdateDevice(ctx context.Context, arg UpdateDeviceParams) (Dev
 		&i.ScanOs,
 		&i.ScanHostname,
 		&i.NetworkID,
+		&i.SshCredentialID,
 		&i.FirstSeen,
 		&i.LastSeen,
 		&i.OfflineSince,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -99,6 +99,7 @@ type Device struct {
 	ScanOs           *string    `json:"scan_os"`
 	ScanHostname     *string    `json:"scan_hostname"`
 	NetworkID        *int64     `json:"network_id"`
+	SshCredentialID  *int64     `json:"ssh_credential_id"`
 	FirstSeen        *time.Time `json:"first_seen"`
 	LastSeen         *time.Time `json:"last_seen"`
 	OfflineSince     *time.Time `json:"offline_since"`
@@ -392,6 +393,7 @@ type ScanTask struct {
 	Timeout         int64      `json:"timeout"`
 	ConcurrentHosts int64      `json:"concurrent_hosts"`
 	CredentialID    *int64     `json:"credential_id"`
+	NetworkID       *int64     `json:"network_id"`
 	Enabled         int64      `json:"enabled"`
 	LastRunAt       *time.Time `json:"last_run_at"`
 	NextRunAt       *time.Time `json:"next_run_at"`
@@ -443,6 +445,20 @@ type SnmpCredential struct {
 	UpdatedAt         time.Time `json:"updated_at"`
 }
 
+type SshCredential struct {
+	ID            int64     `json:"id"`
+	Name          string    `json:"name"`
+	AuthMethod    string    `json:"auth_method"`
+	Username      string    `json:"username"`
+	SecretEnc     string    `json:"secret_enc"`
+	PassphraseEnc string    `json:"passphrase_enc"`
+	HostKeyFp     string    `json:"host_key_fp"`
+	Enabled       int64     `json:"enabled"`
+	Notes         string    `json:"notes"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
 type Subnet struct {
 	ID        int64      `json:"id"`
 	NetworkID int64      `json:"network_id"`
@@ -478,6 +494,13 @@ type User struct {
 	LockedUntil         *time.Time `json:"locked_until"`
 	PasswordChangedAt   *time.Time `json:"password_changed_at"`
 	MustChangePassword  bool       `json:"must_change_password"`
+}
+
+type UserNetworkGrant struct {
+	ID        int64     `json:"id"`
+	UserID    int64     `json:"user_id"`
+	NetworkID int64     `json:"network_id"`
+	GrantedAt time.Time `json:"granted_at"`
 }
 
 type UserTotp struct {

--- a/internal/db/scan_tasks.sql.go
+++ b/internal/db/scan_tasks.sql.go
@@ -47,7 +47,7 @@ const createScanTask = `-- name: CreateScanTask :one
 
 INSERT INTO scan_tasks (name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
-RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 `
 
 type CreateScanTaskParams struct {
@@ -91,6 +91,7 @@ func (q *Queries) CreateScanTask(ctx context.Context, arg CreateScanTaskParams) 
 		&i.Timeout,
 		&i.ConcurrentHosts,
 		&i.CredentialID,
+		&i.NetworkID,
 		&i.Enabled,
 		&i.LastRunAt,
 		&i.NextRunAt,
@@ -115,7 +116,7 @@ func (q *Queries) DeleteScanTask(ctx context.Context, id int64) (int64, error) {
 }
 
 const getScanTask = `-- name: GetScanTask :one
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE id = ?
 `
@@ -133,6 +134,7 @@ func (q *Queries) GetScanTask(ctx context.Context, id int64) (ScanTask, error) {
 		&i.Timeout,
 		&i.ConcurrentHosts,
 		&i.CredentialID,
+		&i.NetworkID,
 		&i.Enabled,
 		&i.LastRunAt,
 		&i.NextRunAt,
@@ -144,7 +146,7 @@ func (q *Queries) GetScanTask(ctx context.Context, id int64) (ScanTask, error) {
 }
 
 const listEnabledScanTasks = `-- name: ListEnabledScanTasks :many
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE enabled = 1
 `
@@ -168,6 +170,7 @@ func (q *Queries) ListEnabledScanTasks(ctx context.Context) ([]ScanTask, error) 
 			&i.Timeout,
 			&i.ConcurrentHosts,
 			&i.CredentialID,
+			&i.NetworkID,
 			&i.Enabled,
 			&i.LastRunAt,
 			&i.NextRunAt,
@@ -189,7 +192,7 @@ func (q *Queries) ListEnabledScanTasks(ctx context.Context) ([]ScanTask, error) 
 }
 
 const listScanTasks = `-- name: ListScanTasks :many
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 ORDER BY id
 LIMIT ? OFFSET ?
@@ -219,6 +222,7 @@ func (q *Queries) ListScanTasks(ctx context.Context, arg ListScanTasksParams) ([
 			&i.Timeout,
 			&i.ConcurrentHosts,
 			&i.CredentialID,
+			&i.NetworkID,
 			&i.Enabled,
 			&i.LastRunAt,
 			&i.NextRunAt,
@@ -240,7 +244,7 @@ func (q *Queries) ListScanTasks(ctx context.Context, arg ListScanTasksParams) ([
 }
 
 const listScanTasksSearch = `-- name: ListScanTasksSearch :many
-SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+SELECT id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 FROM scan_tasks
 WHERE (? = '' OR INSTR(lower(name), lower(?)) > 0 OR INSTR(lower(targets), lower(?)) > 0)
 ORDER BY id
@@ -286,6 +290,7 @@ func (q *Queries) ListScanTasksSearch(ctx context.Context, arg ListScanTasksSear
 			&i.Timeout,
 			&i.ConcurrentHosts,
 			&i.CredentialID,
+			&i.NetworkID,
 			&i.Enabled,
 			&i.LastRunAt,
 			&i.NextRunAt,
@@ -327,7 +332,7 @@ UPDATE scan_tasks
 SET name = ?, targets = ?, cron_expr = ?, pipeline_config = ?, global_labels = ?,
     timeout = ?, concurrent_hosts = ?, credential_id = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?
-RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
+RETURNING id, name, targets, cron_expr, pipeline_config, global_labels, timeout, concurrent_hosts, credential_id, network_id, enabled, last_run_at, next_run_at, last_run_status, created_at, updated_at
 `
 
 type UpdateScanTaskParams struct {
@@ -365,6 +370,7 @@ func (q *Queries) UpdateScanTask(ctx context.Context, arg UpdateScanTaskParams) 
 		&i.Timeout,
 		&i.ConcurrentHosts,
 		&i.CredentialID,
+		&i.NetworkID,
 		&i.Enabled,
 		&i.LastRunAt,
 		&i.NextRunAt,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+// Package metrics holds the process-global Prometheus collectors for MiBee's
+// own operational signals (device counts, heartbeat outcomes, scanner runs).
+// It lives OUTSIDE internal/api/handler so the service layer (heartbeat,
+// scanner runner, scheduler) can increment counters without importing the
+// HTTP layer — handler imports service, never the reverse (#238).
+//
+// Everything registers on the DefaultRegisterer in init() (process-global,
+// like /metrics itself). Consumers must .Inc()/.Observe()/.Set(); nothing here
+// needs a handle.
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"mibee-steward/internal/db"
+)
+
+var (
+	// MibeeDevicesTotal tracks the total number of devices by status and type.
+	// Refreshed by handler.UpdateDeviceMetrics (seeded at router start and
+	// after device mutations).
+	MibeeDevicesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mibee_devices_total",
+			Help: "Total number of devices",
+		},
+		[]string{"status", "type"},
+	)
+
+	// MibeeHeartbeatChecksTotal counts heartbeat probe outcomes. Incremented
+	// by HeartbeatService.probeAndRecord per probe (#238 — previously
+	// registered but never written, leaving the HeartbeatFailures alert dead).
+	MibeeHeartbeatChecksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mibee_heartbeat_checks_total",
+			Help: "Total heartbeat checks",
+		},
+		[]string{"status"},
+	)
+
+	// MibeeHeartbeatLatencySeconds records heartbeat probe latency by method.
+	MibeeHeartbeatLatencySeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "mibee_heartbeat_latency_seconds",
+			Help:    "Heartbeat check latency",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method"},
+	)
+
+	// MibeeScannerRunsTotal counts scan runs by outcome. Incremented by the
+	// runner's complete/fail paths (#238).
+	MibeeScannerRunsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mibee_scanner_runs_total",
+			Help: "Total number of scan runs by status",
+		},
+		[]string{"status"},
+	)
+
+	// MibeeScannerDurationSeconds records scan execution duration.
+	MibeeScannerDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "mibee_scanner_duration_seconds",
+			Help:    "Duration of scan executions",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+
+	// MibeeScannerHostsDiscovered counts total alive hosts found by scans.
+	MibeeScannerHostsDiscovered = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mibee_scanner_hosts_discovered",
+			Help: "Total number of hosts discovered",
+		},
+	)
+
+	// MibeeScannerTasksTotal gauges the scan-task count by enabled state.
+	// Refreshed by RefreshScannerTaskGauges at scheduler start and after task
+	// CRUD (#238).
+	MibeeScannerTasksTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mibee_scanner_tasks_total",
+			Help: "Total number of scan tasks by status",
+		},
+		[]string{"status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(MibeeDevicesTotal)
+	prometheus.MustRegister(MibeeHeartbeatChecksTotal)
+	prometheus.MustRegister(MibeeHeartbeatLatencySeconds)
+	prometheus.MustRegister(MibeeScannerRunsTotal)
+	prometheus.MustRegister(MibeeScannerDurationSeconds)
+	prometheus.MustRegister(MibeeScannerHostsDiscovered)
+	prometheus.MustRegister(MibeeScannerTasksTotal)
+}
+
+// RefreshScannerTaskGauges recomputes mibee_scanner_tasks_total{status} from
+// the DB. Best-effort: errors are returned to the caller, who logs and moves
+// on — a stale gauge never fails a scan-task write.
+func RefreshScannerTaskGauges(ctx context.Context, queries *db.Queries) error {
+	tasks, err := queries.ListScanTasks(ctx, db.ListScanTasksParams{Limit: 100000, Offset: 0})
+	if err != nil {
+		return err
+	}
+	enabled, disabled := 0, 0
+	for _, t := range tasks {
+		if t.Enabled == 1 {
+			enabled++
+		} else {
+			disabled++
+		}
+	}
+	MibeeScannerTasksTotal.WithLabelValues("enabled").Set(float64(enabled))
+	MibeeScannerTasksTotal.WithLabelValues("disabled").Set(float64(disabled))
+	return nil
+}

--- a/internal/service/batch_test.go
+++ b/internal/service/batch_test.go
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS devices (
     scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
     scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/device_attributes_repo_test.go
+++ b/internal/service/device_attributes_repo_test.go
@@ -54,6 +54,7 @@ func setupAttributesTestDB(t *testing.T) (*DeviceRepository, *sql.DB, int64) {
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/device_list_sort_repo_test.go
+++ b/internal/service/device_list_sort_repo_test.go
@@ -55,6 +55,7 @@ func setupSortTestDB(t *testing.T) (*DeviceRepository, *sql.DB) {
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/device_system_repo_test.go
+++ b/internal/service/device_system_repo_test.go
@@ -56,6 +56,7 @@ func setupDeviceSystemTestDB(t *testing.T) (*DeviceSystemRepository, *sql.DB, in
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/device_system_test.go
+++ b/internal/service/device_system_test.go
@@ -54,6 +54,7 @@ func setupDeviceSystemService(t *testing.T) (*DeviceSystemService, *sql.DB, int6
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -60,6 +60,7 @@ func setupDeviceService(t *testing.T) (*DeviceService, *sql.DB) {
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -60,6 +60,7 @@ func setupExportTest(t *testing.T) (*ExportService, *sql.DB) {
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -22,6 +22,7 @@ import (
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/metrics"
 	"mibee-steward/internal/service/probe"
 	"mibee-steward/internal/service/scannerv2"
 )
@@ -452,6 +453,13 @@ func (s *HeartbeatService) probeAndRecord(ctx context.Context, cfg probeConfig) 
 		status = "fail"
 		errorMsg = result.ErrorMessage
 	}
+
+	// Operational metrics (#238): the checks counter is what the
+	// HeartbeatFailures Prometheus alert consumes — it was registered but
+	// never incremented before, leaving that alert permanently at 0. Mirrors
+	// the store row below (one increment per recorded outcome).
+	metrics.MibeeHeartbeatChecksTotal.WithLabelValues(status).Inc()
+	metrics.MibeeHeartbeatLatencySeconds.WithLabelValues(cfg.Method).Observe(result.Latency.Seconds())
 
 	// Hand the result to the dedicated time-series store's batched writer.
 	// Enqueue is non-blocking (drops on overflow with a warning); a dropped

--- a/internal/service/heartbeat_test.go
+++ b/internal/service/heartbeat_test.go
@@ -68,6 +68,7 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 			scan_os       TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.os')) STORED,
 			scan_hostname TEXT GENERATED ALWAYS AS (json_extract(scan_attributes, '$.hostname')) STORED,
 			network_id INTEGER,
+			ssh_credential_id INTEGER,
 			first_seen TIMESTAMP,
 			last_seen TIMESTAMP,
 			offline_since TIMESTAMP,

--- a/internal/service/scannerv2/runner/runner.go
+++ b/internal/service/scannerv2/runner/runner.go
@@ -31,6 +31,7 @@ import (
 
 	"mibee-steward/internal/changedetect"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/metrics"
 	"mibee-steward/internal/service/scannerv2"
 	"mibee-steward/internal/service/scannerv2/engine"
 )
@@ -302,6 +303,11 @@ func (rn *Runner) Run(ctx context.Context, taskID int64, targets string, timeout
 	}); err != nil {
 		rn.logger.Error("scan runner: finalize run failed", "run_id", runID, "error", err)
 	}
+	// Run outcome metrics (#238): runs counter + duration histogram + the
+	// alive-host tally. Mirrors the run row above.
+	metrics.MibeeScannerRunsTotal.WithLabelValues("completed").Inc()
+	metrics.MibeeScannerDurationSeconds.Observe(duration.Seconds())
+	metrics.MibeeScannerHostsDiscovered.Add(float64(aliveHosts))
 	// 5. Update task last-run status (best-effort) — log on failure so a
 	// stale last_run_status (task UI stuck on "running") is observable.
 	if err := rn.queries.UpdateScanTaskStatus(ctx, db.UpdateScanTaskStatusParams{
@@ -316,6 +322,8 @@ func (rn *Runner) Run(ctx context.Context, taskID int64, targets string, timeout
 // failRun marks a run failed and updates the task's last-run status.
 func (rn *Runner) failRun(ctx context.Context, runID, taskID int64, duration time.Duration, msg string) {
 	rn.logger.Error("scan runner: run failed", "run_id", runID, "task_id", taskID, "error", msg)
+	metrics.MibeeScannerRunsTotal.WithLabelValues("failed").Inc()
+	metrics.MibeeScannerDurationSeconds.Observe(duration.Seconds())
 	finish := time.Now()
 	// best-effort: log on failure so the run/task status reflects reality.
 	if err := rn.queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{

--- a/internal/service/scannerv2/scheduler/scheduler.go
+++ b/internal/service/scannerv2/scheduler/scheduler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/metrics"
 )
 
 // ScanFunc executes one scan task. It is invoked by the scheduler on each cron
@@ -120,6 +121,12 @@ func (s *Scheduler) Start(ctx context.Context) {
 		s.mu.Lock()
 		s.scheduler.Start()
 		s.mu.Unlock()
+	}
+
+	// Seed the task-count gauges (#238). Best-effort: a failed refresh just
+	// leaves the gauges absent until the next task CRUD triggers one.
+	if err := metrics.RefreshScannerTaskGauges(ctx, s.queries); err != nil {
+		s.logger.Debug("scheduler: refresh task gauges failed", "error", err)
 	}
 
 	// Periodic stale-run sweeper. Without this, a run that hangs (e.g. a probe

--- a/internal/service/scannerv2/taskservice/taskservice.go
+++ b/internal/service/scannerv2/taskservice/taskservice.go
@@ -25,6 +25,7 @@ import (
 	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/metrics"
 	"mibee-steward/internal/service/scannerv2/scheduler"
 )
 
@@ -51,6 +52,15 @@ type Service struct {
 // browsing).
 func New(queries *db.Queries, conn db.DBTX, sched *scheduler.Scheduler) *Service {
 	return &Service{queries: queries, conn: conn, scheduler: sched}
+}
+
+// refreshTaskGauges recomputes mibee_scanner_tasks_total after a mutation
+// (#238). Best-effort by design: a failed refresh is logged at debug and never
+// fails the write it follows.
+func (s *Service) refreshTaskGauges(ctx context.Context) {
+	if err := metrics.RefreshScannerTaskGauges(ctx, s.queries); err != nil {
+		slog.Debug("taskservice: refresh task gauges failed", "error", err)
+	}
 }
 
 // ResolveNetworkFromTargets maps a scan task's targets to a networks row id
@@ -158,6 +168,7 @@ func (s *Service) CreateTask(ctx context.Context, req domain.ScanTaskRequest) (d
 		}
 	}
 	s.stampTaskNetwork(ctx, task.ID, task.Targets, slog.Default())
+	s.refreshTaskGauges(ctx)
 	return toTaskResponse(task), nil
 }
 
@@ -388,6 +399,7 @@ func (s *Service) UpdateTask(ctx context.Context, id int64, req domain.UpdateSca
 	if targetsChanged {
 		s.stampTaskNetwork(ctx, id, targets, slog.Default())
 	}
+	s.refreshTaskGauges(ctx)
 	return resp, nil
 }
 
@@ -409,6 +421,7 @@ func (s *Service) DeleteTask(ctx context.Context, id int64) error {
 	if rows == 0 {
 		return ErrScanTaskNotFound
 	}
+	s.refreshTaskGauges(ctx)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #237 · Fixes #238 · Fixes #239

## #238 死指标（P1）

`mibee_heartbeat_checks_total` 等 6 个 collector 注册后从不更新 → **HeartbeatFailures 告警恒为 0，从未生效**。

- 新建中立包 `internal/metrics`（service 层可引用，避免 handler→service 循环依赖）
- `heartbeat.probeAndRecord`：递增 `checks_total{status}` + 观测 `latency_seconds{method}`
- runner 完成/失败：递增 `runs_total{status}` + 观察时长 + 累加 `hosts_discovered`
- `tasks_total{status}`：scheduler 启动 + 任务 CRUD 后刷新

**63.101 实机验证**：启动 35 秒后 `checks_total{success}=59 / {fail}=8`、latency 直方图四方法、`tasks_total{enabled}=1`。

## #237 sqlc 漂移（P1）

自 #233 起 `internal/db` 落后于 schema.sql，全量重生成会产出 Row-struct 破坏 ~10 处调用点（#235 被迫手术式合并）。根治：

- devices.sql 补 `ssh_credential_id`（6 清单）、scan_tasks.sql 补 `network_id`（7 清单）→ 列集匹配表定义 → 模型复用回归，**调用点零改动**
- 全量重生成幂等（重复 `sqlc generate` diff 为空）
- **CI 护栏**：sqlc-verify 升级 v1.31.1 + `sqlc generate && git diff --exit-code internal/db/`，漂移即红

## #239 metrics_path（P3）

`prometheus.metrics_path` 此前定义于配置但挂载硬编码 `/metrics`（静默忽略）。现读取配置值，空/非绝对路径回退默认。

## 测试

- `go build ./...` / `go vet` / golangci-lint 0 issues / `go test ./...` 35 包全绿
- CHANGELOG（根 + zh/en 镜像）已记录三个修复