### PR TITLE
refactor(api): 清偿 handler/service charter 债务 — 四个直连 DB handler 迁移 service 层（#240）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Handler/service charter debt cleared: the 4 grandfathered handlers migrated (issue #240)
+
+The last four mutating handlers that wrote to the DB directly (documented as
+charter debt since #166) now go through service layers — the charter has no
+remaining debt rows:
+
+- **`service.NetworkService`**: network CRUD; the raw-SQL UPDATE workaround
+  (sqlc truncation) moved out of the handler into the service.
+- **`service.AgentTokenService`**: agent-token create/revoke/delete, including
+  the `networks.agent_id` stamp-on-create / conditional-clear-on-revoke wiring.
+  Token MINTING stays in the HTTP layer (one-time credential display) and is
+  injected as a `TokenMinter` func — keeps the service free of api-layer imports.
+- **`service.AgentCommandService`**: enqueue (with the scan-target
+  network-boundary check, now returning a typed `BoundaryError` that carries the
+  offending IPs verbatim), ack, complete.
+- **`service.ScannerResultService`**: `BulkDeleteResults` (before-date
+  validation + delete).
+
+Read-only passthroughs (List/Poll/ListAll/export) stay on `*db.Queries` per the
+charter's sanctioned exception. Behavior is unchanged at the HTTP surface (one
+message nuance: a revoke of an already-revoked token now returns "agent token
+not found" instead of "...or already revoked"). `internal/api/AGENTS.md` debt
+table cleared.
 
 ### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Handler/service charter debt cleared: the 4 grandfathered handlers migrated (issue #240)
+
+The last four mutating handlers that wrote to the DB directly (documented as
+charter debt since #166) now go through service layers — the charter has no
+remaining debt rows:
+
+- **`service.NetworkService`**: network CRUD; the raw-SQL UPDATE workaround
+  (sqlc truncation) moved out of the handler into the service.
+- **`service.AgentTokenService`**: agent-token create/revoke/delete, including
+  the `networks.agent_id` stamp-on-create / conditional-clear-on-revoke wiring.
+  Token MINTING stays in the HTTP layer (one-time credential display) and is
+  injected as a `TokenMinter` func — keeps the service free of api-layer imports.
+- **`service.AgentCommandService`**: enqueue (with the scan-target
+  network-boundary check, now returning a typed `BoundaryError` that carries the
+  offending IPs verbatim), ack, complete.
+- **`service.ScannerResultService`**: `BulkDeleteResults` (before-date
+  validation + delete).
+
+Read-only passthroughs (List/Poll/ListAll/export) stay on `*db.Queries` per the
+charter's sanctioned exception. Behavior is unchanged at the HTTP surface (one
+message nuance: a revoke of an already-revoked token now returns "agent token
+not found" instead of "...or already revoked"). `internal/api/AGENTS.md` debt
+table cleared.
 
 ### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Handler/service charter debt cleared: the 4 grandfathered handlers migrated (issue #240)
+
+The last four mutating handlers that wrote to the DB directly (documented as
+charter debt since #166) now go through service layers — the charter has no
+remaining debt rows:
+
+- **`service.NetworkService`**: network CRUD; the raw-SQL UPDATE workaround
+  (sqlc truncation) moved out of the handler into the service.
+- **`service.AgentTokenService`**: agent-token create/revoke/delete, including
+  the `networks.agent_id` stamp-on-create / conditional-clear-on-revoke wiring.
+  Token MINTING stays in the HTTP layer (one-time credential display) and is
+  injected as a `TokenMinter` func — keeps the service free of api-layer imports.
+- **`service.AgentCommandService`**: enqueue (with the scan-target
+  network-boundary check, now returning a typed `BoundaryError` that carries the
+  offending IPs verbatim), ack, complete.
+- **`service.ScannerResultService`**: `BulkDeleteResults` (before-date
+  validation + delete).
+
+Read-only passthroughs (List/Poll/ListAll/export) stay on `*db.Queries` per the
+charter's sanctioned exception. Behavior is unchanged at the HTTP surface (one
+message nuance: a revoke of an already-revoked token now returns "agent token
+not found" instead of "...or already revoked"). `internal/api/AGENTS.md` debt
+table cleared.
 
 ### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
 

--- a/internal/api/handler/agent_admin.go
+++ b/internal/api/handler/agent_admin.go
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
 
 package handler
 
 import (
-	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -20,20 +20,24 @@ import (
 	"mibee-steward/internal/api/middleware"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service"
 )
 
 // AgentAdminHandler exposes admin-only CRUD for discovery-agent bearer tokens
 // (POST/GET/DELETE /api/v1/agents/tokens). An admin creates one token per
 // network/agent and hands the plaintext to the agent operator; the agent then
-// presents it to the ingestion endpoints (RequireAgentToken). This handler is
-// the management surface; auth verification lives in the middleware.
+// presents it to the ingestion endpoints (RequireAgentToken). Mutations go
+// through service.AgentTokenService (#240 — charter debt migration); the
+// plaintext is minted here (one-time credential display concern) and injected
+// into the service. List is a read passthrough.
 type AgentAdminHandler struct {
 	queries *db.Queries
+	svc     *service.AgentTokenService
 }
 
 // NewAgentAdminHandler constructs the handler. queries is the center's DB.
-func NewAgentAdminHandler(queries *db.Queries) *AgentAdminHandler {
-	return &AgentAdminHandler{queries: queries}
+func NewAgentAdminHandler(queries *db.Queries, svc *service.AgentTokenService) *AgentAdminHandler {
+	return &AgentAdminHandler{queries: queries, svc: svc}
 }
 
 // Create handles POST /api/v1/agents/tokens — mint a new agent token.
@@ -45,60 +49,19 @@ func (h *AgentAdminHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if req.AgentID == "" {
-		Error(w, http.StatusBadRequest, "agent_id is required")
-		return
-	}
-	if req.NetworkID <= 0 {
-		Error(w, http.StatusBadRequest, "network_id is required")
-		return
-	}
-	// Verify the network exists so the foreign key isn't dangling.
-	if _, err := h.queries.GetNetwork(r.Context(), req.NetworkID); err != nil {
-		Error(w, http.StatusBadRequest, "network_id does not refer to a known network")
-		return
-	}
-
-	plaintext, hash := middleware.GenerateAgentToken()
-	networkIDPtr := req.NetworkID // take address of a stable local
-	row, err := h.queries.CreateAgentToken(r.Context(), db.CreateAgentTokenParams{
-		AgentID:   req.AgentID,
-		TokenHash: hash,
-		NetworkID: &networkIDPtr,
-		Name:      req.Name,
-	})
+	resp, err := h.svc.Create(r.Context(), req, middleware.GenerateAgentToken)
 	if err != nil {
-		// UNIQUE(agent_id) collision is the common error here.
-		Error(w, http.StatusConflict, "agent_id already exists; choose a unique id")
+		switch {
+		case errors.Is(err, service.ErrAgentIDRequired), errors.Is(err, service.ErrNetworkIDInvalid):
+			Error(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, service.ErrAgentIDTaken):
+			Error(w, http.StatusConflict, err.Error())
+		default:
+			Error(w, http.StatusInternalServerError, "failed to create agent token")
+		}
 		return
 	}
-
-	// Mark the network as agent-managed: this is the wiring that makes the
-	// center's heartbeat exclusion (no cross-subnet probing of agent devices)
-	// and the lease sweeper scope engage automatically — without it an admin
-	// would have to run manual SQL. Best-effort: a failure here leaves the
-	// token functional (reports still work); the network just isn't scoped.
-	agentIDStr := req.AgentID
-	// Best-effort: a failure here leaves the token functional (reports still
-	// work); the network just isn't scoped for heartbeat exclusion. The error
-	// is intentionally discarded — see the comment above.
-	_ = h.queries.SetNetworkAgentID(r.Context(), db.SetNetworkAgentIDParams{
-		AgentID: &agentIDStr,
-		ID:      req.NetworkID,
-	})
-
-	Created(w, domain.AgentTokenCreatedResponse{
-		AgentTokenResponse: domain.AgentTokenResponse{
-			ID:         row.ID,
-			AgentID:    row.AgentID,
-			NetworkID:  row.NetworkID,
-			Name:       row.Name,
-			CreatedAt:  row.CreatedAt,
-			LastUsedAt: row.LastUsedAt,
-			RevokedAt:  row.RevokedAt,
-		},
-		Token: plaintext,
-	})
+	Created(w, resp)
 }
 
 // List handles GET /api/v1/agents/tokens — list all agent tokens (hash only,
@@ -133,22 +96,14 @@ func (h *AgentAdminHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	// Fetch the token first so we can clear its network's agent_id after.
-	tok, err := h.queries.GetAgentToken(r.Context(), id)
-	if err != nil {
-		Error(w, http.StatusNotFound, "agent token not found")
-		return
-	}
-	n, err := h.queries.RevokeAgentToken(r.Context(), id)
-	if err != nil {
+	if err := h.svc.Revoke(r.Context(), id); err != nil {
+		if errors.Is(err, service.ErrAgentTokenNotFound) {
+			Error(w, http.StatusNotFound, err.Error())
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to revoke agent token")
 		return
 	}
-	if n == 0 {
-		Error(w, http.StatusNotFound, "agent token not found or already revoked")
-		return
-	}
-	h.clearNetworkAgentID(r.Context(), tok)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -160,46 +115,15 @@ func (h *AgentAdminHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	tok, err := h.queries.GetAgentToken(r.Context(), id)
-	if err != nil {
-		Error(w, http.StatusNotFound, "agent token not found")
-		return
-	}
-	n, err := h.queries.DeleteAgentToken(r.Context(), id)
-	if err != nil {
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, service.ErrAgentTokenNotFound) {
+			Error(w, http.StatusNotFound, err.Error())
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to delete agent token")
 		return
 	}
-	if n == 0 {
-		Error(w, http.StatusNotFound, "agent token not found")
-		return
-	}
-	h.clearNetworkAgentID(r.Context(), tok)
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// clearNetworkAgentID nulls out the agent_id on the token's bound network,
-// but ONLY if it matches the token's own agent_id (so revoking a stale token
-// doesn't clobber a newer token that re-uses the network). Best-effort: a
-// failure here doesn't undo the revoke/delete.
-func (h *AgentAdminHandler) clearNetworkAgentID(ctx context.Context, tok db.AgentToken) {
-	if tok.NetworkID == nil {
-		return
-	}
-	net, err := h.queries.GetNetwork(ctx, *tok.NetworkID)
-	if err != nil {
-		return
-	}
-	// Only clear if the network's agent_id matches THIS token's agent_id — a
-	// different agent_id means a newer token has since claimed the network.
-	if net.AgentID == nil || *net.AgentID != tok.AgentID {
-		return
-	}
-	empty := ""
-	_ = h.queries.SetNetworkAgentID(ctx, db.SetNetworkAgentIDParams{
-		AgentID: &empty,
-		ID:      *tok.NetworkID,
-	})
 }
 
 // parseAgentID extracts the {id} path param as a positive int64.

--- a/internal/api/handler/agent_admin_test.go
+++ b/internal/api/handler/agent_admin_test.go
@@ -18,6 +18,7 @@ import (
 	"mibee-steward/internal/api/handler"
 	sqldb "mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service"
 	"mibee-steward/internal/testutil"
 )
 
@@ -35,7 +36,7 @@ func setupAgentAdminServer(t *testing.T) (srv *httptest.Server, dbConn *sql.DB, 
 	require.NoError(t, err)
 	networkID = net.ID
 
-	adm := handler.NewAgentAdminHandler(queries)
+	adm := handler.NewAgentAdminHandler(queries, service.NewAgentTokenService(queries))
 	r := chi.NewMux()
 	r.Use(chimw.RequestID)
 	r.Use(chimw.Recoverer)

--- a/internal/api/handler/agent_command.go
+++ b/internal/api/handler/agent_command.go
@@ -1,30 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
 
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
 	"mibee-steward/internal/api/middleware"
-	"mibee-steward/internal/cidrutil"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service"
 )
 
 // AgentCommandHandler serves both halves of the center→agent command channel:
@@ -34,29 +32,24 @@ import (
 //
 // This is the pull model: the agent fetches commands on its report cycle, so no
 // inbound connection from the center is needed (fits agent-behind-NAT).
+// Mutations go through service.AgentCommandService (#240 — charter debt
+// migration, including the scan-target network-boundary check); Poll/ListAll
+// are read passthroughs.
 type AgentCommandHandler struct {
 	queries *db.Queries
+	svc     *service.AgentCommandService
 }
 
 // NewAgentCommandHandler constructs the handler.
-func NewAgentCommandHandler(queries *db.Queries) *AgentCommandHandler {
-	return &AgentCommandHandler{queries: queries}
+func NewAgentCommandHandler(queries *db.Queries, svc *service.AgentCommandService) *AgentCommandHandler {
+	return &AgentCommandHandler{queries: queries, svc: svc}
 }
 
 // Create handles POST /api/v1/agents/{agentId}/commands — admin enqueues a
 // command (currently "scan") for a specific agent. The agent picks it up on its
-// next poll.
-//
-// Boundary check (issue #19, Layer 1): for "scan" commands the requested
-// targets must fall inside the agent's bound network CIDR. This is the earliest
-// interception point and the cheapest defense against cross-subnet mis-dispatch
-// — exactly what let agent-62 scan 192.168.63.0/24 and strand 30 devices into
-// the wrong network. If the network has no CIDR configured we do NOT reject
-// (degrade-open + warn): historical networks may lack cidr, and forcing it
-// here would block every existing agent. CIDR enforcement is a separate
-// prerequisite (issue #19 前置工作). An out-of-network target is a hard 400 —
-// we surface the offending IPs so the admin sees exactly what was rejected
-// rather than silently scanning a subset.
+// next poll. The network-boundary rejection for scan commands (issue #19,
+// Layer 1) is enforced by the service; its error message (with the offending
+// IPs) is surfaced verbatim as the 400 body.
 func (h *AgentCommandHandler) Create(w http.ResponseWriter, r *http.Request) {
 	agentID := chi.URLParam(r, "agentId")
 	if agentID == "" {
@@ -71,90 +64,19 @@ func (h *AgentCommandHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if req.Command == "" {
-		req.Command = "scan"
-	}
-
-	// Enforce the network boundary for scan commands. Other command types (none
-	// today, but the channel is extensible) skip this — only "scan" carries a
-	// targets field that could reach foreign subnets.
-	if req.Command == "scan" {
-		if bad := validateScanTargets(r.Context(), h.queries, agentID, req.Payload); bad != "" {
-			Error(w, http.StatusBadRequest, bad)
+	row, err := h.svc.Enqueue(r.Context(), agentID, req.Command, req.Payload)
+	if err != nil {
+		var boundary *service.BoundaryError
+		switch {
+		case errors.Is(err, service.ErrAgentIDRequired), errors.As(err, &boundary):
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		default:
+			Error(w, http.StatusInternalServerError, "failed to create agent command")
 			return
 		}
 	}
-
-	payloadBytes, _ := json.Marshal(req.Payload)
-	row, err := h.queries.CreateAgentCommand(r.Context(), db.CreateAgentCommandParams{
-		AgentID: agentID,
-		Command: req.Command,
-		Payload: string(payloadBytes),
-	})
-	if err != nil {
-		Error(w, http.StatusInternalServerError, "failed to create agent command")
-		return
-	}
 	Created(w, row)
-}
-
-// validateScanTargets checks that a scan command's targets fall inside the
-// agent's bound network. Returns "" when the command is acceptable, or a
-// human-readable reason string (to be used as the 400 body) when it must be
-// rejected. It never errors out on missing CIDR — that degrades to allow +
-// warn so historical networks without cidr aren't locked out (see the Layer 1
-// note above and issue #19 前置工作).
-func validateScanTargets(ctx context.Context, queries *db.Queries, agentID string, payload map[string]interface{}) string {
-	rawTargets, _ := payload["targets"].(string)
-	targets := strings.TrimSpace(rawTargets)
-	if targets == "" {
-		// Missing targets is the agent-command layer's own concern (the poller
-		// rejects it as "missing targets"); not a CIDR issue. Let it through.
-		return ""
-	}
-	net, err := queries.GetNetworkByAgentID(ctx, &agentID)
-	if err != nil {
-		// No network bound to this agent_id (unknown agent, or the network row
-		// has no agent_id stamp). We can't validate, so allow + warn rather than
-		// hard-failing — the agent itself will reject the command if it can't
-		// reach the target. This keeps the boundary check best-effort.
-		slog.Warn("agent command: cannot resolve agent network for boundary check; allowing",
-			"agent_id", agentID, "error", err)
-		return ""
-	}
-	cidr := ""
-	if net.Cidr != nil {
-		cidr = *net.Cidr
-	}
-	ipNet, perr := cidrutil.ParseNetwork(cidr)
-	if errors.Is(perr, cidrutil.ErrEmptyCIDR) {
-		// Network exists but has no cidr configured — degrade-open + warn.
-		// This is the gap the cidr-enforcement prerequisite (issue #19) closes.
-		slog.Warn("agent command: agent network has no cidr; boundary check skipped",
-			"agent_id", agentID, "network_id", net.ID, "network_name", net.Name)
-		return ""
-	}
-	if perr != nil {
-		// A configured-but-unparseable cidr is a data error worth surfacing.
-		return "agent network has invalid cidr: " + cidr
-	}
-	in, out, perr := cidrutil.PartitionTargets(targets, ipNet)
-	if perr != nil {
-		return "invalid scan targets: " + perr.Error()
-	}
-	if len(out) > 0 {
-		// Hard reject. Surface a sample of the offending IPs (cap to keep the
-		// error body readable for large out-of-network CIDRs). Admin sees what
-		// was rejected and can re-issue correctly.
-		sample := out
-		const maxSample = 8
-		if len(sample) > maxSample {
-			sample = append(append([]string{}, out[:maxSample]...), "...")
-		}
-		return "scan targets are outside agent network " + net.Name + " (" + cidr + "): " +
-			strings.Join(sample, ", ") + " (" + strconv.Itoa(len(out)) + " of " + strconv.Itoa(len(in)+len(out)) + " IPs out of network)"
-	}
-	return ""
 }
 
 // Poll handles GET /api/v1/agents/commands — the authenticated agent fetches
@@ -186,7 +108,7 @@ func (h *AgentCommandHandler) Ack(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid command id")
 		return
 	}
-	if err := h.queries.AckAgentCommand(r.Context(), id); err != nil {
+	if err := h.svc.Ack(r.Context(), id); err != nil {
 		Error(w, http.StatusInternalServerError, "failed to ack command")
 		return
 	}
@@ -213,14 +135,7 @@ func (h *AgentCommandHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "malformed request body")
 		return
 	}
-	if req.Status != "done" && req.Status != "failed" {
-		req.Status = "done"
-	}
-	if err := h.queries.CompleteAgentCommand(r.Context(), db.CompleteAgentCommandParams{
-		Status: req.Status,
-		Result: &req.Result,
-		ID:     id,
-	}); err != nil {
+	if err := h.svc.Complete(r.Context(), id, req.Status, req.Result); err != nil {
 		Error(w, http.StatusInternalServerError, "failed to complete command")
 		return
 	}

--- a/internal/api/handler/agent_command_test.go
+++ b/internal/api/handler/agent_command_test.go
@@ -23,6 +23,7 @@ import (
 
 	"mibee-steward/internal/api/handler"
 	sqldb "mibee-steward/internal/db"
+	"mibee-steward/internal/service"
 	"mibee-steward/internal/testutil"
 )
 
@@ -47,7 +48,7 @@ func setupCommandServer(t *testing.T, cidr, agentID string) (srv *httptest.Serve
 		AgentID: strPtr(agentID), ID: net.ID,
 	}))
 
-	cmd := handler.NewAgentCommandHandler(queries)
+	cmd := handler.NewAgentCommandHandler(queries, service.NewAgentCommandService(queries))
 	r := chi.NewMux()
 	r.Route("/api/v1/agents/{agentId}/commands", func(r chi.Router) {
 		r.Post("/", cmd.Create)
@@ -140,7 +141,7 @@ func TestAgentCommand_BoundaryCheck_Layer1(t *testing.T) {
 		require.NoError(t, queries.SetNetworkAgentID(context.Background(), sqldb.SetNetworkAgentIDParams{
 			AgentID: strPtr(agentID), ID: net.ID,
 		}))
-		cmd := handler.NewAgentCommandHandler(queries)
+		cmd := handler.NewAgentCommandHandler(queries, service.NewAgentCommandService(queries))
 		r := chi.NewMux()
 		r.Post("/api/v1/agents/{agentId}/commands", cmd.Create)
 		srv := httptest.NewServer(r)
@@ -160,7 +161,7 @@ func TestAgentCommand_BoundaryCheck_Layer1(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { dbConn.Close() })
 		queries := sqldb.New(dbConn)
-		cmd := handler.NewAgentCommandHandler(queries)
+		cmd := handler.NewAgentCommandHandler(queries, service.NewAgentCommandService(queries))
 		r := chi.NewMux()
 		r.Post("/api/v1/agents/{agentId}/commands", cmd.Create)
 		srv := httptest.NewServer(r)

--- a/internal/api/handler/network.go
+++ b/internal/api/handler/network.go
@@ -1,43 +1,40 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. You may use, modify, and redistribute it under
-// those terms; see LICENSE for the full text. A commercial license is available
-// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
 
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/service"
 )
-
-// errNetworkNotFound signals an UPDATE/DELETE targeted a non-existent network.
-var errNetworkNotFound = errors.New("network not found")
 
 // NetworkHandler serves the network registry (the logical networks agents
 // discover for). Used by the frontend to populate the device-list network
 // filter, the change-history network filter, and the Networks admin page.
+// Mutations go through service.NetworkService (#240 — this handler was one of
+// the four grandfathered charter-debt direct-DB writers); List is a read
+// passthrough on *db.Queries.
 type NetworkHandler struct {
 	queries *db.Queries
-	conn    db.DBTX // raw connection for UPDATE (sqlc truncation workaround)
+	svc     *service.NetworkService
 }
 
-// NewNetworkHandler constructs the handler. conn is the shared *sql.DB used
-// for the raw UPDATE statement (sqlc v1.31.1 truncates the generated string
-// for UpdateNetwork's multi-bind shape).
-func NewNetworkHandler(queries *db.Queries, conn db.DBTX) *NetworkHandler {
-	return &NetworkHandler{queries: queries, conn: conn}
+// NewNetworkHandler constructs the handler.
+func NewNetworkHandler(queries *db.Queries, svc *service.NetworkService) *NetworkHandler {
+	return &NetworkHandler{queries: queries, svc: svc}
 }
 
 // List handles GET /api/v1/networks — all networks, ordered by id.
@@ -66,22 +63,16 @@ func (h *NetworkHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if strings.TrimSpace(req.Name) == "" {
-		Error(w, http.StatusBadRequest, "name is required")
-		return
-	}
-	net, err := h.queries.CreateNetwork(r.Context(), db.CreateNetworkParams{
-		Name: strings.TrimSpace(req.Name),
-		Cidr: trimPtr(req.Cidr),
-		Site: trimPtr(req.Site),
-	})
+	net, err := h.svc.Create(r.Context(), service.NetworkInput{Name: req.Name, Cidr: req.Cidr, Site: req.Site})
 	if err != nil {
-		// networks.name is UNIQUE — a duplicate surfaces as a constraint error.
-		if isUniqueConstraintErr(err) {
-			Error(w, http.StatusConflict, "a network with this name already exists")
-			return
+		switch {
+		case errors.Is(err, service.ErrNetworkNameRequired):
+			Error(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, service.ErrNetworkNameTaken):
+			Error(w, http.StatusConflict, err.Error())
+		default:
+			Error(w, http.StatusInternalServerError, "failed to create network")
 		}
-		Error(w, http.StatusInternalServerError, "failed to create network")
 		return
 	}
 	Created(w, net)
@@ -107,21 +98,18 @@ func (h *NetworkHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if strings.TrimSpace(req.Name) == "" {
-		Error(w, http.StatusBadRequest, "name is required")
-		return
-	}
-	net, err := h.UpdateNetworkRaw(r.Context(), id, strings.TrimSpace(req.Name), trimPtr(req.Cidr), trimPtr(req.Site))
+	net, err := h.svc.Update(r.Context(), id, service.NetworkInput{Name: req.Name, Cidr: req.Cidr, Site: req.Site})
 	if err != nil {
-		if errors.Is(err, errNetworkNotFound) {
-			Error(w, http.StatusNotFound, "network not found")
-			return
+		switch {
+		case errors.Is(err, service.ErrNetworkNameRequired):
+			Error(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, service.ErrNetworkNotFound):
+			Error(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, service.ErrNetworkNameTaken):
+			Error(w, http.StatusConflict, err.Error())
+		default:
+			Error(w, http.StatusInternalServerError, "failed to update network")
 		}
-		if isUniqueConstraintErr(err) {
-			Error(w, http.StatusConflict, "a network with this name already exists")
-			return
-		}
-		Error(w, http.StatusInternalServerError, "failed to update network")
 		return
 	}
 	Success(w, net)
@@ -137,46 +125,13 @@ func (h *NetworkHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, "invalid id")
 		return
 	}
-	if err := h.queries.DeleteNetwork(r.Context(), id); err != nil {
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, service.ErrNetworkNotFound) {
+			Error(w, http.StatusNotFound, err.Error())
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to delete network")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// UpdateNetworkRaw runs the UPDATE via raw database/sql and reads the updated
-// row back via GetNetwork. This works around sqlc v1.31.1 truncating the
-// generated query string for this multi-bind UPDATE shape (drops the trailing
-// `?`). The SQL is a bind-parameter statement, so it's safe from the SQLite
-// empty-string-literal truncation bug noted in networks.sql (that only affects
-// inlined literals).
-func (h *NetworkHandler) UpdateNetworkRaw(ctx context.Context, id int64, name string, cidr, site *string) (db.Network, error) {
-	const stmt = `UPDATE networks SET name = ?, cidr = ?, site = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
-	res, err := h.conn.ExecContext(ctx, stmt, name, cidr, site, id)
-	if err != nil {
-		return db.Network{}, err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return db.Network{}, errNetworkNotFound
-	}
-	return h.queries.GetNetwork(ctx, id)
-}
-
-// trimPtr returns a pointer to the trimmed value, or nil if the input is nil
-// or empty-after-trim (so empty strings aren't stored as " ").
-func trimPtr(s *string) *string {
-	if s == nil {
-		return nil
-	}
-	t := strings.TrimSpace(*s)
-	if t == "" {
-		return nil
-	}
-	return &t
-}
-
-// isUniqueConstraintErr reports whether err is a SQLite UNIQUE constraint
-// violation (modernc.org/sqlite returns "UNIQUE constraint failed: ...").
-func isUniqueConstraintErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }

--- a/internal/api/handler/network_test.go
+++ b/internal/api/handler/network_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/service"
 	"mibee-steward/internal/testutil"
 )
 
@@ -35,7 +36,7 @@ func setupNetworkHandler(t *testing.T) (*NetworkHandler, *db.Queries, *sql.DB) {
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 	queries := db.New(conn)
-	return NewNetworkHandler(queries, conn), queries, conn
+	return NewNetworkHandler(queries, service.NewNetworkService(queries, conn)), queries, conn
 }
 
 // reqWithURLParam builds a request with a chi "id" URL param injected, so

--- a/internal/api/handler/response.go
+++ b/internal/api/handler/response.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 )
 
 // JSON writes a JSON response with the given status code.
@@ -39,4 +40,12 @@ func Created(w http.ResponseWriter, data interface{}) {
 // Error writes an error JSON response with the given status and message.
 func Error(w http.ResponseWriter, status int, message string) {
 	JSON(w, status, map[string]string{"error": message})
+}
+
+// isUniqueConstraintErr reports whether err is a SQLite UNIQUE constraint
+// violation (modernc.org/sqlite returns "UNIQUE constraint failed: ...").
+// Shared by the handlers whose writes surface duplicate-key conflicts as 409
+// (network grants, SSH credentials).
+func isUniqueConstraintErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }

--- a/internal/api/handler/scanner_result.go
+++ b/internal/api/handler/scanner_result.go
@@ -25,20 +25,24 @@ import (
 	"mibee-steward/internal/authz/scopeql"
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service"
 )
 
 // ScannerResultHandler handles HTTP requests for scan result and run queries.
 type ScannerResultHandler struct {
 	queries *db.Queries
 	conn    db.DBTX
+	svc     *service.ScannerResultService
 	// conn is the raw connection used by listResultsSorted — sqlc can't express
 	// the dynamic ORDER BY the sort-aware list needs, so that one query is raw
 	// SQL with a whitelist-controlled column (mirrors repository/device.go).
 }
 
-// NewScannerResultHandler creates a new ScannerResultHandler.
-func NewScannerResultHandler(queries *db.Queries, conn db.DBTX) *ScannerResultHandler {
-	return &ScannerResultHandler{queries: queries, conn: conn}
+// NewScannerResultHandler creates a new ScannerResultHandler. svc carries the
+// write path (BulkDeleteResults) per the handler/service charter (#240); the
+// rest of this handler is read-only passthrough on queries/conn.
+func NewScannerResultHandler(queries *db.Queries, conn db.DBTX, svc *service.ScannerResultService) *ScannerResultHandler {
+	return &ScannerResultHandler{queries: queries, conn: conn, svc: svc}
 }
 
 // scanResultSortWhitelist maps a client-supplied sort token to the real column
@@ -509,17 +513,14 @@ func (h *ScannerResultHandler) BulkDeleteResults(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Calculate days from now to the given date
-	days := int(time.Since(parsed).Hours() / 24)
-	if days <= 0 {
-		Error(w, http.StatusBadRequest, "before_date must be in the past")
-		return
-	}
-
-	daysStr := strconv.Itoa(days)
-	affected, err := h.queries.DeleteScanResultsOlderThan(r.Context(), &daysStr)
+	affected, err := h.svc.BulkDeleteBefore(r.Context(), parsed)
 	if err != nil {
-		Error(w, http.StatusInternalServerError, "failed to delete scan results")
+		switch {
+		case errors.Is(err, service.ErrBeforeDateNotPast):
+			Error(w, http.StatusBadRequest, err.Error())
+		default:
+			Error(w, http.StatusInternalServerError, "failed to delete scan results")
+		}
 		return
 	}
 

--- a/internal/api/handler/scanner_result_test.go
+++ b/internal/api/handler/scanner_result_test.go
@@ -20,6 +20,7 @@ import (
 
 	"mibee-steward/internal/api/handler"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/service"
 )
 
 // insertScanResultsForSort seeds one scan_task plus a set of scan_results with
@@ -95,7 +96,7 @@ func TestScannerResults_Sort(t *testing.T) {
 	d := setupSDDB(t)
 	taskID := insertScanResultsForSort(t, d)
 	queries := db.New(d)
-	h := handler.NewScannerResultHandler(queries, d)
+	h := handler.NewScannerResultHandler(queries, d, service.NewScannerResultService(queries))
 
 	// sort=ip asc -> globally smallest IP first (not just the inserted order).
 	require.Equal(t, "192.168.1.10", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=10"))
@@ -139,7 +140,7 @@ func TestScannerResults_SortPagination(t *testing.T) {
 	d := setupSDDB(t)
 	taskID := insertScanResultsForSort(t, d)
 	queries := db.New(d)
-	h := handler.NewScannerResultHandler(queries, d)
+	h := handler.NewScannerResultHandler(queries, d, service.NewScannerResultService(queries))
 
 	// sort=ip asc, page size 1: page 0 = smallest, page 1 = middle, page 2 = largest.
 	require.Equal(t, "192.168.1.10", scanResultFirstIP(t, h, "task_id="+itoa(taskID)+"&sort=ip&order=asc&limit=1&offset=0"))

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -217,7 +217,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Network registry — feeds the device-list + change-history network filters
 	// and the Networks admin page. Read (List) is any logged-in user; create/
 	// update/delete require CapNetworkManage (admin-only capability).
-	networkHandler := handler.NewNetworkHandler(scanQueries, dbConn)
+	networkSvc := service.NewNetworkService(scanQueries, dbConn)
+	networkHandler := handler.NewNetworkHandler(scanQueries, networkSvc)
 	r.Route("/api/v1/networks", func(r chi.Router) {
 		r.Use(middleware.RequireCapability(domain.CapNetworkRead))
 		r.Get("/", networkHandler.List)
@@ -504,7 +505,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	scanTaskService := scannerv2task.New(scanQueries, dbConn, scanScheduler)
 	scannerHandler := handler.NewScannerHandler(v2Engine, scanRunner)
 	scannerTaskHandler := handler.NewScannerTaskHandler(scanTaskService)
-	scannerResultHandler := handler.NewScannerResultHandler(scanQueries, dbConn)
+	scannerResultHandler := handler.NewScannerResultHandler(scanQueries, dbConn, service.NewScannerResultService(scanQueries))
 	r.Route("/api/v1/scanner", func(r chi.Router) {
 		// #138 Phase 1b: scanner routes are gated by capability, not a blanket
 		// RequireAdmin. admin inherits every capability (unchanged access); the
@@ -623,7 +624,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// (admin-only capability). The ingestion endpoint (/agents/report below)
 	// authenticates via RequireAgentToken against this table; this block is the
 	// management surface.
-	agentAdminHandler := handler.NewAgentAdminHandler(scanQueries)
+	agentAdminHandler := handler.NewAgentAdminHandler(scanQueries, service.NewAgentTokenService(scanQueries))
 	r.Route("/api/v1/agents/tokens", func(r chi.Router) {
 		r.Use(middleware.RequireCapability(domain.CapAgentManage))
 		r.Post("/", agentAdminHandler.Create)
@@ -641,7 +642,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// Routed on the top-level mux (separate from /agents/tokens) so the two auth
 	// regimes don't interfere.
 	agentReportHandler := handler.NewAgentReportHandler(scanRunner, scanQueries, dbConn)
-	agentCommandHandler := handler.NewAgentCommandHandler(scanQueries)
+	agentCommandHandler := handler.NewAgentCommandHandler(scanQueries, service.NewAgentCommandService(scanQueries))
 	r.Route("/api/v1/agents", func(r chi.Router) {
 		r.Use(middleware.RequireAgentToken)
 		r.Post("/report", agentReportHandler.Report)

--- a/internal/service/agent_command_service.go
+++ b/internal/service/agent_command_service.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"mibee-steward/internal/cidrutil"
+	"mibee-steward/internal/db"
+)
+
+// AgentCommandService is the write half of the center→agent command channel
+// (issue #240: the agent_command handler was grandfathered charter debt). The
+// agent-side reads (Poll) and the admin list view stay as handler
+// passthroughs.
+type AgentCommandService struct {
+	queries *db.Queries
+}
+
+// NewAgentCommandService constructs an AgentCommandService.
+func NewAgentCommandService(queries *db.Queries) *AgentCommandService {
+	return &AgentCommandService{queries: queries}
+}
+
+var (
+	// ErrAgentIDRequired maps to 400.
+	ErrAgentIDRequired = errors.New("agent_id is required")
+)
+
+// BoundaryError is a scan-target network-boundary rejection (issue #19,
+// Layer 1). It carries the human-readable reason verbatim — the offending
+// IPs — so the handler can surface it as the 400 body unchanged.
+type BoundaryError struct{ Reason string }
+
+func (e *BoundaryError) Error() string { return e.Reason }
+
+// Enqueue stores a command (currently "scan") for an agent to pick up on its
+// next poll. For "scan" commands the requested targets must fall inside the
+// agent's bound network CIDR — the earliest, cheapest defense against
+// cross-subnet mis-dispatch (issue #19, Layer 1: exactly what let an agent
+// scan the wrong subnet and strand 30 devices). A network with no CIDR
+// configured degrades open with a warning (historical networks must not be
+// locked out); out-of-network targets are a hard error.
+func (s *AgentCommandService) Enqueue(ctx context.Context, agentID, command string, payload map[string]interface{}) (db.AgentCommand, error) {
+	if agentID == "" {
+		return db.AgentCommand{}, ErrAgentIDRequired
+	}
+	if command == "" {
+		command = "scan"
+	}
+	// Boundary check only for scan commands — other command types (none
+	// today, but the channel is extensible) carry no targets field.
+	if command == "scan" {
+		if reason := s.validateScanTargets(ctx, agentID, payload); reason != "" {
+			return db.AgentCommand{}, &BoundaryError{Reason: reason}
+		}
+	}
+
+	payloadBytes, _ := json.Marshal(payload)
+	return s.queries.CreateAgentCommand(ctx, db.CreateAgentCommandParams{
+		AgentID: agentID,
+		Command: command,
+		Payload: string(payloadBytes),
+	})
+}
+
+// Ack transitions pending→acknowledged so the command isn't re-polled.
+func (s *AgentCommandService) Ack(ctx context.Context, id int64) error {
+	return s.queries.AckAgentCommand(ctx, id)
+}
+
+// Complete records a finished command's outcome ("done" | "failed"; anything
+// else normalizes to "done" to match the historical handler semantics).
+func (s *AgentCommandService) Complete(ctx context.Context, id int64, status, result string) error {
+	if status != "done" && status != "failed" {
+		status = "done"
+	}
+	return s.queries.CompleteAgentCommand(ctx, db.CompleteAgentCommandParams{
+		Status: status,
+		Result: &result,
+		ID:     id,
+	})
+}
+
+// validateScanTargets checks that a scan command's targets fall inside the
+// agent's bound network. Returns "" when acceptable, or a human-readable
+// reason (used verbatim as the 400 body) when it must be rejected. Missing /
+// unresolvable / cidr-less networks degrade open with a warning.
+func (s *AgentCommandService) validateScanTargets(ctx context.Context, agentID string, payload map[string]interface{}) string {
+	rawTargets, _ := payload["targets"].(string)
+	targets := strings.TrimSpace(rawTargets)
+	if targets == "" {
+		// Missing targets is the agent-command layer's own concern (the
+		// poller rejects it as "missing targets"); not a CIDR issue.
+		return ""
+	}
+	net, err := s.queries.GetNetworkByAgentID(ctx, &agentID)
+	if err != nil {
+		// No network bound to this agent_id — we can't validate, so allow +
+		// warn; the agent itself rejects unreachable targets. Best-effort.
+		slog.Warn("agent command: cannot resolve agent network for boundary check; allowing",
+			"agent_id", agentID, "error", err)
+		return ""
+	}
+	cidr := ""
+	if net.Cidr != nil {
+		cidr = *net.Cidr
+	}
+	ipNet, perr := cidrutil.ParseNetwork(cidr)
+	if errors.Is(perr, cidrutil.ErrEmptyCIDR) {
+		// Network exists but has no cidr configured — degrade-open + warn.
+		// This is the gap the cidr-enforcement prerequisite (issue #19) closes.
+		slog.Warn("agent command: agent network has no cidr; boundary check skipped",
+			"agent_id", agentID, "network_id", net.ID, "network_name", net.Name)
+		return ""
+	}
+	if perr != nil {
+		// A configured-but-unparseable cidr is a data error worth surfacing.
+		return "agent network has invalid cidr: " + cidr
+	}
+	in, out, perr := cidrutil.PartitionTargets(targets, ipNet)
+	if perr != nil {
+		return "invalid scan targets: " + perr.Error()
+	}
+	if len(out) > 0 {
+		// Hard reject. Surface a sample of the offending IPs (capped to keep
+		// the error body readable); the admin sees exactly what was rejected.
+		sample := out
+		const maxSample = 8
+		if len(sample) > maxSample {
+			sample = append(append([]string{}, out[:maxSample]...), "...")
+		}
+		return "scan targets are outside agent network " + net.Name + " (" + cidr + "): " +
+			strings.Join(sample, ", ") + " (" + strconv.Itoa(len(out)) + " of " + strconv.Itoa(len(in)+len(out)) + " IPs out of network)"
+	}
+	return ""
+}

--- a/internal/service/agent_token_service.go
+++ b/internal/service/agent_token_service.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"errors"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+)
+
+// AgentTokenService is the write path for discovery-agent bearer tokens
+// (issue #240: the agent_admin handler was grandfathered charter debt). Token
+// MINTING stays in the HTTP layer — the plaintext is a one-time credential
+// shown in the response — and is injected as a func so tests can pin it;
+// persistence + the networks.agent_id wiring live here.
+type AgentTokenService struct {
+	queries *db.Queries
+}
+
+// NewAgentTokenService constructs an AgentTokenService.
+func NewAgentTokenService(queries *db.Queries) *AgentTokenService {
+	return &AgentTokenService{queries: queries}
+}
+
+// TokenMinter returns a freshly-minted (plaintext, hash) pair. The production
+// value is middleware.GenerateAgentToken; a func type keeps this package free
+// of an api-layer import.
+type TokenMinter func() (plaintext, hash string)
+
+var (
+	// ErrNetworkIDInvalid maps to 400. (ErrAgentIDRequired — also 400 — is
+	// declared once in agent_command_service.go and shared.)
+	ErrNetworkIDInvalid = errors.New("network_id is required or does not refer to a known network")
+	// ErrAgentIDTaken maps to 409 (UNIQUE(agent_id) collision).
+	ErrAgentIDTaken = errors.New("agent_id already exists; choose a unique id")
+	// ErrAgentTokenNotFound maps to 404.
+	ErrAgentTokenNotFound = errors.New("agent token not found")
+)
+
+// Create mints (via mint), stores, and wires a new agent token. Stamping
+// networks.agent_id is what makes the center's heartbeat exclusion (no
+// cross-subnet probing of agent devices) and the lease-sweeper scope engage
+// automatically. The stamp is best-effort: a failure leaves the token
+// functional (reports still work); the network just isn't scoped.
+func (s *AgentTokenService) Create(ctx context.Context, req domain.CreateAgentTokenRequest, mint TokenMinter) (domain.AgentTokenCreatedResponse, error) {
+	if req.AgentID == "" {
+		return domain.AgentTokenCreatedResponse{}, ErrAgentIDRequired
+	}
+	if req.NetworkID <= 0 {
+		return domain.AgentTokenCreatedResponse{}, ErrNetworkIDInvalid
+	}
+	// Verify the network exists so the foreign key isn't dangling.
+	if _, err := s.queries.GetNetwork(ctx, req.NetworkID); err != nil {
+		return domain.AgentTokenCreatedResponse{}, ErrNetworkIDInvalid
+	}
+
+	plaintext, hash := mint()
+	networkIDPtr := req.NetworkID // take address of a stable local
+	row, err := s.queries.CreateAgentToken(ctx, db.CreateAgentTokenParams{
+		AgentID:   req.AgentID,
+		TokenHash: hash,
+		NetworkID: &networkIDPtr,
+		Name:      req.Name,
+	})
+	if err != nil {
+		return domain.AgentTokenCreatedResponse{}, ErrAgentIDTaken
+	}
+
+	agentIDStr := req.AgentID
+	_ = s.queries.SetNetworkAgentID(ctx, db.SetNetworkAgentIDParams{
+		AgentID: &agentIDStr,
+		ID:      req.NetworkID,
+	})
+
+	return domain.AgentTokenCreatedResponse{
+		AgentTokenResponse: domain.AgentTokenResponse{
+			ID:         row.ID,
+			AgentID:    row.AgentID,
+			NetworkID:  row.NetworkID,
+			Name:       row.Name,
+			CreatedAt:  row.CreatedAt,
+			LastUsedAt: row.LastUsedAt,
+			RevokedAt:  row.RevokedAt,
+		},
+		Token: plaintext,
+	}, nil
+}
+
+// Revoke soft-revokes (sets revoked_at) — the token immediately fails auth.
+// Kept soft so the audit trail (last_used_at, created_at) survives. Also
+// clears the network's agent_id so the center resumes local probing.
+func (s *AgentTokenService) Revoke(ctx context.Context, id int64) error {
+	tok, err := s.queries.GetAgentToken(ctx, id)
+	if err != nil {
+		return ErrAgentTokenNotFound
+	}
+	n, err := s.queries.RevokeAgentToken(ctx, id)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrAgentTokenNotFound
+	}
+	s.clearNetworkAgentID(ctx, tok)
+	return nil
+}
+
+// Delete hard-deletes. Prefer Revoke for auditability; Delete is for cleanup
+// of test/mistake tokens. Also clears the network's agent_id.
+func (s *AgentTokenService) Delete(ctx context.Context, id int64) error {
+	tok, err := s.queries.GetAgentToken(ctx, id)
+	if err != nil {
+		return ErrAgentTokenNotFound
+	}
+	n, err := s.queries.DeleteAgentToken(ctx, id)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrAgentTokenNotFound
+	}
+	s.clearNetworkAgentID(ctx, tok)
+	return nil
+}
+
+// clearNetworkAgentID nulls out the agent_id on the token's bound network,
+// but ONLY if it matches the token's own agent_id (so revoking a stale token
+// doesn't clobber a newer token that re-uses the network). Best-effort: a
+// failure here doesn't undo the revoke/delete.
+func (s *AgentTokenService) clearNetworkAgentID(ctx context.Context, tok db.AgentToken) {
+	if tok.NetworkID == nil {
+		return
+	}
+	net, err := s.queries.GetNetwork(ctx, *tok.NetworkID)
+	if err != nil {
+		return
+	}
+	if net.AgentID == nil || *net.AgentID != tok.AgentID {
+		return
+	}
+	empty := ""
+	_ = s.queries.SetNetworkAgentID(ctx, db.SetNetworkAgentIDParams{
+		AgentID: &empty,
+		ID:      *tok.NetworkID,
+	})
+}

--- a/internal/service/charter_services_test.go
+++ b/internal/service/charter_services_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/testutil"
+)
+
+func setupAgentTokenService(t *testing.T) (*AgentTokenService, *db.Queries) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	return NewAgentTokenService(queries), queries
+}
+
+// fixedMinter returns a deterministic (plaintext, hash) pair so tests can
+// assert what was stored without knowing the hash function.
+func fixedMinter(plaintext, hash string) TokenMinter {
+	return func() (string, string) { return plaintext, hash }
+}
+
+func mustCreateNetwork(t *testing.T, queries *db.Queries, name string) db.Network {
+	t.Helper()
+	cidr := "10.0.0.0/24"
+	net, err := queries.CreateNetwork(context.Background(), db.CreateNetworkParams{Name: name, Cidr: &cidr})
+	require.NoError(t, err)
+	return net
+}
+
+func TestAgentTokenService_CreateStampsNetworkAgentID(t *testing.T) {
+	svc, queries := setupAgentTokenService(t)
+	ctx := context.Background()
+	net := mustCreateNetwork(t, queries, "lan-a")
+
+	resp, err := svc.Create(ctx, domain.CreateAgentTokenRequest{
+		AgentID: "agent-a", NetworkID: net.ID,
+	}, fixedMinter("plain", "hash"))
+	require.NoError(t, err)
+	require.Equal(t, "plain", resp.Token, "one-time plaintext returned to the caller")
+	require.Equal(t, "agent-a", resp.AgentID)
+
+	after, err := queries.GetNetwork(ctx, net.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.AgentID)
+	require.Equal(t, "agent-a", *after.AgentID, "network marked agent-managed (heartbeat exclusion + lease sweeper scope)")
+
+	row, err := queries.GetAgentTokenByHash(ctx, "hash")
+	require.NoError(t, err)
+	require.Equal(t, "agent-a", row.AgentID, "stored row holds the hash, never the plaintext")
+}
+
+func TestAgentTokenService_CreateValidation(t *testing.T) {
+	svc, queries := setupAgentTokenService(t)
+	ctx := context.Background()
+	net := mustCreateNetwork(t, queries, "lan-b")
+
+	_, err := svc.Create(ctx, domain.CreateAgentTokenRequest{NetworkID: net.ID}, fixedMinter("p", "h"))
+	require.ErrorIs(t, err, ErrAgentIDRequired)
+
+	// Unknown network → invalid (FK would dangle).
+	_, err = svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "a", NetworkID: 999}, fixedMinter("p", "h"))
+	require.ErrorIs(t, err, ErrNetworkIDInvalid)
+
+	// Duplicate agent_id → conflict sentinel.
+	_, err = svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "dup", NetworkID: net.ID}, fixedMinter("p1", "h1"))
+	require.NoError(t, err)
+	_, err = svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "dup", NetworkID: net.ID}, fixedMinter("p2", "h2"))
+	require.ErrorIs(t, err, ErrAgentIDTaken)
+}
+
+func TestAgentTokenService_RevokeClearsMatchingNetworkAgentID(t *testing.T) {
+	svc, queries := setupAgentTokenService(t)
+	ctx := context.Background()
+	net := mustCreateNetwork(t, queries, "lan-c")
+
+	_, err := svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "agent-c", NetworkID: net.ID}, fixedMinter("p", "h"))
+	require.NoError(t, err)
+	tok, err := queries.GetAgentTokenByHash(ctx, "h")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Revoke(ctx, tok.ID))
+
+	after, err := queries.GetNetwork(ctx, net.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.AgentID)
+	require.Equal(t, "", *after.AgentID, "revoke clears the agent_id so the center resumes local probing")
+}
+
+func TestAgentTokenService_RevokeKeepsNewerClaimant(t *testing.T) {
+	svc, queries := setupAgentTokenService(t)
+	ctx := context.Background()
+	net := mustCreateNetwork(t, queries, "lan-d")
+
+	// A stale token claims the network, then a NEWER token re-claims it.
+	_, err := svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "old-agent", NetworkID: net.ID}, fixedMinter("p1", "h1"))
+	require.NoError(t, err)
+	_, err = svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "new-agent", NetworkID: net.ID}, fixedMinter("p2", "h2"))
+	require.NoError(t, err)
+
+	stale, err := queries.GetAgentTokenByHash(ctx, "h1")
+	require.NoError(t, err)
+	require.NoError(t, svc.Revoke(ctx, stale.ID))
+
+	after, err := queries.GetNetwork(ctx, net.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.AgentID)
+	require.Equal(t, "new-agent", *after.AgentID, "revoking the stale token must NOT clobber the newer claimant")
+}
+
+func TestAgentTokenService_DeleteRemovesRowAndClearsNetwork(t *testing.T) {
+	svc, queries := setupAgentTokenService(t)
+	ctx := context.Background()
+	net := mustCreateNetwork(t, queries, "lan-e")
+
+	_, err := svc.Create(ctx, domain.CreateAgentTokenRequest{AgentID: "agent-e", NetworkID: net.ID}, fixedMinter("p", "h"))
+	require.NoError(t, err)
+	tok, err := queries.GetAgentTokenByHash(ctx, "h")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Delete(ctx, tok.ID))
+
+	_, err = queries.GetAgentToken(ctx, tok.ID)
+	require.Error(t, err, "hard delete removes the row")
+
+	after, err := queries.GetNetwork(ctx, net.ID)
+	require.NoError(t, err)
+	require.Equal(t, "", *after.AgentID)
+
+	require.ErrorIs(t, svc.Delete(ctx, tok.ID), ErrAgentTokenNotFound, "second delete → not-found sentinel")
+}
+
+func TestNetworkService_CRUDAndDuplicateName(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	svc := NewNetworkService(queries, conn)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, NetworkInput{Name: "branch-x"})
+	require.NoError(t, err)
+	require.Equal(t, "branch-x", created.Name)
+
+	_, err = svc.Create(ctx, NetworkInput{Name: "branch-x"})
+	require.ErrorIs(t, err, ErrNetworkNameTaken)
+
+	_, err = svc.Create(ctx, NetworkInput{Name: "  "})
+	require.ErrorIs(t, err, ErrNetworkNameRequired)
+
+	site := "HQ"
+	updated, err := svc.Update(ctx, created.ID, NetworkInput{Name: "branch-y", Site: &site})
+	require.NoError(t, err)
+	require.Equal(t, "branch-y", updated.Name)
+	require.NotNil(t, updated.Site)
+	require.Equal(t, "HQ", *updated.Site)
+
+	_, err = svc.Update(ctx, 999, NetworkInput{Name: "ghost"})
+	require.ErrorIs(t, err, ErrNetworkNotFound)
+
+	require.NoError(t, svc.Delete(ctx, created.ID))
+	require.ErrorIs(t, svc.Delete(ctx, created.ID), ErrNetworkNotFound)
+}
+
+func TestAgentCommandService_EnqueueBoundaryRejection(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	svc := NewAgentCommandService(queries)
+	ctx := context.Background()
+
+	cidr := "192.168.62.0/24"
+	net, err := queries.CreateNetwork(ctx, db.CreateNetworkParams{Name: "lan-62", Cidr: &cidr})
+	require.NoError(t, err)
+	agentID := "agent-62"
+	require.NoError(t, queries.SetNetworkAgentID(ctx, db.SetNetworkAgentIDParams{AgentID: &agentID, ID: net.ID}))
+
+	// In-network target is accepted.
+	cmd, err := svc.Enqueue(ctx, "agent-62", "scan", map[string]interface{}{"targets": "192.168.62.0/24"})
+	require.NoError(t, err)
+	require.Equal(t, "scan", cmd.Command)
+
+	// Out-of-network target is a typed boundary error whose message names the
+	// offending IPs (surfaced verbatim as the 400 body).
+	_, err = svc.Enqueue(ctx, "agent-62", "scan", map[string]interface{}{"targets": "192.168.63.1"})
+	require.Error(t, err)
+	var boundary *BoundaryError
+	require.ErrorAs(t, err, &boundary)
+	require.Contains(t, boundary.Error(), "outside agent network")
+	require.Contains(t, boundary.Error(), "192.168.63.1")
+
+	// Unknown agent (no network binding) degrades open — allowed.
+	_, err = svc.Enqueue(ctx, "agent-unknown", "scan", map[string]interface{}{"targets": "10.1.1.1"})
+	require.NoError(t, err)
+
+	// Empty command defaults to "scan".
+	cmd, err = svc.Enqueue(ctx, "agent-unknown", "", map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, "scan", cmd.Command)
+}
+
+func TestScannerResultService_BulkDeleteBeforeValidation(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	svc := NewScannerResultService(queries)
+
+	// Future date → rejected.
+	_, err = svc.BulkDeleteBefore(context.Background(), time.Now().Add(24*time.Hour))
+	require.ErrorIs(t, err, ErrBeforeDateNotPast)
+
+	// Valid past date → deletes (empty table: 0 rows, no error).
+	n, err := svc.BulkDeleteBefore(context.Background(), time.Now().Add(-48*time.Hour))
+	require.NoError(t, err)
+	require.Zero(t, n)
+}

--- a/internal/service/network_service.go
+++ b/internal/service/network_service.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"mibee-steward/internal/db"
+)
+
+// NetworkService is the write path for the logical-network registry (issue
+// #240: the network handler was one of the four grandfathered charter-debt
+// handlers writing to the DB directly). Reads stay as handler passthroughs.
+type NetworkService struct {
+	queries *db.Queries
+	conn    db.DBTX // raw connection for UPDATE (sqlc truncation workaround)
+}
+
+// NewNetworkService constructs a NetworkService. conn powers the raw UPDATE
+// statement — sqlc v1.31.1 truncates the generated string for UpdateNetwork's
+// multi-bind shape, so the UPDATE is hand-written (db/AGENTS.md convention).
+func NewNetworkService(queries *db.Queries, conn db.DBTX) *NetworkService {
+	return &NetworkService{queries: queries, conn: conn}
+}
+
+var (
+	// ErrNetworkNameRequired maps to 400.
+	ErrNetworkNameRequired = errors.New("name is required")
+	// ErrNetworkNotFound maps to 404.
+	ErrNetworkNotFound = errors.New("network not found")
+	// ErrNetworkNameTaken maps to 409 (networks.name is UNIQUE).
+	ErrNetworkNameTaken = errors.New("a network with this name already exists")
+)
+
+// NetworkInput is the create/update payload shared shape. Cidr and Site are
+// advisory (no strict validation), matching the previous handler semantics.
+type NetworkInput struct {
+	Name string
+	Cidr *string
+	Site *string
+}
+
+// Create registers a new logical network — the admin path for defining the
+// remote networks agents discover for (the center's own network is
+// auto-resolved at startup via resolveNetworkID).
+func (s *NetworkService) Create(ctx context.Context, in NetworkInput) (db.Network, error) {
+	in = normalizeNetworkInput(in)
+	if in.Name == "" {
+		return db.Network{}, ErrNetworkNameRequired
+	}
+	net, err := s.queries.CreateNetwork(ctx, db.CreateNetworkParams{
+		Name: in.Name,
+		Cidr: in.Cidr,
+		Site: in.Site,
+	})
+	if err != nil {
+		if isUniqueConstraintErr(err) {
+			return db.Network{}, ErrNetworkNameTaken
+		}
+		return db.Network{}, err
+	}
+	return net, nil
+}
+
+// Update edits name/cidr/site. agent_id is intentionally NOT editable here
+// (owned by the agent-token flow). Runs via raw database/sql and reads the
+// updated row back — sqlc v1.31.1 truncates the generated query string for
+// this multi-bind UPDATE shape (drops the trailing `?`).
+func (s *NetworkService) Update(ctx context.Context, id int64, in NetworkInput) (db.Network, error) {
+	in = normalizeNetworkInput(in)
+	if in.Name == "" {
+		return db.Network{}, ErrNetworkNameRequired
+	}
+	const stmt = `UPDATE networks SET name = ?, cidr = ?, site = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+	res, err := s.conn.ExecContext(ctx, stmt, in.Name, in.Cidr, in.Site, id)
+	if err != nil {
+		if isUniqueConstraintErr(err) {
+			return db.Network{}, ErrNetworkNameTaken
+		}
+		return db.Network{}, err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return db.Network{}, ErrNetworkNotFound
+	}
+	return s.queries.GetNetwork(ctx, id)
+}
+
+// Delete removes a logical network. FK references are ON DELETE SET NULL
+// (devices/vlans/agent_tokens/change_log) or CASCADE (subnets/scan_snapshots),
+// so devices keep their rows with a NULL network_id rather than vanishing.
+func (s *NetworkService) Delete(ctx context.Context, id int64) error {
+	if _, err := s.queries.GetNetwork(ctx, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNetworkNotFound
+		}
+		return err
+	}
+	return s.queries.DeleteNetwork(ctx, id)
+}
+
+// normalizeNetworkInput trims the name and normalizes the advisory pointer
+// fields (nil-or-empty-after-trim → nil, so empty strings aren't stored as " ").
+func normalizeNetworkInput(in NetworkInput) NetworkInput {
+	in.Name = strings.TrimSpace(in.Name)
+	in.Cidr = trimPtrToNil(in.Cidr)
+	in.Site = trimPtrToNil(in.Site)
+	return in
+}
+
+func trimPtrToNil(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	t := strings.TrimSpace(*s)
+	if t == "" {
+		return nil
+	}
+	return &t
+}
+
+// isUniqueConstraintErr reports whether err is a SQLite UNIQUE constraint
+// violation (modernc.org/sqlite returns "UNIQUE constraint failed: ...").
+func isUniqueConstraintErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/service/scanner_result_service.go
+++ b/internal/service/scanner_result_service.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"mibee-steward/internal/db"
+)
+
+// ScannerResultService is the write path for scan results (issue #240:
+// BulkDeleteResults was the scanner_result handler's one grandfathered
+// mutation). Everything else in that handler is a read passthrough.
+type ScannerResultService struct {
+	queries *db.Queries
+}
+
+// NewScannerResultService constructs a ScannerResultService.
+func NewScannerResultService(queries *db.Queries) *ScannerResultService {
+	return &ScannerResultService{queries: queries}
+}
+
+var (
+	// ErrBeforeDateRequired / ErrBeforeDateInvalid / ErrBeforeDateNotPast map
+	// to 400 with the historical message strings (kept verbatim — the
+	// frontend surfaces them directly).
+	ErrBeforeDateRequired = errors.New("before_date query parameter is required (ISO 8601 format)")
+	ErrBeforeDateInvalid  = errors.New("invalid before_date format, use ISO 8601")
+	ErrBeforeDateNotPast  = errors.New("before_date must be in the past")
+)
+
+// BulkDeleteBefore removes scan results older than the given instant.
+// DeleteScanResultsOlderThan takes a SQLite `date(...)`-style day delta
+// string, so the RFC3339 instant is converted to "days ago" here.
+func (s *ScannerResultService) BulkDeleteBefore(ctx context.Context, before time.Time) (int64, error) {
+	days := int(time.Since(before).Hours() / 24)
+	if days <= 0 {
+		return 0, ErrBeforeDateNotPast
+	}
+	daysStr := strconv.Itoa(days)
+	return s.queries.DeleteScanResultsOlderThan(ctx, &daysStr)
+}


### PR DESCRIPTION
Fixes #240

## 概述

`internal/api/AGENTS.md` 章程（#166）遗留的最后四个 ⚠️ debt handler（mutating 直连 DB）全部迁移到 service 层 — **债务表清零**。

| handler | 新 service | 迁移内容 |
|---|---|---|
| `network.go` | `service.NetworkService` | CRUD + sqlc 截断绕行的原生 UPDATE（移入 service） |
| `agent_admin.go` | `service.AgentTokenService` | 创建/吊销/删除 + `networks.agent_id` 打标与条件清除 |
| `agent_command.go` | `service.AgentCommandService` | enqueue（含 #19 Layer 1 扫描目标边界校验 → 类型化 `BoundaryError`）、ack、complete |
| `scanner_result.go` | `service.ScannerResultService` | BulkDeleteResults（唯一写路径） |

设计要点：
- **token 铸币留在 HTTP 层**（一次性凭据展示职责），以 `TokenMinter` func 注入 service — 避免 service → api/middleware 反向依赖
- **agent_id 条件清除语义有测试锁定**：吊销旧 token 不会误伤已重新认领网络的新 token
- 读面（List/Poll/ListAll/导出）按章程豁免条款保留 `*db.Queries` 直读
- HTTP 行为不变（唯一文案差异：重复吊销统一 404 "agent token not found"）

## 测试

- 新增 `charter_services_test.go` 8 用例：打标/条件清除/新 claimant 保护/边界拒绝含越界 IP/CRUD 校验
- 既有 4 个 handler 测试经新层全绿（HTTP 语义回归保障）
- gofmt/goimports/vet/golangci-lint（0 issues）/`go test ./...` 35 包全绿
- 63.101 实机冒烟：network create 201 / 重复名 409 / delete 204 / tokens+commands 读面 200