### PR TITLE
chore(scanner): 启动日志暴露 raw-evidence 持久化开关状态（#255）

### DIFF
--- a/internal/service/scannerv2/engine/engine.go
+++ b/internal/service/scannerv2/engine/engine.go
@@ -320,6 +320,11 @@ func NewEngine(db *sql.DB, cfg Config, logger *slog.Logger) (*Engine, error) {
 	})
 
 	logger.Info("scannerv2 engine ready", "registry", reg.String())
+	// Surface the evidence-persistence switch at startup: with it off (the
+	// default — raw evidence is voluminous) service_evidence stays empty by
+	// design and the 14d retention sweep is a no-op, which otherwise reads
+	// exactly like a broken persistence chain (#255).
+	logger.Info("scannerv2: raw-evidence persistence", "enabled", cfg.PersistRawEvidence)
 	e := &Engine{Orchestrator: orch, Registry: reg, Repository: repo}
 	// Per-probe timeout: bound each probe attempt so a dead host fails in
 	// seconds instead of consuming the whole per-host budget. Default 3s.


### PR DESCRIPTION
Closes #255（works-as-designed 调查结论 + 可见性补强）

## 调查结论：链路完好，非断线
`service_evidence` 0 行的根因是 **`scanner.persist_raw_evidence` 默认 false**（所有 shipped 配置 + 代码默认），`RecordEvidence` 在开关关闭时按设计 no-op：

- **链路已接线**：orchestrator.Run → repo.RecordEvidence → INSERT service_evidence（store/sqlite.go:122）；`NoopRepository` 仅用于无 DB 构造
- **开关两侧均有测试**：`TestRecordEvidence_SampledByDefault`（off → 0 行；on → 写入）
- **注释明确设计意图**：sqlite.go:42 「off by default to avoid storage bloat」、config.production.yaml 「开启后会写入大量原始探测数据，仅调试时启用」、docs/en/configuration.md:289 已文档化
- **host_tls_certs 不受该开关门控**（issue 顺带要求核查项）：`RecordTLSCerts` 独立路径，TLS-wrapped 服务扫描即写入

## 本 PR 改动
engine ready 日志后追加 `scannerv2: raw-evidence persistence enabled=false` —— 让「表为空」在部署侧一眼可自诊（对照日志即知是开关而非断线），不再需要翻代码。

## 保留清理不删
`service_evidence` 14d 保留 sweep 保留：开关打开后即生效，sweep 空表无成本。

## 若要启用（测试环境验证方式）
`MIBEE_SCANNER_PERSIST_RAW_EVIDENCE=true` 或 config `scanner.persist_raw_evidence: true`，一轮扫描后 `SELECT COUNT(*) FROM service_evidence` 应 > 0。