### PR TITLE
fix(scanner): 服务行替换改为作用域语义 — 超时≠关闭，降级周期不再抹掉已知服务（#256）

### DIFF
--- a/internal/service/scannerv2/orchestrator.go
+++ b/internal/service/scannerv2/orchestrator.go
@@ -211,9 +211,12 @@ func (o *Orchestrator) Run(ctx context.Context, ip string, hint ProbeHint) HostR
 		}
 	}
 
-	// ② persist service identities.
-	if o.repo != nil && len(services) > 0 {
-		if err := o.repo.RecordServices(ctx, ip, services); err != nil {
+	// ② persist service identities. Called even with zero services when the
+	// scan positively closed ports (RST evidence) — confirmed-gone rows must
+	// be removed; a zero-service cycle with no closure signal keeps the old
+	// rows (a degraded scan must not wipe the service set, #256).
+	if o.repo != nil && (len(services) > 0 || hasEvidenceKind(evidence, "port_closed")) {
+		if err := o.repo.RecordServices(ctx, ip, services, closedPortsFromEvidence(evidence)); err != nil {
 			o.logger.Debug("record services failed", "ip", ip, "error", err)
 		}
 	}
@@ -232,6 +235,19 @@ func hasEvidenceKind(ev []Evidence, kind string) bool {
 		}
 	}
 	return false
+}
+
+// closedPortsFromEvidence collects the ports the port scan positively closed
+// (TCP RST → "port_closed" evidence). Only these justify deleting a host's
+// existing service rows; a dial timeout is NOT closure (#256).
+func closedPortsFromEvidence(ev []Evidence) []int {
+	var closed []int
+	for _, e := range ev {
+		if e.Kind == "port_closed" && e.Port > 0 {
+			closed = append(closed, e.Port)
+		}
+	}
+	return closed
 }
 
 // stripWildcardPrefix removes a leading "*." from a TLS cert CN so it reads as

--- a/internal/service/scannerv2/orchestrator_test.go
+++ b/internal/service/scannerv2/orchestrator_test.go
@@ -113,7 +113,7 @@ func (r *recordRepo) RecordEvidence(_ context.Context, ev []Evidence) error {
 	r.evidence = append(r.evidence, ev...)
 	return nil
 }
-func (r *recordRepo) RecordServices(_ context.Context, ip string, svcs []ServiceIdentity) error {
+func (r *recordRepo) RecordServices(_ context.Context, ip string, svcs []ServiceIdentity, _ []int) error {
 	r.services[ip] = svcs
 	return nil
 }

--- a/internal/service/scannerv2/probe/ports.go
+++ b/internal/service/scannerv2/probe/ports.go
@@ -21,12 +21,14 @@ package probe
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"mibee-steward/internal/service/scannerv2"
@@ -109,11 +111,28 @@ func (p *PortSpecProbe) Probe(ctx context.Context, ip string, hint scannerv2.Pro
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			open, banner := dialAndGrab(ctx, ip, port, timeout)
+			open, refused, banner := dialAndGrab(ctx, ip, port, timeout)
+			mu.Lock()
+			defer mu.Unlock()
 			if !open {
+				// A TCP RST is positive knowledge: the port is closed. Emit it
+				// as negative evidence so the store can distinguish "confirmed
+				// gone" (safe to drop the service row) from "no answer this
+				// cycle" (timeout — keep the row; a degraded scan cycle must
+				// not erase known services, #256).
+				if refused {
+					evs = append(evs, scannerv2.Evidence{
+						Source:     "active:tcp",
+						Kind:       "port_closed",
+						IP:         ip,
+						Port:       port,
+						Protocol:   "tcp",
+						Confidence: 1.0,
+						ObservedAt: now,
+					})
+				}
 				return
 			}
-			mu.Lock()
 			evs = append(evs, scannerv2.Evidence{
 				Source:     "active:tcp",
 				Kind:       "port_open",
@@ -135,7 +154,6 @@ func (p *PortSpecProbe) Probe(ctx context.Context, ip string, hint scannerv2.Pro
 					ObservedAt: now,
 				})
 			}
-			mu.Unlock()
 		}(port)
 	}
 	wg.Wait()
@@ -149,12 +167,30 @@ func (p *PortSpecProbe) Probe(ctx context.Context, ip string, hint scannerv2.Pro
 // read — this is what lets the port scan classify HTTP on ports where the
 // server waits silently for a request.
 //
-// Returns (open, banner).
-func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration) (bool, string) {
+// A dial that ends in RST (connection refused) is a CONFIRMED-closed port;
+// a dial that runs out of time is UNKNOWN (filtered, or — commonly on busy
+// routers (#256) — a transient drop under load). Unknown dials get one retry
+// so a momentarily-saturated target isn't misread as closed.
+//
+// Returns (open, refused, banner).
+func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration) (bool, bool, string) {
 	dialer := net.Dialer{Timeout: timeout}
-	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
+	addr := net.JoinHostPort(ip, strconv.Itoa(port))
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
-		return false, ""
+		if isRefused(err) {
+			return false, true, ""
+		}
+		if ctx.Err() == nil && !isRefused(err) {
+			// Transient (timeout / overloaded target / momentary drop): one
+			// retry before declaring the port unknown.
+			conn, err = dialer.DialContext(ctx, "tcp", addr)
+			if err != nil {
+				return false, isRefused(err), ""
+			}
+		} else {
+			return false, false, ""
+		}
 	}
 	defer conn.Close()
 
@@ -178,7 +214,7 @@ func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration
 		}
 	}
 	if n > 0 {
-		return true, strings.TrimRight(string(buf[:n]), "\r\n\x00")
+		return true, false, strings.TrimRight(string(buf[:n]), "\r\n\x00")
 	}
 
 	// No passive greeting: try the active probe for this port (if any). This
@@ -186,13 +222,20 @@ func dialAndGrab(ctx context.Context, ip string, port int, timeout time.Duration
 	if probe := probeForPort(port); probe != nil {
 		_ = conn.SetWriteDeadline(time.Now().Add(bannerReadTimeout))
 		if _, werr := conn.Write(probe); werr != nil {
-			return true, ""
+			return true, false, ""
 		}
 		_ = conn.SetReadDeadline(time.Now().Add(bannerReadTimeout))
 		n, _ = conn.Read(buf)
-		return true, strings.TrimRight(string(buf[:n]), "\r\n\x00")
+		return true, false, strings.TrimRight(string(buf[:n]), "\r\n\x00")
 	}
-	return true, ""
+	return true, false, ""
+}
+
+// isRefused reports whether the dial error is a TCP RST (ECONNREFUSED) — the
+// kernel-level proof that nothing listens on the port. Everything else
+// (timeout, no route, network unreachable) leaves the port's state unknown.
+func isRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
 }
 
 // priorityPortList orders ports with fingerprint ports first (in fingerprint

--- a/internal/service/scannerv2/probe/ports_test.go
+++ b/internal/service/scannerv2/probe/ports_test.go
@@ -121,7 +121,9 @@ func TestPortSpecProbe_OpenPortAndBanner(t *testing.T) {
 }
 
 func TestPortSpecProbe_ClosedPortNoEvidence(t *testing.T) {
-	// A port nothing is listening on.
+	// A port nothing is listening on: the dial gets an RST. Since #256 a
+	// refused port emits exactly one port_closed evidence (positive closure
+	// knowledge — safe to drop the host's service row) and nothing else.
 	ln, _ := net.Listen("tcp", "127.0.0.1:0")
 	port := ln.Addr().(*net.TCPAddr).Port
 	ln.Close()
@@ -131,8 +133,8 @@ func TestPortSpecProbe_ClosedPortNoEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(evs) != 0 {
-		t.Errorf("closed port should yield no evidence, got %d", len(evs))
+	if len(evs) != 1 || evs[0].Kind != "port_closed" || evs[0].Port != port {
+		t.Errorf("refused port should yield exactly one port_closed evidence, got %+v", evs)
 	}
 }
 
@@ -369,5 +371,25 @@ func ioReadUntilClosed(conn net.Conn) {
 		if _, err := conn.Read(buf); err != nil {
 			return
 		}
+	}
+}
+
+// TestPortSpecProbe_TimeoutIsUnknownNotClosed dials a non-routable TEST-NET
+// address with a short timeout: the probe must emit NOTHING for that port
+// (timeout ≠ closed) and stay bounded (one retry, not a hang).
+func TestPortSpecProbe_TimeoutIsUnknownNotClosed(t *testing.T) {
+	p := NewPortSpecProbe("22", nil)
+	start := time.Now()
+	evs, err := p.Probe(context.Background(), "192.0.2.1", scannerv2.ProbeHint{Timeout: 150 * time.Millisecond})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 0 {
+		t.Fatalf("timed-out port must emit no evidence (unknown, not closed), got %+v", evs)
+	}
+	// Two attempts at 150ms + slack; a hang or unbounded retry loop blows past.
+	if elapsed > 2*time.Second {
+		t.Fatalf("retry must stay bounded, took %v", elapsed)
 	}
 }

--- a/internal/service/scannerv2/repository.go
+++ b/internal/service/scannerv2/repository.go
@@ -28,8 +28,11 @@ type Repository interface {
 	RecordEvidence(ctx context.Context, ev []Evidence) error
 
 	// RecordServices persists the classified service identities for an IP.
-	// Replaces the prior set for the IP within the current scan run.
-	RecordServices(ctx context.Context, ip string, services []ServiceIdentity) error
+	// Replacement is scoped (#256): rows on ports that were re-identified OR
+	// positively confirmed closed (closedPorts — TCP RST evidence) are
+	// replaced/removed; rows on ports with no signal this cycle (dial timeout,
+	// degraded scan) are kept, so one bad cycle can't erase known services.
+	RecordServices(ctx context.Context, ip string, services []ServiceIdentity, closedPorts []int) error
 
 	// RecordDevice upserts the enriched device fields.
 	RecordDevice(ctx context.Context, ip string, device DeviceRef) error
@@ -150,8 +153,10 @@ type IdentityWrite struct {
 // persistence is wired (e.g. unit tests, ad-hoc CLI scans).
 type NoopRepository struct{}
 
-func (NoopRepository) RecordEvidence(context.Context, []Evidence) error                   { return nil }
-func (NoopRepository) RecordServices(context.Context, string, []ServiceIdentity) error    { return nil }
+func (NoopRepository) RecordEvidence(context.Context, []Evidence) error { return nil }
+func (NoopRepository) RecordServices(context.Context, string, []ServiceIdentity, []int) error {
+	return nil
+}
 func (NoopRepository) RecordDevice(context.Context, string, DeviceRef) error              { return nil }
 func (NoopRepository) RecordHeartbeats(context.Context, string, []HeartbeatSpec) error    { return nil }
 func (NoopRepository) RecordNeighbors(context.Context, string, []NeighborSpec) error      { return nil }

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -168,7 +168,7 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 // device); the rows land with device_uuid=” and are healed on the next scan.
 // The DELETE keeps an IP guard as a belt-and-suspenders so a not-yet-uuid'd row
 // set is still replaced rather than accumulated while the uuid is unresolved.
-func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, services []scannerv2.ServiceIdentity) error {
+func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, services []scannerv2.ServiceIdentity, closedPorts []int) error {
 	uuid, _ := r.resolveDeviceUUID(ctx, ip)
 
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -177,14 +177,36 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Replace the host's prior service set. The rows belong to this IP regardless
-	// of their device_uuid state, so the DELETE keys on IP. This matters across
-	// the uuid-resolution transition: scan 1 (no device row yet) lands rows with
-	// device_uuid='', scan 2 (uuid resolved) must remove those rows — a DELETE
-	// scoped to the resolved uuid would miss the device_uuid='' rows and the
-	// subsequent INSERT would collide on UNIQUE(ip,service,port), silently
-	// dropping the fresh data (regression #129).
-	if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ?`, ip); err != nil {
+	// Scoped replace (#256): only rows whose port was re-identified this cycle
+	// OR positively confirmed closed (TCP RST → closedPorts) are removed. The
+	// previous blanket DELETE-by-IP let one degraded cycle (dial timeouts on a
+	// busy gateway, a half-dead camera that accepts TCP but never answers)
+	// erase every known service for the host. Rows on ports with no signal
+	// (timeout = unknown, not closed) survive until a later cycle resolves
+	// them. The DELETE still keys on IP alone within the port scope — that
+	// keeps the uuid-resolution transition working (scan-1 rows with
+	// device_uuid='' must be replaced by scan-2's resolved rows, regression
+	// #129).
+	portsInPlay := make([]int, 0, len(services)+len(closedPorts))
+	for _, s := range services {
+		if s.Port > 0 {
+			portsInPlay = append(portsInPlay, s.Port)
+		}
+	}
+	portsInPlay = append(portsInPlay, closedPorts...)
+	if len(portsInPlay) == 0 {
+		// Nothing identified and nothing confirmed closed: keep the existing
+		// rows rather than wipe on a no-signal cycle.
+		return nil
+	}
+	placeholders := strings.Repeat("?,", len(portsInPlay))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, 0, len(portsInPlay)+1)
+	args = append(args, ip)
+	for _, p := range portsInPlay {
+		args = append(args, p)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM host_services WHERE ip = ? AND port IN (`+placeholders+`)`, args...); err != nil {
 		return err
 	}
 	if len(services) == 0 {

--- a/internal/service/scannerv2/store/sqlite_test.go
+++ b/internal/service/scannerv2/store/sqlite_test.go
@@ -68,17 +68,18 @@ func TestRecordServices_ReplaceOnRescan(t *testing.T) {
 	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
 		{Service: "http", Port: 80, Confidence: 0.9, Metadata: map[string]string{"server": "nginx"}},
 		{Service: "ssh", Port: 22, Confidence: 0.95},
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("record services (1): %v", err)
 	}
 	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=?`, ip); cnt != 2 {
 		t.Fatalf("expected 2 services after first scan, got %d", cnt)
 	}
 
-	// Second scan: only http remains (ssh dropped). Replace semantics → 1 row.
+	// Second scan: only http remains — the port scan positively closed 22 (RST)
+	// and re-identified 80. Scoped replace → 1 row.
 	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
 		{Service: "http", Port: 80, Confidence: 0.95, Metadata: map[string]string{"server": "nginx/1.25"}},
-	}); err != nil {
+	}, []int{22}); err != nil {
 		t.Fatalf("record services (2): %v", err)
 	}
 	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=?`, ip); cnt != 1 {
@@ -116,7 +117,7 @@ func TestRecordServices_ReplaceAcrossUUIDResolution(t *testing.T) {
 	// device_uuid=''. Mirrors first discovery via the orchestrator path.
 	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
 		{Service: "http", Port: 80, Confidence: 0.9, Metadata: map[string]string{"server": "nginx-old"}},
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("record services (scan 1): %v", err)
 	}
 	// Sanity: the row landed with empty device_uuid.
@@ -133,7 +134,7 @@ func TestRecordServices_ReplaceAcrossUUIDResolution(t *testing.T) {
 	// replace scan-1's device_uuid='' row, not collide with it.
 	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
 		{Service: "http", Port: 80, Confidence: 0.95, Metadata: map[string]string{"server": "nginx-new"}},
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("record services (scan 2): %v", err)
 	}
 
@@ -467,5 +468,63 @@ func TestRecordDevice_DoesNotCreateIdentity(t *testing.T) {
 	}
 	if devMAC != mac {
 		t.Errorf("mac not enriched: %q", devMAC)
+	}
+}
+
+// TestRecordServices_DegradedCycleKeepsRows pins the #256 fix on the store
+// side: a degraded scan cycle (dial timeouts — no TCP evidence, no closure
+// signal) must NOT erase the host's known service rows. Only positively
+// confirmed-closed ports justify deletion.
+func TestRecordServices_DegradedCycleKeepsRows(t *testing.T) {
+	repo, ctx := newRepo(t, Options{})
+	ip := "10.0.0.9"
+
+	// Healthy cycle: gateway-scale service set.
+	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
+		{Service: "ssh", Port: 22, Confidence: 0.95},
+		{Service: "http", Port: 80, Confidence: 0.99},
+		{Service: "https", Port: 443, Confidence: 0.99},
+		{Service: "snmp", Port: 161, Confidence: 0.99, Protocol: "udp"},
+	}, nil); err != nil {
+		t.Fatalf("record services (healthy): %v", err)
+	}
+
+	// Degraded cycle — exactly the #256 field signature: only snmp answered
+	// (fast, lightweight), every TCP dial timed out (no banner, no port_open,
+	// no port_closed). The old blanket DELETE-by-IP wiped ssh/http/https and
+	// left the host with a lone snmp row until a healthy cycle restored them.
+	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
+		{Service: "snmp", Port: 161, Confidence: 0.99, Protocol: "udp"},
+	}, nil); err != nil {
+		t.Fatalf("record services (degraded): %v", err)
+	}
+	for _, want := range []struct {
+		svc  string
+		port int
+	}{
+		{"ssh", 22}, {"http", 80}, {"https", 443}, {"snmp", 161},
+	} {
+		if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=? AND service=? AND port=?`, ip, want.svc, want.port); cnt != 1 {
+			t.Errorf("degraded cycle dropped %s:%d (timeout is not closure)", want.svc, want.port)
+		}
+	}
+
+	// Fully-empty cycle with no closure signal: nothing identified, nothing
+	// closed — the entire prior set must survive untouched.
+	if err := repo.RecordServices(ctx, ip, nil, nil); err != nil {
+		t.Fatalf("record services (empty): %v", err)
+	}
+	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=?`, ip); cnt != 4 {
+		t.Fatalf("no-signal cycle must keep all rows, got %d", cnt)
+	}
+
+	// Service actually stopped (RST observed): the row goes away.
+	if err := repo.RecordServices(ctx, ip, []scannerv2.ServiceIdentity{
+		{Service: "snmp", Port: 161, Confidence: 0.99, Protocol: "udp"},
+	}, []int{22, 80, 443}); err != nil {
+		t.Fatalf("record services (shutdown): %v", err)
+	}
+	if cnt := countRows(t, repo.db, `SELECT COUNT(*) FROM host_services WHERE ip=?`, ip); cnt != 1 {
+		t.Fatalf("confirmed-closed ports must remove their rows, got %d", cnt)
 	}
 }


### PR DESCRIPTION
Fixes #256

## 实测调查结论（测试环境三路径复现）
在隔离实例（DB 副本 + persist_raw_evidence 开启）分别跑 **.1 单 IP 扫描、/24 同步扫描（16 并发）、任务触发（50 并发）**：三条路径下 .1 的 TCP 证据（22/53/80/443/8080/8443/9100）与服务分类**全部正常**。探针→分类→持久化链路本身无缺陷。

**真实机制**：`RecordServices` 的整体替换语义（DELETE BY ip + INSERT）把**一次降级采集周期**变成对该主机已知服务行的整体抹除：
- 网关在高并发扫描负载下 TCP accept 变慢 → 拨号超时（3s per-probe）→ 无 port_open/banner 证据 → 该周期 services=[snmp]（SNMP 轻量仍应答）→ 替换后 ssh/http/https 全部消失，只剩 snmp:161 —— 与生产现场完全吻合
- 缺口 2（.133 半死相机：TCP 握手通但应用层不答）同机制：无 banner → 无身份 → 旧行被抹

**附带发现**：`Runner.Run` 并未应用 task.pipeline_config（无阶段门控/端口 spec 传递，引擎固定用全局端口表）——task 的 7 端口白名单实际未生效，本 PR 不扩scope，留作后续 issue。

## 修复（负证据 + 作用域替换 + 有界重试）
1. **PortSpecProbe 负证据**：RST（ECONNREFUSED）= 正向关闭知识 → 发 `port_closed` 证据；拨号超时 = 未知 → 不发证据且**有界重试一次**（瞬时高负载不误判）
2. **RecordServices(ctx, ip, services, closedPorts)**：DELETE 作用域收窄为『本轮重新识别 ∪ 确认关闭』端口集合；**无信号周期的旧行保留**；#129 的 uuid 迁移语义在端口作用域内保持（同端口 delete+insert）
3. orchestrator：零服务但有 port_closed 时仍调用（确认关闭要生效）

## 测试
- probe：拒绝→恰一条 port_closed；超时→零证据 + 耗时有界
- store：**降级周期保全**（services=[snmp] + 无关闭信号 → ssh/http/https 存活）、空周期不动、确认关闭删除
- 服务器实测：修复二进制 /24 扫描 .1 全 8 服务 + 全网 1248 条 port_closed 负证据

## 已知 trade-off
端口开放但服务无法识别的周期，该端口旧行会保留（不会误删）——这是刻意的：宁可陈旧也不闪断。陈旧行会在端口真正关闭（RST）或服务重新识别时被清掉。