### PR TITLE
fix(web): 侧栏 footer 补 Settings 入口（#248）

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -241,7 +241,20 @@
 				<NotificationBell />
 			</div>
 			{#if $auth.token}
-				<div class="flex items-center justify-between pt-2">
+				<!-- Self-service settings (profile/2FA/appearance) + the admin-ish
+				     sub-pages (notification channels, SNMP credentials) live under
+				     /settings; without this link they are undiscoverable (#248). -->
+				<a
+					href="/settings"
+					class="flex items-center gap-1.5 px-1 pt-2 pb-1 text-xs transition-colors
+						{$page.url.pathname.startsWith('/settings')
+						? 'text-primary font-medium'
+						: 'text-muted hover:text-text'}"
+				>
+					<Settings class="w-3.5 h-3.5" />
+					{m['navigation.Settings']()}
+				</a>
+				<div class="flex items-center justify-between pt-1">
 					<span class="text-xs text-muted truncate flex items-center gap-1.5">
 						<Users class="w-3.5 h-3.5" />
 						{$auth.user?.username || '...'}


### PR DESCRIPTION
Fixes #248

## 根因
`+layout.svelte` 的导航分组注释写着 *"The Settings entry stays in the footer (it's self-service profile/security, not admin infra)"* —— 但 footer 模板**从未渲染这个链接**（`Settings` 图标 :29 import 了却零使用）。三个功能齐全的页面只能手敲 URL：
- `/settings` — 个人资料/改密/外观/**2FA 开启**/语言
- `/settings/notifications` — 通知渠道 + 规则管理
- `/settings/snmp-credentials` — SNMP 凭据库

## 修复
footer 用户区上方补 Settings 链接：登录态可见（含未登录隐藏逻辑复用现有 `{#if $auth.token}` 块）、`/settings` 前缀路由高亮、复用既有 `navigation.Settings` i18n 键（en=Settings / zh=设置）。

## 验证
vitest 197 全绿；svelte-check 与改动前基线一致（47 errors 为存量，非 CI 门槛）。