### PR TITLE
fix(web): paraglide 参数传递修正 10 处 + Documents 页标题错键（#249 #250）

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -228,7 +228,8 @@
 		"Preview File": "Preview File",
 		"Preview Not Available": "Preview not available for this file type",
 		"Restore Failed": "Restore failed",
-		"URL Placeholder": "https://..."
+		"URL Placeholder": "https://...",
+		"Page Title": "Documents"
 	},
 	"heartbeat": {
 		"Success": "Success",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -228,7 +228,8 @@
 		"Preview File": "预览文件",
 		"Preview Not Available": "此文件类型不支持预览",
 		"Restore Failed": "恢复失败",
-		"URL Placeholder": "https://..."
+		"URL Placeholder": "https://...",
+		"Page Title": "文档"
 	},
 	"heartbeat": {
 		"Success": "成功",

--- a/web/src/lib/components/scanner/PipelineConfigEditor.svelte
+++ b/web/src/lib/components/scanner/PipelineConfigEditor.svelte
@@ -159,7 +159,7 @@
 			{/each}
 		</div>
 		<span class="ml-auto text-xs text-muted">
-			{m['scanner.pipeline.stages_enabled']().replace('{count}', String(enabledCount))}
+			{m['scanner.pipeline.stages_enabled']({ count: enabledCount })}
 		</span>
 	</div>
 

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -391,7 +391,7 @@ interface AddDevicesResponse {
 		batchLoading = true;
 		try {
 			await api.post('/devices/batch-delete', { ids: Array.from(selectedIds) });
-			addToast('success', m['devices.Batch Delete Success']().replace('{count}', String(selectedIds.size)));
+			addToast('success', m['devices.Batch Delete Success']({ count: selectedIds.size }));
 			selectedIds = new Set();
 			fetchDevices();
 		} catch (err: unknown) {
@@ -501,10 +501,10 @@ interface AddDevicesResponse {
 			if (res.errors && res.errors.length > 0) {
 				// Summary warning with the first error reason, rather than a toast
 				// per failure (noisy when many rows fail).
-				addToast('warning', m['scanner.Import N Failed']().replace('{count}', String(res.errors.length)).replace('{reason}', res.errors[0]));
+				addToast('warning', m['scanner.Import N Failed']({ count: res.errors.length, reason: res.errors[0] }));
 			}
 			if (res.added > 0) {
-				addToast('success', m['scanner.Added N Devices']().replace('{count}', String(res.added)));
+				addToast('success', m['scanner.Added N Devices']({ count: res.added }));
 				importOpen = false;
 				csvFile = null;
 				csvPreviewRows = [];
@@ -1127,7 +1127,7 @@ interface AddDevicesResponse {
 				<input type="checkbox" checked onchange={toggleSelectAll}
 					class="w-4 h-4 rounded border-border text-primary focus:ring-primary cursor-pointer" />
 				<span class="text-sm font-medium text-primary">
-					{m['devices.Selected Count']().replace('{count}', String(selectedIds.size))}
+					{m['devices.Selected Count']({ count: selectedIds.size })}
 				</span>
 			</div>
 			<div class="flex-1"></div>

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -284,11 +284,11 @@
 				// Single summary warning (count + first reason) instead of one
 				// toast per failure — floods the toast stack when many devices
 				// fail (e.g. duplicates). Matches the CSV-import path. #152 part 3.
-				addToast('warning', m['scanner.Add N Failed']().replace('{count}', String(res.errors.length)).replace('{reason}', res.errors[0]));
+				addToast('warning', m['scanner.Add N Failed']({ count: res.errors.length, reason: res.errors[0] }));
 			}
 
 			if (res.added > 0) {
-				addToast('success', m['scanner.Added N Devices']().replace('{count}', String(res.added)));
+				addToast('success', m['scanner.Added N Devices']({ count: res.added }));
 				deselectAll();
 			}
 		} catch (err) {
@@ -570,7 +570,7 @@
 									<td colspan="10" class="px-3 py-2">
 										<div class="flex items-center gap-2 text-xs text-muted">
 											<span class="w-2 h-2 bg-error rounded-full"></span>
-											{m['scanner.Unreachable Hosts']().replace('{count}', String(getUnreachableHosts().length))}
+											{m['scanner.Unreachable Hosts']({ count: getUnreachableHosts().length })}
 										</div>
 									</td>
 								</tr>
@@ -597,7 +597,7 @@
 										>
 											{showAllUnreachable
 												? m['scanner.Show Less Unreachable']()
-												: m['scanner.Show All Unreachable']().replace('{count}', String(getUnreachableHosts().length))}
+												: m['scanner.Show All Unreachable']({ count: getUnreachableHosts().length })}
 										</button>
 									</td>
 								</tr>
@@ -632,7 +632,7 @@
 	<ConfirmDialog
 		bind:open={confirmAddOpen}
 		title={m['scanner.Confirm Add Title']()}
-		message={m['scanner.Confirm Add Message']().replace('{count}', String(selectedIps.size))}
+		message={m['scanner.Confirm Add Message']({ count: selectedIps.size })}
 		confirmLabel={m['scanner.Add Selected']()}
 		onConfirm={performAdd}
 		onCancel={() => { confirmAddOpen = false; }}

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -405,7 +405,7 @@
 <div class="p-4 sm:p-6">
 	<!-- Header -->
 	<div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
-		<h2 class="text-2xl font-bold text-primary">{m["documents.Title"]()}</h2>
+		<h2 class="text-2xl font-bold text-primary">{m["documents.Page Title"]()}</h2>
 		<div class="flex gap-2">
 			<button
 				onclick={openUrlCreate}


### PR DESCRIPTION
Fixes #249, Fixes #250

## #249 — "undefined stages enabled"
paraglide 消息函数未传参时缺失参数渲染为字面 `undefined`，后面的 `.replace('{count}', …)` 匹配不到已消失的占位符。**全局搜索发现同款 `.replace('{…}')` 模式共 10 处**（不止 issue 报告的 1 处）：

- `PipelineConfigEditor` stages_enabled（issue 原报）
- `devices/scanner`：Add N Failed / Added N Devices / Unreachable Hosts / Show All Unreachable / Confirm Add Message
- `devices`：Batch Delete Success / Import N Failed / Added N Devices / Selected Count

全部改为 `m[key]({ count, reason })` 直接传参（paraglide 标准用法）。

## #250 — Documents 页标题
`documents/+page.svelte:408` 误用列标签键 `documents.Title`（页头显示 "Title"/"标题"）→ 新增 `documents.Page Title`（en=Documents / zh=文档）。

## 验证
vitest 197 全绿；i18n 键经 paraglide 类型化引用（编译期查键）。