### PR TITLE
fix(web): GUI 巡检小问题批 — 时长格式/心跳语义/校验文案/按钮态/密码清空/无障碍（#251）

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1093,6 +1093,7 @@
 		"Health Certificates": "Certificates",
 		"Health No Certs": "None",
 		"Health Not Configured": "Not configured",
+		"Health No Data": "No data yet",
 		"Health Success Rate": "{rate}% success",
 		"Health Check Certs": "View certificates",
 		"No IP Address": "Device has no IP address",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1093,6 +1093,7 @@
 		"Health Certificates": "证书",
 		"Health No Certs": "无",
 		"Health Not Configured": "未配置",
+		"Health No Data": "暂无数据",
 		"Health Success Rate": "成功率 {rate}%",
 		"Health Check Certs": "查看证书",
 		"No IP Address": "该设备没有 IP 地址",

--- a/web/src/lib/utils/format.ts
+++ b/web/src/lib/utils/format.ts
@@ -42,3 +42,14 @@ export function formatTime(iso: string | number | Date | null | undefined): stri
 		return String(iso);
 	}
 }
+
+/**
+ * Human-readable duration from milliseconds ("940ms" / "108.3s"), shared by
+ * the scan-results run history and the dashboard scan-activity table — the
+ * two surfaces used to disagree (raw ms vs formatted) for the same column
+ * (#251).
+ */
+export function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -21,6 +21,7 @@
 	import { m } from '$lib/i18n-paraglide';
 	import { Plus, RotateCw, Puzzle, BarChart3, AlertTriangle, CheckCircle2, Radar } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
+	import { formatDuration } from '$lib/utils/format';
 	import { addToast } from '$lib/stores/toast';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { scanRunStatusBadge } from '$lib/utils/badges';
@@ -956,7 +957,7 @@
 											</td>
 											<td class="py-2 pr-3 tabular-nums">{run.alive_hosts}/{run.total_hosts}</td>
 											<td class="py-2 pr-3 tabular-nums">{run.new_hosts}</td>
-											<td class="py-2 pr-3 tabular-nums text-muted">{run.duration_ms}ms</td>
+											<td class="py-2 pr-3 tabular-nums text-muted">{formatDuration(run.duration_ms)}</td>
 										</tr>
 									{/each}
 								</tbody>

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -138,6 +138,12 @@
 	let trendError = $state('');
 	// --- Heartbeat config state ---
 	let heartbeatConfigs = $state<Array<{ id: number; method: string; target: string; interval_seconds: number; timeout_seconds: number; enabled: number }>>([]);
+	// Header-level existence probe (#251): the Health card needs to distinguish
+	// "no heartbeat configs" (Not configured) from "configs exist but produced
+	// no results yet" (No data yet) — trendStats alone can't tell them apart,
+	// and it only loads when the Heartbeat tab opens. Cheapest source of truth
+	// is a limit=1 list call reading `total`.
+	let heartbeatConfigCount = $state<number | null>(null);
 	let heartbeatConfigLoading = $state(false);
 	let creatingHeartbeat = $state(false);
 
@@ -358,6 +364,10 @@
 		// the same `device` fetch, Network/Heartbeat/Config fetch on first open
 		// via setTab. This cuts the initial load from 6 parallel requests to 2.
 		fetchSystems();
+		// Header Health card probe (see heartbeatConfigCount above).
+		api.get<{ total: number }>(`/devices/${deviceId}/heartbeat-configs?limit=1`)
+			.then((res) => { heartbeatConfigCount = res.total ?? 0; })
+			.catch(() => { heartbeatConfigCount = null; });
 		// A deep link (?tab=…) lands directly on a lazy tab — fetch its data so
 		// the panel isn't empty until the user clicks away and back.
 		loadTabData(activeTab);
@@ -1005,6 +1015,8 @@
 						<span class="font-mono {heartbeatRate >= 90 ? 'text-success' : heartbeatRate >= 50 ? 'text-warning' : 'text-error'}">
 							{m['devicedetail.Health Success Rate']({ rate: heartbeatRate })}
 						</span>
+					{:else if heartbeatConfigCount !== null && heartbeatConfigCount > 0}
+						<span class="text-muted">{m['devicedetail.Health No Data']()}</span>
 					{:else}
 						<span class="text-muted">{m['devicedetail.Health Not Configured']()}</span>
 					{/if}

--- a/web/src/routes/devices/scan-results/+page.svelte
+++ b/web/src/routes/devices/scan-results/+page.svelte
@@ -16,6 +16,7 @@
 	import { getErrorMessage } from '$lib/utils/error';
 	import { scanRunStatusBadge } from '$lib/utils/badges';
 	import { formatDateTime as formatTime } from '$lib/utils/index';
+	import { formatDuration } from '$lib/utils/format';
 	import { goto } from '$app/navigation';
 
 	import Pagination from '$lib/components/Pagination.svelte';
@@ -282,10 +283,6 @@
 	}
 
 	// --- Formatting ---
-	function formatDuration(ms: number): string {
-		if (ms < 1000) return `${ms}ms`;
-		return `${(ms / 1000).toFixed(1)}s`;
-	}
 
 	function formatBytes(bytes: number): string {
 		if (bytes < 1024) return `${bytes} B`;

--- a/web/src/routes/devices/scan-tasks/+page.svelte
+++ b/web/src/routes/devices/scan-tasks/+page.svelte
@@ -606,12 +606,14 @@
 									<div class="flex gap-2 justify-end">
 										<button
 											onclick={() => triggerTask(task)}
-											disabled={triggeringId === task.id}
+											aria-label={m['scanner.Trigger']()}
+											disabled={triggeringId === task.id || activeRuns.has(task.id)}
 											class="text-xs px-2 py-1 rounded text-accent hover:bg-accent/10
 												transition-colors disabled:opacity-50"
 										>
 									{#if triggeringId === task.id || activeRuns.has(task.id)}
-										⏳
+										<span aria-hidden="true">⏳</span>
+										<span class="sr-only">{m['scanner.Trigger']()}</span>
 									{:else}
 										{m['scanner.Trigger']()}
 									{/if}

--- a/web/src/routes/devices/scanner/+page.svelte
+++ b/web/src/routes/devices/scanner/+page.svelte
@@ -134,7 +134,10 @@
 	async function startScan() {
 		const err = validateTargets();
 		if (err) {
-			addToast('error', m['scanner.Invalid Range']());
+			// Empty targets and malformed targets are different failures — the
+			// field hint already shows the precise reason; the toast used to
+			// blanket-report "invalid range" even for a bare empty field (#251).
+			addToast('error', targets.trim() === '' ? m['scanner.Targets Required']() : m['scanner.Invalid Range']());
 			return;
 		}
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -61,9 +61,11 @@
 		}
 
 		loading = true;
+		let loginDone = false;
 		try {
 			const res = await api.post<LoginResponse>('/auth/login', { username, password });
 			loginResponse = res;
+			loginDone = true;
 
 			// Check if 2FA is required. LoginResponse models these fields
 			// (two_factor_required / user_id) directly — no `as any` needed.
@@ -103,6 +105,10 @@
 			}
 		} finally {
 			loading = false;
+			// A failed attempt leaves the typed password in the (masked) field —
+			// clear it so a stale password isn't shoulder-surfed or resubmitted
+			// after the user walks away (#251).
+			if (!loginDone) password = '';
 		}
 	}
 

--- a/web/src/routes/settings/notifications/+page.svelte
+++ b/web/src/routes/settings/notifications/+page.svelte
@@ -612,8 +612,8 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-4">
 		<div class="flex items-center gap-3">
-			<a href="/settings" class="text-text-muted hover:text-text transition-colors">
-				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<a href="/settings" class="text-text-muted hover:text-text transition-colors" aria-label={m['navigation.Settings']()}>
+				<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
 				</svg>
 			</a>


### PR DESCRIPTION
Fixes #251

## 逐项对照 issue
1. **Duration 口径统一**：`formatDuration` 提为 $lib/utils/format 共享；dashboard Scan Activity 与 scan-results Run History 同渲染（`108989ms` → `108.3s`）
2. **Heartbeat 语义**：页头区分「未配置」（无 configs）与「暂无数据」（有 configs 但 0 结果）——挂载期 `limit=1` 轻量探测 `total`，新增 i18n `devicedetail.Health No Data`（No data yet / 暂无数据）
3. **空目标 toast**：空值报 `Targets Required`，非空畸形才报 `Invalid Range`
4. **Trigger 按钮**：运行中 `disabled`（原仅换 ⏳ 仍可点）+ ⏳ 配 `sr-only` 可访问名 + aria-label
5. **登录失败清密码**：失败/异常路径清空密码框（2FA 转场与成功路径保留语义由局部标志区分）
6. **返回链接无障碍**：icon-only 链接补 aria-label（复用 `navigation.Settings`）、svg aria-hidden
7. **遗留 Test Widget**：由 #247 的 position 迁移转为可见可删，无需单独数据清理

## 验证
vitest 197 全绿；svelte-check 46 errors（低于改动前基线 47，非 CI 门槛）；paraglide 经 prebuild 重编译