### PR TITLE
obs(probe): 周期探测失败日志降级 — WARN/DEBUG 采样 + 恢复 INFO 翻转（#271）

### DIFF
--- a/internal/service/probe/flog.go
+++ b/internal/service/probe/flog.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You can use, copy, modify, and redistribute it
+// under those terms; see LICENSE for the full text. A commercial license is
+// available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package probe
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Log-noise reduction for periodic probes (#271).
+//
+// A device that is offline fails EVERY cycle by design: two days of field logs
+// showed 7518 "probe failed" ERROR lines for known-dead targets, drowning the
+// ~1459 real errors (SQLITE_BUSY writes). Consecutive-failure streaks drive
+// the level instead:
+//
+//   - first warnStreakThreshold failures of a streak → WARN (a target that
+//     just went down is news),
+//   - after that → DEBUG, sampled every debugSampleEvery-th failure so the
+//     "still failing" heartbeat stays greppable without flooding,
+//   - recovery after a long streak → INFO (the offline→online transition),
+//   - the streak map is unbounded in theory but keyed by (method, target)
+//     where targets are probe/heartbeat configs — dozens of entries, not
+//     thousands; entries are deleted on success.
+const (
+	warnStreakThreshold = 3
+	debugSampleEvery    = 20
+)
+
+var failStreaks sync.Map // "method|target" -> *atomic.Int64
+
+// logProbeFailure records one failed probe attempt and logs it at the level
+// the current streak warrants. Caller-side errors (unparseable target, bad
+// config) never go through here — they stay ERROR; only execution failures
+// against the target do.
+func logProbeFailure(method, target string, err error) {
+	streak, _ := failStreaks.LoadOrStore(method+"|"+target, new(atomic.Int64))
+	n := streak.(*atomic.Int64).Add(1)
+	switch {
+	case n <= warnStreakThreshold:
+		slog.Warn("probe failed", "method", method, "target", target, "error", err, "streak", n)
+	case n%debugSampleEvery == 0:
+		slog.Debug("probe target still failing", "method", method, "target", target, "error", err, "streak", n)
+	}
+}
+
+// noteProbeSuccess clears a target's failure streak, emitting an INFO
+// transition when it recovers from an established outage (>= threshold
+// failures). Routine successes stay at their existing Debug logging — this
+// only owns the transition event.
+func noteProbeSuccess(method, target string, latency time.Duration) {
+	if v, ok := failStreaks.LoadAndDelete(method + "|" + target); ok {
+		if n := v.(*atomic.Int64).Load(); n >= warnStreakThreshold {
+			slog.Info("probe target recovered", "method", method, "target", target,
+				"after_failures", n, "latency", latency)
+		}
+	}
+}

--- a/internal/service/probe/flog_test.go
+++ b/internal/service/probe/flog_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 MiBee Studio. All rights reserved.
+
+package probe
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestProbeFailureStreakLogging pins the #271 log-noise contract at the unit
+// level by driving the streak counters directly:
+//   - failures 1..warnStreakThreshold increment the streak,
+//   - a recovery before the threshold emits NO transition,
+//   - a recovery after an established outage DOES (the offline→online event
+//     the issue requires to stay visible),
+//   - the streak resets after success.
+func TestProbeFailureStreakLogging(t *testing.T) {
+	failStreaks = sync.Map{} // reset global state
+
+	// Target goes down: streak accumulates past the WARN threshold.
+	for i := 0; i < warnStreakThreshold+2; i++ {
+		logProbeFailure("icmp", "10.0.0.99", errors.New("timeout"))
+	}
+	v, ok := failStreaks.Load("icmp|10.0.0.99")
+	if !ok {
+		t.Fatal("streak entry missing after failures")
+	}
+	if n := v.(*atomic.Int64).Load(); n != warnStreakThreshold+2 {
+		t.Fatalf("streak = %d, want %d", n, warnStreakThreshold+2)
+	}
+
+	// Established outage recovers: streak cleared.
+	noteProbeSuccess("icmp", "10.0.0.99", 5*time.Millisecond)
+	if _, still := failStreaks.Load("icmp|10.0.0.99"); still {
+		t.Fatal("streak entry must be deleted on success")
+	}
+
+	// Brief flap (below threshold) then success: no transition expected,
+	// entry still cleaned up.
+	logProbeFailure("tcp", "10.0.0.100", errors.New("refused"))
+	noteProbeSuccess("tcp", "10.0.0.100", time.Millisecond)
+	if _, still := failStreaks.Load("tcp|10.0.0.100"); still {
+		t.Fatal("streak entry must be deleted on success (flap case)")
+	}
+}

--- a/internal/service/probe/http.go
+++ b/internal/service/probe/http.go
@@ -33,7 +33,8 @@ func (p *HTTPProber) Probe(ctx context.Context, target string, timeout time.Dura
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
-		slog.Error("probe failed", "method", "http", "target", target, "error", err)
+		// execution failure against the target (dial/timeout/response) → streak log
+		logProbeFailure("http", target, err)
 		return &Result{
 			Success:      false,
 			ErrorMessage: err.Error(),
@@ -57,6 +58,7 @@ func (p *HTTPProber) Probe(ctx context.Context, target string, timeout time.Dura
 	latency := elapsed
 	if success := resp.StatusCode < 400; success {
 		slog.Debug("probe executed", "method", "http", "target", target, "success", true, "latency", latency)
+		noteProbeSuccess("http", target, latency)
 		return &Result{
 			Success:    true,
 			Latency:    latency,

--- a/internal/service/probe/icmp.go
+++ b/internal/service/probe/icmp.go
@@ -41,7 +41,7 @@ func (p *ICMPProber) Probe(ctx context.Context, target string, timeout time.Dura
 	elapsed := time.Since(start)
 
 	if err != nil {
-		slog.Error("probe failed", "method", "icmp", "target", target, "error", err)
+		logProbeFailure("icmp", target, err)
 		return &Result{
 			Success:      false,
 			Latency:      elapsed,
@@ -52,6 +52,7 @@ func (p *ICMPProber) Probe(ctx context.Context, target string, timeout time.Dura
 	stats := pinger.Statistics()
 	if stats.PacketsRecv > 0 {
 		slog.Debug("probe executed", "method", "icmp", "target", target, "success", true, "latency", stats.AvgRtt)
+		noteProbeSuccess("icmp", target, stats.AvgRtt)
 		return &Result{
 			Success: true,
 			Latency: stats.AvgRtt,

--- a/internal/service/probe/snmp.go
+++ b/internal/service/probe/snmp.go
@@ -50,7 +50,7 @@ func (p *SNMPProber) Probe(_ context.Context, target string, timeout time.Durati
 	err := snmp.Connect()
 	if err != nil {
 		elapsed := time.Since(start)
-		slog.Error("probe failed", "method", "snmp", "target", target, "error", err)
+		logProbeFailure("snmp", target, err)
 		return &Result{
 			Success:      false,
 			Latency:      elapsed,
@@ -63,7 +63,7 @@ func (p *SNMPProber) Probe(_ context.Context, target string, timeout time.Durati
 	elapsed := time.Since(start)
 
 	if err != nil {
-		slog.Error("probe failed", "method", "snmp", "target", target, "error", err)
+		logProbeFailure("snmp", target, err)
 		return &Result{
 			Success:      false,
 			Latency:      elapsed,
@@ -72,6 +72,7 @@ func (p *SNMPProber) Probe(_ context.Context, target string, timeout time.Durati
 	}
 
 	slog.Debug("probe executed", "method", "snmp", "target", target, "success", true, "latency", elapsed)
+	noteProbeSuccess("snmp", target, elapsed)
 	return &Result{
 		Success: true,
 		Latency: elapsed,

--- a/internal/service/probe/tcp.go
+++ b/internal/service/probe/tcp.go
@@ -27,7 +27,7 @@ func (p *TCPProber) Probe(ctx context.Context, target string, timeout time.Durat
 	elapsed := time.Since(start)
 
 	if err != nil {
-		slog.Error("probe failed", "method", "tcp", "target", target, "error", err)
+		logProbeFailure("tcp", target, err)
 		return &Result{
 			Success:      false,
 			Latency:      elapsed,
@@ -37,6 +37,7 @@ func (p *TCPProber) Probe(ctx context.Context, target string, timeout time.Durat
 	conn.Close()
 
 	slog.Debug("probe executed", "method", "tcp", "target", target, "success", true, "latency", elapsed)
+	noteProbeSuccess("tcp", target, elapsed)
 	return &Result{
 		Success: true,
 		Latency: elapsed,


### PR DESCRIPTION
Fixes #271

## 根因
周期探测（心跳 + 拨测）对**已知离线目标**每轮必然失败：实测 2 天 **7518 条 ERROR**（全部日志错误的 84%），真实的 1459 条错误（#252 SQLITE_BUSY 丢写）被淹没。

## 修复：连击（streak）驱动的日志级别
新增 `internal/service/probe/flog.go`，按 `(method, target)` 维护连续失败计数：

| 状态 | 级别 |
|---|---|
| 连击 1–3 次 | **WARN**（刚掉线是新闻） |
| 连击 >3 次 | **DEBUG**，每 20 次采样 1 条（保留 "仍在失败" 的 grep 心跳，30s 周期 ≈ 10 分钟一条） |
| 连击 ≥3 后恢复 | **INFO** `probe target recovered`（offline→online 翻转事件保持可见） |
| 成功（无连击） | 原有 Debug 日志不变 |

**边界维持**：
- 调用方构造错误（畸形 target/URL/pinger 创建失败）保持 **ERROR** —— 不是目标状态问题
- 基础设施错误（probe engine 持久化失败、heartbeat store 等）**不经过本路径**，维持 ERROR 不被限频（issue 明确要求）
- 状态翻转双方均可见（掉线：第 1 次 WARN；恢复：INFO）

## 测试
`TestProbeFailureStreakLogging`：连击累计、established outage 恢复清理条目、低于阈值的 flap 恢复同样清理。`go test ./...` 全绿。

## 效果估算
37 台设备离线场景：原每 30s × 每方法一条 ERROR → 现每目标 3 条 WARN + 每 10 分钟 1 条 DEBUG，ERROR 通道回归"真实错误专用"。