### PR TITLE
test(e2e): 端到端冒烟脚本 — 四类回归断言单命令 60 秒跑完（#270）

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -170,7 +170,7 @@ fi
 echo "== 5. probe-target persistence (anti-#252) =="
 curl -sf -m 5 -X POST "${BASE}/api/v1/probe-targets" \
     -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
-    -d "{\"name\":\"e2e-self\",\"module\":\"http\",\"target\":\"${BASE}/api/v1/health\",\"interval_seconds\":10}" >/dev/null
+    -d "{\"name\":\"e2e-self\",\"module\":\"http\",\"target\":\"${BASE}/api/v1/health\",\"interval_seconds\":10,\"timeout_seconds\":5}" >/dev/null
 PSTAT=1
 for i in $(seq 1 20); do
     PLIST="$(curl -sf -m 5 "${BASE}/api/v1/probe-targets" -H "Authorization: Bearer ${TOKEN}" || echo '{}')"
@@ -181,10 +181,10 @@ done
 PRES=""
 for i in $(seq 1 20); do
     PRES="$(curl -sf -m 5 "${BASE}/api/v1/probe-targets/${PID}/results?limit=1" -H "Authorization: Bearer ${TOKEN}" || echo '')"
-    printf '%s' "${PRES}" | grep -q '"success": *true\|"success":true' && break
+    printf '%s' "${PRES}" | grep -q '"status":"success"' && break
     sleep 2
 done
-if printf '%s' "${PRES}" | grep -q '"success": *true\|"success":true'; then
+if printf '%s' "${PRES}" | grep -q '"status":"success"'; then
     ok "probe-target result persisted (http ${BASE}/api/v1/health)"
 else
     bad "probe-target produced no persisted result (#252 regression class)"


### PR DESCRIPTION
Fixes #270

## 交付：`scripts/e2e.sh`
黑盒端到端冒烟，覆盖单元测试拦不住的**四类静默回归**（#252/#253 的教训）：

| 断言组 | 防的回归 | 实现方式 |
|---|---|---|
| 1. /health + /metrics | 服务不可用/指标断流 | 直接 GET |
| 2. agent 上报 → 设备入库 | 分布式链路断线 | 真实 API 流：建网络 → 签发 agent token → POST /agents/report（2 虚构主机）→ 设备列表断言 |
| 3. 同步扫描发现真实服务 | 识别链路退化 | **扫中心自身**（loopback HTTP 真服务，`ports` 参数锁定自身端口，零外部依赖）→ open_ports 断言 |
| 4. 异步任务二次触发 | **#253 静默冻结** | 触发两次 → 断言结果仍 1 行（upsert）且 scanned_at 刷新 |
| 5. 拨测结果落库 | **#252 静默丢写** | 建拨测目标指向自身 /health → 等引擎 tick → results 断言 `status:success` |

## 设计要点
- **自扫描**：目标是运行中的中心自己 —— 无需 python/外部监听器/第二进程，任何能跑 go build 的机器都能跑
- 依赖仅 `go` + `curl`；临时目录隔离；trap 清理；失败时打印服务器日志尾部
- **实测：13/13 断言通过，全程 ~50 秒**（要求 <2 分钟）

## 使用
```bash
./scripts/e2e.sh          # 发版前手动 / CI 可选 job
```