### PR TITLE
fix(heartbeat): 扫描种子心跳幂等化 — 重扫不再撞 UNIQUE(device_id,method)（#291）

### DIFF
--- a/db/queries/heartbeat_configs.sql
+++ b/db/queries/heartbeat_configs.sql
@@ -12,6 +12,17 @@ INSERT INTO heartbeat_configs (device_id, method, target, interval_seconds, time
 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING id, device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled, created_at, updated_at;
 
+-- name: CreateHeartbeatConfigIfAbsent :execrows
+-- Idempotent form of CreateHeartbeatConfig for scan-time seeding (#291): a
+-- device scanned twice (or seeded by two paths in one bridge) re-asserts the
+-- same (device_id, method) spec as a no-op instead of failing the UNIQUE
+-- index. The user-driven API create keeps the strict form so a manual
+-- duplicate surfaces as a 409.
+INSERT INTO heartbeat_configs (device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(device_id, method) DO NOTHING
+RETURNING id, device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled, created_at, updated_at;
+
 -- name: GetHeartbeatConfig :one
 SELECT id, device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled, created_at, updated_at
 FROM heartbeat_configs

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -241,6 +241,11 @@ CREATE INDEX IF NOT EXISTS idx_devices_type ON devices(type);
 -- scan_attributes column. They cannot live here because schema replay runs
 -- before the ALTER on existing DBs and would fail with "no such column".
 -- (Fresh installs get them via the same migration step, which is idempotent.)
+-- One heartbeat config per (device, method). Scan-time seeding must be
+-- idempotent: repeated scans / dual seeding paths re-assert the same spec
+-- instead of failing the UNIQUE index (#291). Declared here for fresh
+-- installs; runMigrations creates it for existing DBs.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_heartbeat_configs_device_method ON heartbeat_configs(device_id, method);
 CREATE INDEX IF NOT EXISTS idx_heartbeat_results_device ON heartbeat_results(device_id, checked_at);
 CREATE INDEX IF NOT EXISTS idx_heartbeat_results_checked_at ON heartbeat_results(checked_at);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);

--- a/internal/db/heartbeat_configs.sql.go
+++ b/internal/db/heartbeat_configs.sql.go
@@ -63,6 +63,46 @@ func (q *Queries) CreateHeartbeatConfig(ctx context.Context, arg CreateHeartbeat
 	return i, err
 }
 
+const createHeartbeatConfigIfAbsent = `-- name: CreateHeartbeatConfigIfAbsent :execrows
+INSERT INTO heartbeat_configs (device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(device_id, method) DO NOTHING
+RETURNING id, device_id, method, target, interval_seconds, timeout_seconds, snmp_community, snmp_oid, enabled, created_at, updated_at
+`
+
+type CreateHeartbeatConfigIfAbsentParams struct {
+	DeviceID        int64  `json:"device_id"`
+	Method          string `json:"method"`
+	Target          string `json:"target"`
+	IntervalSeconds int64  `json:"interval_seconds"`
+	TimeoutSeconds  int64  `json:"timeout_seconds"`
+	SnmpCommunity   string `json:"snmp_community"`
+	SnmpOid         string `json:"snmp_oid"`
+	Enabled         int64  `json:"enabled"`
+}
+
+// Idempotent form of CreateHeartbeatConfig for scan-time seeding (#291): a
+// device scanned twice (or seeded by two paths in one bridge) re-asserts the
+// same (device_id, method) spec as a no-op instead of failing the UNIQUE
+// index. The user-driven API create keeps the strict form so a manual
+// duplicate surfaces as a 409.
+func (q *Queries) CreateHeartbeatConfigIfAbsent(ctx context.Context, arg CreateHeartbeatConfigIfAbsentParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, createHeartbeatConfigIfAbsent,
+		arg.DeviceID,
+		arg.Method,
+		arg.Target,
+		arg.IntervalSeconds,
+		arg.TimeoutSeconds,
+		arg.SnmpCommunity,
+		arg.SnmpOid,
+		arg.Enabled,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteHeartbeatConfig = `-- name: DeleteHeartbeatConfig :execrows
 DELETE FROM heartbeat_configs
 WHERE id = ?

--- a/internal/service/heartbeat.go
+++ b/internal/service/heartbeat.go
@@ -194,11 +194,21 @@ func (s *HeartbeatService) CreateConfigs(ctx context.Context, deviceID int64, co
 		return nil
 	}
 	validMethods := map[string]bool{"icmp": true, "snmp": true, "http": true, "tcp": true}
+	// Seeding must be idempotent (#291): a rescan (or two seeding paths in
+	// one bridge) re-asserts the same spec. Deduplicate the spec list by
+	// method and insert with ON CONFLICT DO NOTHING, so an existing
+	// (device_id, method) row is a no-op instead of a UNIQUE failure that
+	// surfaced as a per-device WARN on every scan.
+	seen := make(map[string]bool, len(configs))
 	for _, cfg := range configs {
 		if !validMethods[cfg.Method] {
 			return fmt.Errorf("invalid heartbeat method: %s", cfg.Method)
 		}
-		_, err := s.queries.CreateHeartbeatConfig(ctx, db.CreateHeartbeatConfigParams{
+		if seen[cfg.Method] {
+			continue
+		}
+		seen[cfg.Method] = true
+		if _, err := s.queries.CreateHeartbeatConfigIfAbsent(ctx, db.CreateHeartbeatConfigIfAbsentParams{
 			DeviceID:        deviceID,
 			Method:          cfg.Method,
 			Target:          cfg.Target,
@@ -207,8 +217,7 @@ func (s *HeartbeatService) CreateConfigs(ctx context.Context, deviceID int64, co
 			SnmpCommunity:   cfg.SNMPCommunity,
 			SnmpOid:         cfg.SNMPOID,
 			Enabled:         1,
-		})
-		if err != nil {
+		}); err != nil {
 			return fmt.Errorf("create %s config for device %d: %w", cfg.Method, deviceID, err)
 		}
 	}

--- a/internal/service/heartbeat_test.go
+++ b/internal/service/heartbeat_test.go
@@ -92,7 +92,9 @@ func setupHeartbeatTest(t *testing.T) (*HeartbeatService, *sql.DB, *db.Queries) 
 			enabled INTEGER NOT NULL DEFAULT 1,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-		)
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_heartbeat_configs_device_method
+			ON heartbeat_configs(device_id, method)
 	`)
 	require.NoError(t, err)
 
@@ -933,4 +935,26 @@ func TestSyncStatus_StampOfflineSince(t *testing.T) {
 	require.NoError(t, dbConn.QueryRowContext(ctx,
 		`SELECT offline_since FROM devices WHERE id = ?`, dev.ID).Scan(&offlineSince))
 	require.Nil(t, offlineSince, "flipping offline→online must clear offline_since to NULL")
+}
+
+// TestCreateConfigs_IdempotentRescan pins #291: seeding the same heartbeat
+// specs twice (a rescan, or two seeding paths in one bridge) must be a no-op,
+// not a UNIQUE(device_id, method) failure that WARNed per device per scan.
+func TestCreateConfigs_IdempotentRescan(t *testing.T) {
+	svc, dbConn, _ := setupHeartbeatTest(t)
+	ctx := context.Background()
+	specs := []scannerv2.HeartbeatSpec{
+		{Method: "tcp", Target: "10.0.0.1:80", IntervalSeconds: 30, TimeoutSeconds: 5},
+		{Method: "icmp", Target: "10.0.0.1", IntervalSeconds: 30, TimeoutSeconds: 5},
+	}
+	require.NoError(t, svc.CreateConfigs(ctx, 1, specs))
+	// Same specs again (rescan) — previously "UNIQUE constraint failed:
+	// heartbeat_configs.device_id, heartbeat_configs.method".
+	require.NoError(t, svc.CreateConfigs(ctx, 1, specs), "re-seeding the same specs must be idempotent")
+	// A duplicate method WITHIN one spec list must also be tolerated.
+	dup := append(append([]scannerv2.HeartbeatSpec{}, specs...), specs[0])
+	require.NoError(t, svc.CreateConfigs(ctx, 1, dup))
+	var cfgCount int
+	require.NoError(t, dbConn.QueryRow("SELECT COUNT(*) FROM heartbeat_configs WHERE device_id = 1").Scan(&cfgCount))
+	require.Equal(t, 2, cfgCount, "exactly one config per method, no duplicates")
 }


### PR DESCRIPTION
Fixes #291

## 根因
device bridge 的新建（:169）与已存在（:264）两条路径都会调 `HeartbeatService.CreateConfigs` 重放扫描产生的同一组心跳 spec。重复扫描（及同一次 bridge 内的双路径）下，第二条 INSERT 必然撞 `idx_heartbeat_configs_device_method` 唯一索引 —— **每设备每轮扫描一条 WARN**（真机 19 台全复现；我在 #270 e2e 的服务器日志里也捕获到同一报错，交叉印证）。

## 修复
1. **新查询 `CreateHeartbeatConfigIfAbsent`**：`ON CONFLICT(device_id, method) DO NOTHING`（`:execrows`——冲突即 no-op，0 行受影响）。**用户手动创建路径保留严格版**（API 重复仍报 409，行为不变）
2. `CreateConfigs`（种子路径）按 method 去重 spec 列表 + 走幂等插入
3. **schema.sql 补声明该唯一索引**——原先只在 runMigrations 建（schema 与迁移形状不一致，本 PR 顺带对齐；fresh install 此前实际缺此索引）
4. 回归测试 `TestCreateConfigs_IdempotentRescan`：同 specs 二次种子 no-op、单列表内重复 method 容忍、每方法恰一行

## 效果
- 扫描日志中 `device bridge: seed heartbeats failed ... UNIQUE constraint failed` WARN 消除
- 功能无损：首次种子行为不变，设备心跳照常生成