### PR TITLE
docs: 代码围栏补语言标注 — 官网高亮渲染对齐（#297）

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -43,7 +43,7 @@ Alternatively, email the completed agreement to mickey_zzc@163.com.
 
 Please complete every field.
 
-```
+```text
 Full name:      ___________________________________________
 GitHub username:___________________________________________
 Email:          ___________________________________________
@@ -127,7 +127,7 @@ as of the date such litigation is filed.
 
 Please complete every field.
 
-```
+```text
 Corporation name:__________________________________________
 Corporation address:_______________________________________
 Country:           ___________________________________________

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ flowchart TB
     PROM["Prometheus · Grafana · Alertmanager"] <-.->|"/metrics · /sd"| MW
 ```
 
-```
+```text
 ├── cmd/server/           # Center entry point (+ reset-admin-password subcommand)
 ├── cmd/agent/            # Distributed discovery agent for remote LANs
 ├── internal/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,7 @@ flowchart TB
     PROM["Prometheus · Grafana · Alertmanager"] <-.->|"/metrics · /sd"| MW
 ```
 
-```
+```text
 ├── cmd/server/           # 中心入口（+ reset-admin-password 子命令）
 ├── cmd/agent/            # 远程局域网的分布式发现采集器
 ├── internal/

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -42,7 +42,7 @@ Complete REST API documentation for the MiBee Steward device management and moni
 
 Every request passes through the following middleware in source registration order:
 
-```
+```text
 RequestID → RealIP → Logging → Metrics → Recoverer → CORS → SecurityHeaders → CSRF → Global Rate Limit → Auth/RBAC (+ Network Scope / Agent Token)
 ```
 

--- a/docs/en/fingerprint-spec.md
+++ b/docs/en/fingerprint-spec.md
@@ -175,7 +175,7 @@ cross-language results diverge.
 Independent evidence reinforces: a single 0.9 source stays 0.9; two 0.9 sources
 yield ~0.99.
 
-```
+```text
 fused = 1 - (1 - evidence.conf) * (1 - rule.conf)
 ```
 

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -42,7 +42,7 @@ MiBee Steward 设备管理与监控系统（含设备系统、网络扫描、多
 
 每个请求依次经过以下中间件（与源码注册顺序一致）：
 
-```
+```text
 RequestID → RealIP → Logging → Metrics → Recoverer → CORS → SecurityHeaders → CSRF → 全局限流 → 认证/RBAC（+ 网络范围 / 代理令牌）
 ```
 

--- a/docs/zh/fingerprint-spec.md
+++ b/docs/zh/fingerprint-spec.md
@@ -196,7 +196,7 @@ cross-language results diverge.
 Independent evidence reinforces: a single 0.9 source stays 0.9; two 0.9 sources
 yield ~0.99.
 
-```
+```text
 fused = 1 - (1 - evidence.conf) * (1 - rule.conf)
 ```
 


### PR DESCRIPTION
Fixes #297

## 交付
用与官网同内核的规则审计仓库内**全部** markdown 源文档的无语言围栏并补标注：

| 文件 | 处数 | 标注 |
|---|---|---|
| README.md / README.zh-CN.md（目录树） | 2 | `text` |
| docs/{en,zh}/api.md（中间件链） | 2 | `text` |
| docs/{en,zh}/fingerprint-spec.md（置信度公式） | 2 | `text` |
| CLA.md（签署示例） | 2 | `text` |
| web/ + internal/api/ + internal/service/scannerv2/ + db/ AGENTS.md（命令/输出示例） | 6 | `bash`/`text` 按内容 |

共 14 处（超 issue 估计的 9 处——子目录 AGENTS.md 与 CLA.md 一并清理）。工具生成的 `web/src/paraglide/README.md`、`web/project.inlang/README.md` 不动（会被上游覆盖）。

## 防回归建议（未实施，供决策）
issue 建议的 markdownlint MD040 进 CI —— 可在后续 PR 加 `.markdownlint.yml` + CI job；本 PR 保持纯文档改动。