### PR TITLE
fix(discovery): arp_cache 源按 network.cidr 过滤 — form C 双臂邻居不再灌进本网画像（#292）

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -219,7 +219,7 @@ func main() {
 		}
 		// arp_cache: free byproduct of normal operation (reads /proc/net/arp).
 		if cfg.Scanner.Discovery.ARPCache.Enabled {
-			arpCacheSrc := scannerv2discovery.NewARPCacheSource(interval, discSvc, slog.Default())
+			arpCacheSrc := scannerv2discovery.NewARPCacheSource(cfg.Network.CIDR, interval, discSvc, slog.Default())
 			arpCacheSrc.Start(discCtx)
 			activeSources = append(activeSources, "arp_cache")
 		}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -405,7 +405,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		}
 		// arp_cache: free byproduct of normal operation (reads /proc/net/arp).
 		if cfg.Scanner.Discovery.ARPCache.Enabled {
-			arpCacheSrc := scannerv2discovery.NewARPCacheSource(interval, discSvc, slog.Default())
+			arpCacheSrc := scannerv2discovery.NewARPCacheSource(cfg.Network.CIDR, interval, discSvc, slog.Default())
 			arpCacheSrc.Start(discCtx)
 			activeSources = append(activeSources, "arp_cache")
 		}

--- a/internal/service/scannerv2/discovery/arp_cache.go
+++ b/internal/service/scannerv2/discovery/arp_cache.go
@@ -12,6 +12,7 @@ package discovery
 import (
 	"context"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -33,21 +34,41 @@ type ARPCacheSource struct {
 	interval time.Duration
 	svc      *Service
 	logger   *slog.Logger
+	// localNet filters neighbours to the configured LAN (network.cidr). nil =
+	// no filtering (the pre-#292 behavior). On a form-C center running ON the
+	// router, /proc/net/arp holds BOTH arms' neighbours — without the filter
+	// the WAN side (e.g. the upstream network the router itself sits in) gets
+	// recorded into this LAN's portrait and actively probed.
+	localNet *net.IPNet
 
 	mu       sync.Mutex
 	previous map[string]string // ip → mac, last sweep
 }
 
-// NewARPCacheSource constructs the source. interval is the poll cadence
-// (typically 60s, same as RouterARPSource so they stay in lockstep).
-func NewARPCacheSource(interval time.Duration, svc *Service, logger *slog.Logger) *ARPCacheSource {
+// NewARPCacheSource constructs the source. cidr is the local LAN
+// (network.cidr) used to drop out-of-subnet neighbours (#292); interval is
+// the poll cadence (typically 60s, same as RouterARPSource so they stay in
+// lockstep). An empty or unparseable cidr logs a warning and keeps the
+// unfiltered behavior — unlike the conntrack source (which goes silent), this
+// source predates the filter and must not lose a working deployment to a
+// config typo.
+func NewARPCacheSource(cidr string, interval time.Duration, svc *Service, logger *slog.Logger) *ARPCacheSource {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	var localNet *net.IPNet
+	if cidr != "" {
+		if _, ipnet, err := net.ParseCIDR(cidr); err == nil {
+			localNet = ipnet
+		} else {
+			logger.Warn("discovery: arp_cache source has invalid LAN CIDR; emitting unfiltered (pre-#292 behavior)", "cidr", cidr)
+		}
 	}
 	return &ARPCacheSource{
 		interval: interval,
 		svc:      svc,
 		logger:   logger,
+		localNet: localNet,
 		previous: map[string]string{},
 	}
 }
@@ -80,8 +101,17 @@ func (s *ARPCacheSource) sweep() {
 		s.logger.Debug("discovery: arp_cache read failed", "error", err)
 		return
 	}
+	s.sweepWith(entries)
+}
+
+// sweepWith is the test seam: the diff-and-emit logic over a given neighbour
+// set, so tests can feed fixtures without /proc/net/arp.
+func (s *ARPCacheSource) sweepWith(entries []probe.ARPEntry) {
 	current := make(map[string]string, len(entries))
 	for _, e := range entries {
+		if s.localNet != nil && !s.localNet.Contains(net.ParseIP(e.IP)) {
+			continue
+		}
 		current[e.IP] = e.MAC
 	}
 

--- a/internal/service/scannerv2/discovery/arp_cache_test.go
+++ b/internal/service/scannerv2/discovery/arp_cache_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+package discovery
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/service/scannerv2"
+	"mibee-steward/internal/service/scannerv2/probe"
+)
+
+// recordingSink captures the host reports the event loop hands to the sink.
+type recordingSink struct {
+	mu     sync.Mutex
+	events *[]NewHostEvent
+}
+
+func (r *recordingSink) Apply(_ context.Context, rep scannerv2.HostReport) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	*r.events = append(*r.events, NewHostEvent{IP: rep.IP})
+	return false
+}
+
+// TestARPCacheSource_CIDRFilter pins #292: on a form-C center running on the
+// router, /proc/net/arp holds BOTH arms' neighbours. With network.cidr set,
+// only in-subnet neighbours are recorded; without/invalid cidr the historical
+// unfiltered behavior is kept (warn, pass through) — a config typo must not
+// disable a previously working source.
+func TestARPCacheSource_CIDRFilter(t *testing.T) {
+	var events []NewHostEvent
+	sink := &recordingSink{events: &events}
+	svc := New(Config{}, sink, nil, nil, 0, nil)
+	svc.Start(context.Background())
+	t.Cleanup(func() { svc.Stop() })
+
+	entries := []probe.ARPEntry{
+		{IP: "192.168.64.241", MAC: "02:11:aa:bb:cc:01"}, // LAN side
+		{IP: "192.168.63.1", MAC: "94:83:c4:29:97:3e"},   // WAN side (upstream gateway)
+		{IP: "192.168.63.101", MAC: "b8:27:eb:11:22:33"}, // WAN side (lab server)
+	}
+
+	// Filtered: cidr set → only LAN-side neighbours emitted. The event loop
+	// runs on its own goroutine, so poll briefly for the Apply to land.
+	src := NewARPCacheSource("192.168.64.0/24", time.Minute, svc, nil)
+	src.sweepWith(entries)
+	waitFor(t, func() bool { sink.mu.Lock(); defer sink.mu.Unlock(); return len(events) > 0 })
+	require.Len(t, events, 1, "WAN-side neighbours must be dropped when network.cidr is set")
+	require.Equal(t, "192.168.64.241", events[0].IP)
+
+	// Unfiltered: empty cidr keeps the pre-#292 behavior. Fresh service so the
+	// in-loop known-host path can't dedup hosts seen in the phase above.
+	events = nil
+	sink2 := &recordingSink{events: &events}
+	svc2 := New(Config{}, sink2, nil, nil, 0, nil)
+	svc2.Start(context.Background())
+	t.Cleanup(func() { svc2.Stop() })
+	src2 := NewARPCacheSource("", time.Minute, svc2, nil)
+	src2.sweepWith(entries)
+	waitFor(t, func() bool { sink2.mu.Lock(); defer sink2.mu.Unlock(); return len(events) >= 3 })
+	require.Len(t, events, 3, "empty cidr must keep the historical unfiltered behavior")
+}
+
+// waitFor polls cond every 10ms up to 2s.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Fixes #292

## 根因
form C（center 装在路由器上，如 GL-MT2500）天然双臂：`/proc/net/arp` 同时含 LAN 与 WAN 邻居。`ARPCacheSource` 无 CIDR 过滤 —— WAN 侧 18 台（上游网关/测试服务器/实验室设备）全部被当"新主机"：发事件 → 触发单 IP identify 扫描（**对 WAN 侧主动探测**）→ 落库进本 LAN 网络。reconcile 每 cycle 19 mismatches、启动 ghost cleanup unresolved=19（持续给 #254 路径喂脏数据）。

`ConntrackSource`（同为本地内核表源）早有 CIDR 过滤；dhcp_leases/dns_log/hostapd 天然只产本网主机 —— **arp_cache 是唯一会把外网段灌进来的源**。

## 修复
- `NewARPCacheSource(cidr, interval, svc, logger)`：按 `network.cidr` 过滤邻居（中心 routes.go + cmd/agent 两处接线）
- **降级语义按 issue 指定**：cidr 空/解析失败 → 告警 + 保持旧（不过滤）行为 —— 与 conntrack 的静默失效不同：此源先于过滤存在，配置笔误不应废掉既有部署的功能
- `sweepWith` 测试缝（与 conntrack 的 withPath 同思路）

## 测试
`TestARPCacheSource_CIDRFilter`：MT2500 真实数据形状（LAN 1 台 + WAN 2 台）—— 过滤开启时仅 LAN 邻居 emitted；空 cidr 全量通过。`go test ./...` 全绿。

## 效果
form C 下 WAN 侧邻居不再进画像、不再被主动探测；reconcile/ghost-cleanup 的 mismatch 噪音消除。