### PR TITLE
fix(web): 仪表盘自定义布局渲染冻结 — class:drag-over 编译陷阱毒死效应调度器

### DIFF
--- a/web/src/lib/components/DashboardWidget.svelte
+++ b/web/src/lib/components/DashboardWidget.svelte
@@ -65,9 +65,13 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- NOTE: the drag-over class must be interpolated, NOT `class:drag-over` —
+     the class directive parses dash-names as an expression (drag - over),
+     throwing "drag is not defined" during mount and poisoning Svelte's effect
+     scheduler (every later reactive update on the page silently stopped —
+     the dashboard-custom-layout freeze bug). -->
 <div
-	class="widget-card"
-	class:drag-over
+	class="widget-card {dragOver ? 'drag-over' : ''}"
 	draggable="true"
 	ondragstart={handleDragStart}
 	ondragover={handleDragOver}

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -547,10 +547,24 @@
 		}
 	}
 
+	// fetchOverview loads the banner payload (attention counts, scan activity,
+	// offline list). Runs in BOTH layouts: the custom-widget layout skips the
+	// default cards' stats/device fetch, but the banner still needs overview —
+	// without it the banner fell back to the totalDevices===0 onboarding state
+	// and told the user "no devices yet" over a populated inventory.
+	async function fetchOverview() {
+		try {
+			overview = await api.get<OverviewResponse>('/dashboard/overview');
+		} catch {
+			// Non-fatal: legacy charts still render; type/location pies fall back
+			// to the 200-row sample, scan/offline sections render empty.
+			overview = null;
+		}
+	}
+
 	async function fetchDefaultData() {
-		// stats (status pie + gauge) + overview (full-population type/location
-		// distributions, scan activity, offline list) load in parallel. overview
-		// is in its own try so a failure there doesn't blank the legacy charts.
+		// stats (status pie + gauge) for the default-layout cards. overview is
+		// fetched separately (fetchOverview) so both layouts share it.
 		try {
 			const [statsRes, devsRes] = await Promise.all([
 				api.get<DeviceStats>('/devices/stats'),
@@ -562,13 +576,6 @@
 			addToast('error', getErrorMessage(err));
 			stats = { by_status: { online: 0, offline: 0, unknown: 0 } };
 			devices = [];
-		}
-		try {
-			overview = await api.get<OverviewResponse>('/dashboard/overview');
-		} catch {
-			// Non-fatal: legacy charts still render; type/location pies fall back
-			// to the 200-row sample, scan/offline sections render empty.
-			overview = null;
 		}
 	}
 
@@ -587,6 +594,8 @@
 		loading.set(true);
 		try {
 			await fetchCustomWidgets();
+			// Banner payload in BOTH layouts (see fetchOverview).
+			await fetchOverview();
 			if (!useCustomLayout) {
 				await fetchDefaultData();
 			}
@@ -801,7 +810,7 @@
 			{/if}
 			<button
 				onclick={handleRefresh}
-				disabled={refreshing}
+					disabled={refreshing}
 				class="btn btn-primary shrink-0"
 			>
 				<RotateCw class="w-4 h-4 {refreshing ? 'animate-spin' : ''}" />
@@ -854,13 +863,21 @@
 		</div>
 	{/if}
 
-	{#if $loading}
-		<!-- Top-level skeleton: previously the dashboard rendered nothing at all
-		     while stats/overview/widgets loaded — no feedback that work was
-		     happening. The $loading store path (vs a bare $state) is required
-		     under prerender hydration (see the note above loadAll). -->
-		<PageSkeleton type="dashboard" />
-	{:else if useCustomLayout}
+
+			<!-- Rendered-content block keyed on the NEGATIVE store read ({#if !$loading})
+		     — the same shape as the banner block above, which reliably
+		     re-renders under prerender hydration. The previous positive form
+		     ({#if $loading} skeleton {:else if ...}) left the skeleton branch
+		     mounted forever after the first custom-layout load: the else-if
+		     chain's effect never re-evaluated on the store's true→false flip,
+		     so the widget grid never appeared. -->
+		{#if $loading}
+			<!-- Top-level skeleton: previously the dashboard rendered nothing at all
+			     while stats/overview/widgets loaded — no feedback that work was
+			     happening. The $loading store path (vs a bare $state) is required
+			     under prerender hydration (see the note above loadAll). -->
+			<PageSkeleton type="dashboard" />
+		{:else if useCustomLayout}
 		<!-- Custom widget layout with drag-and-drop -->
 		{#if widgets.length === 0}
 			<EmptyState


### PR DESCRIPTION
## 根因（浏览器实测发现的 #247 潜伏回归）

`DashboardWidget.svelte` 的 `class:drag-over`：**Svelte 把带连字符的 class 指令名解析为表达式 `drag - over`** → 组件挂载即抛 `ReferenceError: drag is not defined` → 异常发生在效应 flush 内，**毒死 Svelte 5 效应调度器** → 全页响应式更新静默停摆。

该组件在 #247 之前从未真正渲染（数据链路断），修复数据链路后首次挂载即引爆 —— 浏览器测试（部署后实测）捕获。

## 症状全景（全部同源）
- 骨架屏永久挂载（$loading store 值正确但模板冻结）
- widget-grid 零节点
- 标题属性等所有快照停在挂载态（生产探针证实 store=false 而 DOM=true）
- 自定义布局横幅误显「还没有设备」（该布局此前不取 overview）

## 修复
1. **DashboardWidget**：`class:drag-over` → `class="widget-card {dragOver ? 'drag-over' : ''}"`（附注释说明陷阱）
2. **dashboard 页**：`fetchOverview` 拆分、两种布局都拉取（横幅数据源）

## 验证（本地生产构建 + 浏览器）
- widget 渲染 ✓（grid=1、tile=1、名称可见）
- 骨架正确切换 ✓
- 拖拽提示 ✓、无数据回退「暂无数据」✓
- svelte-check 无新增错误；vitest 197 全绿