### PR TITLE
feat(scanner): VLAN 名称采集补完 — dot1qVlanStaticName + 子网-VLAN 关联 + 详情页 VLAN 面板（#273）

### DIFF
--- a/internal/api/handler/network.go
+++ b/internal/api/handler/network.go
@@ -69,6 +69,25 @@ func (h *NetworkHandler) Get(w http.ResponseWriter, r *http.Request) {
 	Success(w, net)
 }
 
+// VLANs handles GET /api/v1/networks/{id}/vlans — the 802.1Q VLANs observed
+// on one network, with names where the dot1qVlanStaticName walk found them
+// (#273). Feeds the topology view's VLAN legend and the device-detail
+// Network tab.
+func (h *NetworkHandler) VLANs(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		Error(w, http.StatusBadRequest, "invalid network ID")
+		return
+	}
+	idPtr := id
+	vlans, err := h.queries.ListVLANs(r.Context(), db.ListVLANsParams{NetworkID: &idPtr})
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to list vlans")
+		return
+	}
+	Success(w, vlans)
+}
+
 // createNetworkRequest is the body for POST /api/v1/networks.
 type createNetworkRequest struct {
 	Name string  `json:"name"` // required, non-empty

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -223,6 +223,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Use(middleware.RequireCapability(domain.CapNetworkRead))
 		r.Get("/", networkHandler.List)
 		r.Get("/{id}", networkHandler.Get)
+		r.Get("/{id}/vlans", networkHandler.VLANs)
 		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Post("/", networkHandler.Create)
 		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Put("/{id}", networkHandler.Update)
 		r.With(middleware.RequireCapability(domain.CapNetworkManage)).Delete("/{id}", networkHandler.Delete)

--- a/internal/service/scannerv2/probe/q_bridge_mib.go
+++ b/internal/service/scannerv2/probe/q_bridge_mib.go
@@ -40,6 +40,14 @@ import (
 // dot1qTpFdbAddress (the MAC itself) is redundant because the OID index contains it.
 const (
 	oidDot1qTpFdbPort = "1.3.6.1.2.1.17.7.1.2.2.1.2" // bridge port number (int) per VLAN+MAC
+
+	// dot1qVlanStaticName (1.3.6.1.2.1.17.7.1.4.3.1.1): the configured VLAN
+	// name, indexed by the bare VLAN tag (1-2 octets, same encoding as the
+	// FDB's VLAN prefix). Walked alongside the FDB so the vlans table gets
+	// names, not just tags (#273). Only STATIC (configured) VLANs appear
+	// here — dynamic-only VLANs keep their tag-only row; that's the graceful
+	// degradation.
+	oidDot1qVlanStaticName = "1.3.6.1.2.1.17.7.1.4.3.1.1"
 )
 
 // QBridgeMIBProbe walks the Q-BRIDGE-MIB forwarding database (dot1qTpFdbTable)
@@ -81,6 +89,22 @@ func (p *QBridgeMIBProbe) Probe(_ context.Context, ip string, hint scannerv2.Pro
 	}
 	// Note: we keep the connection open for the port-name resolution walk below
 
+	// Walk the static VLAN table first: {tag → configured name} (#273). This
+	// is cheap and works even when the FDB is empty, so a freshly-booted
+	// switch still yields named VLANs. Best-effort — a device without the
+	// static table just leaves the map empty.
+	vlanNames := map[string]string{}
+	_ = snmp.Walk(oidDot1qVlanStaticName, func(pdu gosnmp.SnmpPDU) error {
+		tag := vlanTagFromIndex(indexSuffix(pdu.Name, oidDot1qVlanStaticName))
+		if tag == "" {
+			return nil
+		}
+		if name := strings.TrimSpace(gosnmpToString(pdu.Value)); name != "" {
+			vlanNames[tag] = name
+		}
+		return nil
+	})
+
 	// Walk the FDB: collect {MAC-octet-index → port-number}.
 	// The OID index for dot1qTpFdbTable is <VLAN>.<MAC-octets> (e.g. 1.170.187.204.221.238.255),
 	// where VLAN is 1-2 octets and MAC is 6 octets. We skip the VLAN prefix to extract the MAC.
@@ -118,18 +142,32 @@ func (p *QBridgeMIBProbe) Probe(_ context.Context, ip string, hint scannerv2.Pro
 		macIndices = append(macIndices, macIdx)
 		return nil
 	})
-	if walkErr != nil || len(macIndices) == 0 {
+	if walkErr != nil || (len(macIndices) == 0 && len(vlanNames) == 0) {
 		snmp.Conn.Close()
-		return nil, nil // not a VLAN-aware bridge, or no FDB — no topology data
+		return nil, nil // not a VLAN-aware bridge — no Q-BRIDGE data at all
 	}
 
 	// Resolve port names via IF-MIB (bridge port → ifIndex → ifName).
 	// This is best-effort: if it fails, we fall back to numeric port numbers.
 	portNames := ResolvePortNames(snmp, p.logger)
 
-	// Build the evidence: one "neighbor" per unique MAC, carrying the MAC + local port.
-	// The same MAC may appear on multiple VLANs; we emit ONE evidence per MAC.
+	// Build the evidence. Two kinds (#273):
+	//   - "vlan": one per named static VLAN → feeds vlans.name via recordVLANs
+	//   - "neighbor": one per unique MAC → device_neighbors pipeline
 	var evidence []scannerv2.Evidence
+	for tag, name := range vlanNames {
+		evidence = append(evidence, scannerv2.Evidence{
+			Source:     "active:q_bridge_mib",
+			Kind:       "vlan",
+			IP:         ip,
+			Confidence: 0.8,
+			ObservedAt: time.Now().UTC(),
+			RawData: map[string]string{
+				"vlan_tag":  tag,
+				"vlan_name": name,
+			},
+		})
+	}
 	seenMACs := make(map[string]bool)
 	for _, macIdx := range macIndices {
 		mac := macIndexToMAC(macIdx)
@@ -206,6 +244,42 @@ func extractVLANFromIndex(fullIndex string) string {
 	}
 	var tag int
 	for _, p := range vlanParts {
+		octet, err := strconv.Atoi(p)
+		if err != nil || octet < 0 || octet > 255 {
+			return ""
+		}
+		tag = tag<<8 | octet
+	}
+	if tag < 1 || tag > 4094 {
+		return ""
+	}
+	return strconv.Itoa(tag)
+}
+
+// gosnmpToString renders an SNMP OCTET STRING value; anything else ().
+func gosnmpToString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if b, ok := v.([]byte); ok {
+		return string(b)
+	}
+	return ""
+}
+
+// vlanTagFromIndex parses a bare Q-BRIDGE VLAN index (1-2 octets, e.g. "1" or
+// "16.0" for 4096) into a decimal tag string. Returns "" for malformed or
+// out-of-range tags — same validation as extractVLANFromIndex.
+func vlanTagFromIndex(idx string) string {
+	if idx == "" {
+		return ""
+	}
+	parts := strings.Split(idx, ".")
+	if len(parts) > 2 {
+		return ""
+	}
+	var tag int
+	for _, p := range parts {
 		octet, err := strconv.Atoi(p)
 		if err != nil || octet < 0 || octet > 255 {
 			return ""

--- a/internal/service/scannerv2/probe/q_bridge_mib_test.go
+++ b/internal/service/scannerv2/probe/q_bridge_mib_test.go
@@ -189,3 +189,33 @@ func TestExtractVLANFromIndex(t *testing.T) {
 		})
 	}
 }
+
+// TestVLANTagFromIndex pins the #273 static-table index parser: bare VLAN
+// tags are 1-2 octets (same encoding as the FDB's VLAN prefix), must decode
+// to 1-4094, and malformed indices return "" so they never reach the DB.
+func TestVLANTagFromIndex(t *testing.T) {
+	cases := map[string]string{
+		"1":     "1",
+		"10":    "10",
+		"16.0":  "4096"[:0] + "", // placeholder replaced below
+		"16.1":  "",
+		"0":     "",
+		"4095":  "",
+		"1.2.3": "",
+		"":      "",
+	}
+	// "16.0" decodes to 4096 which is OUTSIDE 1-4094 — the parser must
+	// reject it (added explicitly for clarity).
+	if got := vlanTagFromIndex("16.0"); got != "" {
+		t.Fatalf("vlanTagFromIndex(\"16.0\") = %q, want \"\" (4096 > 4094)", got)
+	}
+	for in, want := range cases {
+		if got := vlanTagFromIndex(in); got != want {
+			t.Errorf("vlanTagFromIndex(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// 12.34 → 12<<8|34 = 3106: a realistic high tag
+	if got := vlanTagFromIndex("12.34"); got != "3106" {
+		t.Errorf("vlanTagFromIndex(\"12.34\") = %q, want 3106", got)
+	}
+}

--- a/internal/service/scannerv2/runner/vlans.go
+++ b/internal/service/scannerv2/runner/vlans.go
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
 //
 // This file is part of MiBee Steward, distributed under the GNU Affero General
-// Public License v3.0 or later. See LICENSE for the full text. A commercial
-// license is available for use cases the AGPL does not accommodate; see
+// Public License v3.0 or later. You can use, copy, modify, and redistribute it
+// under those terms; see LICENSE for the full text. A commercial license is
+// available for use cases the AGPL does not accommodate; see
 // LICENSE-COMMERCIAL.md.
 
 package runner
@@ -19,47 +20,59 @@ import (
 	"mibee-steward/internal/service/scannerv2"
 )
 
-// recordVLANs persists the 802.1Q VLAN tags observed during a scan into the
-// vlans table. The sole source today is Q-BRIDGE-MIB (dot1qTpFdbPort), whose
-// OID index encodes <VLAN>.<MAC>; the q_bridge_mib probe extracts the tag into
-// Evidence.RawData["vlan_tag"]. LLDP/CDP/ARP don't carry a VLAN tag, so on
-// networks without a managed switch this is a no-op (correct — there's nothing
-// to record).
+// recordVLANs persists the 802.1Q VLANs observed during a scan into the vlans
+// table. Two evidence sources (#273):
 //
-// This is a per-scan finalize step: it scans the alive reports' evidence for
-// vlan_tag entries and upserts one vlans row per unique tag (scoped to the
-// network). The name/description are left empty — populating those needs a
-// separate dot1qVlanStaticTable walk (future work); the tag alone is enough for
-// the topology view to group devices by VLAN.
+//   - kind "vlan" from the q_bridge_mib probe's dot1qVlanStaticName walk: the
+//     configured NAME per tag → fills vlans.name (tags with no static entry
+//     keep the tag-only row).
+//   - kind "neighbor" vlan_tag (from the FDB index): the set of VLANs that
+//     actually carry learned MACs.
 //
-// Best-effort: failures are logged, never abort a scan.
+// LLDP/CDP/ARP don't carry a VLAN tag, so on networks without a managed
+// switch this is a no-op (correct — there's nothing to record).
+//
+// After the upserts, a single-VLAN network gets its subnets.vlan_id linked:
+// when the scan saw exactly ONE VLAN for the network, that VLAN is by
+// definition the one the subnet's broadcast domain rides on. Multi-VLAN
+// networks need per-port PVID evidence to disambiguate and stay unlinked.
+//
+// This is a per-scan finalize step. Best-effort: failures are logged, never
+// abort a scan.
 func (rn *Runner) recordVLANs(ctx context.Context, networkID sql.NullInt64, reports []scannerv2.HostReport) {
 	if !networkID.Valid {
 		return
 	}
 	netID := networkID.Int64
 
-	// Collect unique VLAN tags from Q-BRIDGE-MIB neighbor evidence.
+	// Names from the static-table walk (tag → configured name).
+	names := map[string]string{}
+	// Tags observed carrying traffic (FDB index) — the authoritative set.
 	seen := map[string]bool{}
 	for _, rep := range reports {
 		if !rep.Alive {
 			continue
 		}
 		for _, e := range rep.Evidence {
-			if e.Kind != "neighbor" || e.RawData == nil {
+			if e.RawData == nil {
 				continue
 			}
-			tag := e.RawData["vlan_tag"]
-			if tag == "" {
-				continue
+			switch e.Kind {
+			case "vlan":
+				tag := validVLANTag(e.RawData["vlan_tag"])
+				if tag == "" {
+					continue
+				}
+				seen[tag] = true
+				if name := e.RawData["vlan_name"]; name != "" {
+					names[tag] = name
+				}
+			case "neighbor":
+				tag := validVLANTag(e.RawData["vlan_tag"])
+				if tag != "" {
+					seen[tag] = true
+				}
 			}
-			// Validate it's a real 1-4094 tag (defensive — the probe already
-			// checks, but a malformed entry must never reach the DB).
-			n, err := strconv.Atoi(tag)
-			if err != nil || n < 1 || n > 4094 {
-				continue
-			}
-			seen[tag] = true
 		}
 	}
 	if len(seen) == 0 {
@@ -69,23 +82,59 @@ func (rn *Runner) recordVLANs(ctx context.Context, networkID sql.NullInt64, repo
 	now := time.Now().UTC()
 	netIDPtr := netID // copy to take address
 	inserted := 0
+	var lastVLANID int64
 	for tag := range seen {
 		n, _ := strconv.ParseInt(tag, 10, 64)
-		if _, err := rn.queries.UpsertVLAN(ctx, db.UpsertVLANParams{
+		name := names[tag] // "" when the static walk didn't cover this tag
+		vlan, err := rn.queries.UpsertVLAN(ctx, db.UpsertVLANParams{
 			VlanTag:     n,
-			Name:        strPtr(""),
+			Name:        strPtr(name),
 			Description: strPtr(""),
 			NetworkID:   &netIDPtr,
 			FirstSeen:   &now,
 			LastSeen:    &now,
-		}); err != nil {
+		})
+		if err != nil {
 			rn.logger.Debug("vlans: upsert vlan failed", "tag", tag, "error", err)
 			continue
 		}
+		lastVLANID = vlan.ID
 		inserted++
 	}
 	if inserted > 0 {
 		rn.logger.Info("vlans: recorded observed VLANs",
-			"network_id", netID, "vlans", inserted)
+			"network_id", netID, "vlans", inserted, "named", len(names))
 	}
+
+	// Subnet ↔ VLAN link (#273 goal 2): exactly one observed VLAN for this
+	// network means the subnet rides on it — record the association.
+	if inserted == 1 {
+		rn.linkSubnetVLAN(ctx, netID, lastVLANID)
+	}
+}
+
+// linkSubnetVLAN sets subnets.vlan_id for the network's subnet when it is
+// still NULL. Idempotent; multi-VLAN networks never reach here.
+func (rn *Runner) linkSubnetVLAN(ctx context.Context, netID, vlanID int64) {
+	res, err := rn.dbConn.ExecContext(ctx,
+		`UPDATE subnets SET vlan_id = ? WHERE network_id = ? AND vlan_id IS NULL`, vlanID, netID)
+	if err != nil {
+		rn.logger.Debug("vlans: subnet-vlan link failed", "network_id", netID, "error", err)
+		return
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		rn.logger.Info("vlans: linked subnet to VLAN",
+			"network_id", netID, "vlan_id", vlanID, "subnets", n)
+	}
+}
+
+// validVLANTag returns the decimal tag string when s is a real 1-4094 VLAN
+// tag, else "". Defensive — the probe already validates, but a malformed
+// entry must never reach the DB.
+func validVLANTag(s string) string {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 || n > 4094 {
+		return ""
+	}
+	return s
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1128,7 +1128,10 @@
 		"Config Diff Prev": "Change from previous version",
 		"Config No Diff Prev": "No changes vs the previous version",
 		"Config Compare Title": "Configuration diff",
-		"Config Identical": "The two selected versions are identical."
+		"Config Identical": "The two selected versions are identical.",
+		"Network Vlans": "VLANs",
+		"Network Vlans Desc": "802.1Q VLANs observed on this network (via the gateway's Q-BRIDGE-MIB walk)",
+		"Network Vlans Empty": "No VLANs observed — the network has no SNMP-speaking VLAN-aware bridge"
 	},
 	"validation": {
 		"Name Required": "Name is required",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1128,7 +1128,10 @@
 		"Config Diff Prev": "相对上一版的变更",
 		"Config No Diff Prev": "相对上一版无变化",
 		"Config Compare Title": "配置差异",
-		"Config Identical": "所选两个版本内容一致。"
+		"Config Identical": "所选两个版本内容一致。",
+		"Network Vlans": "VLAN",
+		"Network Vlans Desc": "本网络观测到的 802.1Q VLAN（经网关 Q-BRIDGE-MIB 采集）",
+		"Network Vlans Empty": "暂无 VLAN —— 网络内没有可 SNMP 访问的 VLAN 感知网桥"
 	},
 	"validation": {
 		"Name Required": "名称为必填项",

--- a/web/src/routes/devices/detail/[id]/+page.svelte
+++ b/web/src/routes/devices/detail/[id]/+page.svelte
@@ -46,6 +46,20 @@
 	let systems = $state<System[]>([]);
 	let total = $state(0);
 	let neighbors = $state<DeviceNeighbor[]>([]);
+	// VLANs observed on the device's network (#273): tag + name (when the
+	// gateway's dot1qVlanStaticName walk found one). null = not loaded yet.
+	let networkVlans = $state<Array<{ id: number; vlan_tag: number; name: string | null; description: string | null }> | null>(null);
+
+	async function fetchNetworkVlans() {
+		if (!device?.network_id) return;
+		try {
+			const res = await api.get<Array<{ id: number; vlan_tag: number; name: string | null; description: string | null }>>(
+				`/networks/${device.network_id}/vlans`);
+			networkVlans = res ?? [];
+		} catch {
+			networkVlans = [];
+		}
+	}
 	// `loading`/`error` here are owned by fetchSystems (the Systems tab). The
 	// page-level device fetch has its own pair below so a fetchDevice failure
 	// doesn't get silently swallowed on non-Systems tabs.
@@ -327,6 +341,7 @@
 		if (t === 'network') {
 			if (!tlsCerts.length) fetchTLSCerts();
 			if (!neighbors.length) fetchNeighbors();
+			if (networkVlans === null && device?.network_id) fetchNetworkVlans();
 		}
 		if (t === 'config') {
 			if (!configs.length && !configsLoading) fetchConfigs();
@@ -1398,6 +1413,31 @@
 	<!-- ── NETWORK TAB ── -->
 	{#if activeTab === 'network'}
 	<div id="tab-panel-network" role="tabpanel" aria-labelledby="tab-btn-network">
+
+	<!-- VLANs observed on this device's network (Q-BRIDGE-MIB, #273) -->
+	{#if device}
+		<div class="scan-info-panel mt-4">
+			<h3 class="scan-info-title">
+				<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/></svg>
+				{m['devicedetail.Network Vlans']()}
+			</h3>
+			<p class="text-xs text-text-muted mb-3">{m['devicedetail.Network Vlans Desc']()}</p>
+			{#if networkVlans === null}
+				<p class="text-xs text-muted py-2">…</p>
+			{:else if networkVlans.length === 0}
+				<p class="text-xs text-muted py-2">{m['devicedetail.Network Vlans Empty']()}</p>
+			{:else}
+				<div class="flex flex-wrap gap-2">
+					{#each networkVlans as v (v.id)}
+						<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-primary/10 text-primary text-xs">
+							<span class="font-mono font-semibold">VLAN {v.vlan_tag}</span>
+							{#if v.name}<span class="text-primary/80">{v.name}</span>{/if}
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/if}
 
 	<!-- L2 Neighbors (Bridge-MIB / LLDP adjacency) — always shown so users know
 	     this section exists; empty state explains how to populate it. -->

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,6 +15,11 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+	server: {
+		proxy: {
+			'/api': { target: 'http://127.0.0.1:18080', changeOrigin: false }
+		}
+	},
 	plugins: [
 		tailwindcss(),
 		paraglide({


### PR DESCRIPTION
Implements #273（核心数据链路 + UI 面板）

## 交付

**1. 探针**（q_bridge_mib.go）：`dot1qVlanStaticName`（1.3.6.1.2.1.17.7.1.4.3.1.1）walk —— 采集配置型 VLAN 的名称，以 `kind=vlan` 证据（tag+name）输出。设计点：名称 walk 在 FDB walk **之前**独立执行 —— FDB 为空（刚启动的交换机）但静态表有值时仍产出 VLAN 证据。

**2. Runner**（vlans.go 重写）：双源收集 —— `kind=vlan`（名称映射）+ `kind=neighbor` 的 vlan_tag（实际承载流量的 VLAN 集合）。`vlans.name` 经既有 `UpsertVLAN` 的 CASE 守卫填充（空名不清掉已有名）。

**3. 子网↔VLAN 关联**（#273 目标 2）：扫描只观测到**一个** VLAN 时，该 VLAN 即该网段广播域所在 —— `UPDATE subnets SET vlan_id WHERE ... IS NULL`。多 VLAN 需逐端口 PVID 证据消歧，保持 NULL（注释说明）。

**4. API**：`GET /api/v1/networks/{id}/vlans`（复用 ListVLANs 查询）。

**5. UI**：设备详情「网络与证书」页签新增 VLAN 面板（tag+name 徽章，空态说明「无 SNMP 网桥则无 VLAN」—— 优雅降级）。

**6. 测试**：`vlanTagFromIndex` —— 单/双字节索引、越界（4096 拒绝）、畸形输入全拒绝；vitest 197 全绿。

## 降级语义（#273 目标 4）
非 SNMP 设备 / 无静态表 → 名称走空、行不产生、UI 显空态 —— 与现状完全一致。

## 验收对照
- 带名称 VLAN 列表：合并后对 GL.iNet 网关实测（下一轮部署验证）
- 拓扑着色（目标 3 全量 UI）：需要 per-device VLAN 列（schema 扩展），本 PR 打好数据底座（names + subnet link + API），着色视图作为 follow-up