### PR TITLE
feat(fingerprint): 覆盖率报表 + 未识别设备聚合 + 规则草稿贡献闭环（#282）

### DIFF
--- a/docs/en/fingerprint-spec.md
+++ b/docs/en/fingerprint-spec.md
@@ -306,3 +306,13 @@ is the reference. A Zig/Rust implementation is considered conforming iff, given
 the same rule files and evidence, it emits byte-identical `ServiceIdentity`
 output (service, port, protocol, confidence within 1e-9, metadata). The parity
 tests in `rule_classifier_test.go` are the conformance suite.
+
+## 10. Coverage report & the rule-draft loop
+
+The center ships the contribution loop described above as a first-class page (**Fingerprint Coverage**, `/fingerprints`):
+
+- **Coverage tiers** — every device is bucketed by how its type was identified: *protocol evidence* (SNMP/RTSP/ONVIF/mDNS — trustworthy), *heuristic* (hostname/brand keyword — spoofable, `?` badge in the UI), or *unidentified* (falls back to generic `other`). The same tiers are exported as `mibee_fingerprint_identified_devices{source}` for Prometheus.
+- **Most-needed rule targets** — unidentified devices are clustered by shared features (NIC vendor from the OUI, open-port signature, hostname prefix), so one contributed rule can be evaluated against N devices at once.
+- **Rule draft** — for any unidentified device, "Rule draft" generates a YAML file pre-filled from the evidence the scanner already collected (SNMP `sys_descr`, TCP banners, HTTP `title`/`server`, RTSP `server`). The draft is compile-validated through the real rule classifier before you see it, so what you download is guaranteed loadable — you only fill in the service name judgment calls and tune the match values.
+
+The API behind it: `GET /api/v1/fingerprints/coverage` (tier stats + list + groups) and `POST /api/v1/devices/{uuid}/fingerprint-draft` (returns `text/yaml`).

--- a/docs/zh/fingerprint-spec.md
+++ b/docs/zh/fingerprint-spec.md
@@ -327,3 +327,13 @@ is the reference. A Zig/Rust implementation is considered conforming iff, given
 the same rule files and evidence, it emits byte-identical `ServiceIdentity`
 output (service, port, protocol, confidence within 1e-9, metadata). The parity
 tests in `rule_classifier_test.go` are the conformance suite.
+
+## 10. 覆盖率报表与规则草稿闭环
+
+中心把上述贡献流程做成了一等公民页面（**指纹覆盖**，`/fingerprints`）：
+
+- **覆盖分层** —— 每台设备按类型识别方式分桶：*协议证据*（SNMP/RTSP/ONVIF/mDNS —— 可信）、*启发式*（主机名/品牌关键字 —— 可被伪造，UI 显示 `?` 徽章）、*未识别*（回落为通用 `other`）。同样的分层以 `mibee_fingerprint_identified_devices{source}` 导出到 Prometheus。
+- **最需要规则的特征** —— 未识别设备按共同特征聚类（OUI 网卡厂商、开放端口签名、主机名前缀），一条贡献规则可以一次覆盖 N 台设备。
+- **规则草稿** —— 对任意未识别设备，「规则草稿」从扫描器已收集的证据（SNMP `sys_descr`、TCP banner、HTTP `title`/`server`、RTSP `server`）预填生成 YAML。草稿在返回前经过真实规则分类器的编译验证，下载即可加载 —— 你只需补全 service 名称判断并微调匹配值。
+
+对应 API：`GET /api/v1/fingerprints/coverage`（分层统计 + 清单 + 聚合）与 `POST /api/v1/devices/{uuid}/fingerprint-draft`（返回 `text/yaml`）。

--- a/internal/api/handler/fingerprint.go
+++ b/internal/api/handler/fingerprint.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/service"
+)
+
+// FingerprintHandler exposes the fingerprint coverage report + rule-draft
+// generation (#282). Read-only analytics over device scan_attributes and
+// collected evidence; the draft endpoint POSTs but persists nothing — it is
+// a pure computation returning YAML text.
+type FingerprintHandler struct {
+	svc *service.FingerprintReportService
+}
+
+func NewFingerprintHandler(svc *service.FingerprintReportService) *FingerprintHandler {
+	return &FingerprintHandler{svc: svc}
+}
+
+// Coverage handles GET /api/v1/fingerprints/coverage — identification-tier
+// stats + the unidentified-device list with feature groupings.
+func (h *FingerprintHandler) Coverage(w http.ResponseWriter, r *http.Request) {
+	cov, err := h.svc.Coverage(r.Context(), domain.ScopeFromContext(r.Context()))
+	if err != nil {
+		Error(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	Success(w, cov)
+}
+
+// RuleDraft handles POST /api/v1/devices/{uuid}/fingerprint-draft — returns
+// text/yaml body generated (and compile-validated) from the device's stored
+// evidence. Text (not JSON) so the UI can offer it as a file download
+// directly.
+func (h *FingerprintHandler) RuleDraft(w http.ResponseWriter, r *http.Request) {
+	uuid := chi.URLParam(r, "uuid")
+	if uuid == "" {
+		Error(w, http.StatusBadRequest, "device uuid is required")
+		return
+	}
+	draft, err := h.svc.RuleDraft(r.Context(), uuid, domain.ScopeFromContext(r.Context()))
+	if err != nil {
+		Error(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "text/yaml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(draft))
+}

--- a/internal/api/handler/metrics.go
+++ b/internal/api/handler/metrics.go
@@ -45,4 +45,19 @@ func UpdateDeviceMetrics(ctx context.Context, dbtx db.DBTX) {
 	for _, s := range statuses {
 		metrics.MibeeDevicesTotal.WithLabelValues(s.Status, "").Set(float64(s.Count))
 	}
+
+	// Identification-tier breakdown (#282) — same json_extract tiers as the
+	// fingerprint coverage report. Best-effort: never fails the caller.
+	metrics.MibeeFingerprintIdentified.Reset()
+	var protocol, heuristic, unidentified int64
+	if err := dbtx.QueryRowContext(ctx, `
+		SELECT
+		  COALESCE(SUM(CASE WHEN json_extract(scan_attributes,'$.inferred_type_source')='protocol' THEN 1 ELSE 0 END),0),
+		  COALESCE(SUM(CASE WHEN json_extract(scan_attributes,'$.inferred_type_source')='heuristic' THEN 1 ELSE 0 END),0),
+		  COALESCE(SUM(CASE WHEN COALESCE(json_extract(scan_attributes,'$.inferred_type'),'other')='other' THEN 1 ELSE 0 END),0)
+		FROM devices`).Scan(&protocol, &heuristic, &unidentified); err == nil {
+		metrics.MibeeFingerprintIdentified.WithLabelValues("protocol").Set(float64(protocol))
+		metrics.MibeeFingerprintIdentified.WithLabelValues("heuristic").Set(float64(heuristic))
+		metrics.MibeeFingerprintIdentified.WithLabelValues("unidentified").Set(float64(unidentified))
+	}
 }

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -865,6 +865,18 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 		r.Get("/api/v1/devices/{id}/heartbeat-history", heartbeatHandler.ListHistory)
 		r.Get("/api/v1/devices/{id}/heartbeat-stats", heartbeatHandler.GetStats)
 	})
+	// Fingerprint coverage report + rule-draft generation (#282). Read-only
+	// analytics over scan_attributes + collected evidence; the draft POST is
+	// a pure computation (returns YAML text, persists nothing).
+	fingerprintSvc := service.NewFingerprintReportService(db.New(dbConn), dbConn)
+	fingerprintHandler := handler.NewFingerprintHandler(fingerprintSvc)
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.NetworkScope(scopeResolver))
+		r.Use(middleware.RequireCapability(domain.CapDeviceRead))
+		r.Get("/api/v1/fingerprints/coverage", fingerprintHandler.Coverage)
+		r.Post("/api/v1/devices/{uuid}/fingerprint-draft", fingerprintHandler.RuleDraft)
+	})
+
 	// Dashboard routes
 	dashSvc := service.NewDashboardService(dbConn, cfg)
 	dashHandler := handler.NewDashboardHandler(dashSvc)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -132,6 +132,19 @@ var (
 		},
 		[]string{"status"},
 	)
+
+	// MibeeFingerprintIdentified gauges the identification-tier breakdown of
+	// the device inventory (#282): source = "protocol" (SNMP/RTSP/ONVIF/mDNS
+	// evidence), "heuristic" (hostname/brand keyword — spoofable), or
+	// "unidentified" (inferred as generic "other"). The coverage report the
+	// UI shows is computed from the same scan_attributes extraction.
+	MibeeFingerprintIdentified = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mibee_fingerprint_identified_devices",
+			Help: "Device count by identification tier (protocol evidence / heuristic keyword / unidentified)",
+		},
+		[]string{"source"},
+	)
 )
 
 func init() {
@@ -145,6 +158,7 @@ func init() {
 	prometheus.MustRegister(MibeeAgentLastReportTimestamp)
 	prometheus.MustRegister(MibeeDBSizeBytes)
 	prometheus.MustRegister(MibeeDBTableRows)
+	prometheus.MustRegister(MibeeFingerprintIdentified)
 }
 
 // RefreshScannerTaskGauges recomputes mibee_scanner_tasks_total{status} from

--- a/internal/service/fingerprint_report.go
+++ b/internal/service/fingerprint_report.go
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	fp "github.com/Mi-Bee-Studio/mibee-fingerprints-go"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+)
+
+// FingerprintReportService builds the fingerprint-coverage report (#282):
+// how well the identification stack (protocol evidence / heuristic keyword
+// rules) is doing on this inventory, which devices remain unidentified, and
+// how to turn one of them into a contribution — a validated YAML rule draft
+// generated from the evidence the scanner already collected.
+//
+// The tiers read devices.scan_attributes (the engine-written discovery
+// aggregation): inferred_type_source = "protocol" (SNMP/RTSP/ONVIF/mDNS
+// evidence — trustworthy) / "heuristic" (hostname/brand keyword guess —
+// spoofable, shown with a ? badge in the UI) / anything else with
+// inferred_type resolving to "other" = unidentified.
+type FingerprintReportService struct {
+	queries *db.Queries
+	dbtx    db.DBTX
+}
+
+func NewFingerprintReportService(queries *db.Queries, dbtx db.DBTX) *FingerprintReportService {
+	return &FingerprintReportService{queries: queries, dbtx: dbtx}
+}
+
+// FingerprintCoverage is the payload of GET /api/v1/fingerprints/coverage.
+type FingerprintCoverage struct {
+	Total        int64                `json:"total"`
+	Protocol     int64                `json:"protocol"`
+	Heuristic    int64                `json:"heuristic"`
+	Unidentified int64                `json:"unidentified"`
+	Devices      []UnidentifiedDevice `json:"devices"`
+	Groups       []UnidentifiedGroup  `json:"groups"`
+}
+
+// UnidentifiedDevice is one row of the unidentified list, enriched with the
+// device's known services so the UI can show what evidence exists to build
+// a rule from.
+type UnidentifiedDevice struct {
+	UUID      string `json:"device_uuid"`
+	Name      string `json:"name"`
+	IP        string `json:"ip_address"`
+	MAC       string `json:"mac_address"`
+	Hostname  string `json:"hostname"`
+	Vendor    string `json:"vendor"`
+	OUIVendor string `json:"oui_vendor"`
+	OS        string `json:"os"`
+	// Ports/Services come from host_services (the classified service set).
+	Ports    []int    `json:"ports"`
+	Services []string `json:"services"`
+}
+
+// UnidentifiedGroup clusters unidentified devices by a shared feature so the
+// report can show "the TOP characteristics that need rules": one rule added
+// for a signature may identify N devices at once.
+type UnidentifiedGroup struct {
+	Kind       string   `json:"kind"` // "oui" | "ports" | "hostname_prefix"
+	Signature  string   `json:"signature"`
+	Count      int      `json:"count"`
+	ExampleIPs []string `json:"example_ips"`
+}
+
+// Coverage computes the tier stats + the unidentified list with groupings.
+// scope filters the inventory to the caller's network grants (nil / global =
+// every network — admin or open-mode rbac).
+func (s *FingerprintReportService) Coverage(ctx context.Context, scope domain.Scope) (*FingerprintCoverage, error) {
+	cov := &FingerprintCoverage{}
+	netFilter, netArgs := networkFilter(scope)
+	err := s.dbtx.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		  COALESCE(SUM(CASE WHEN json_extract(scan_attributes,'$.inferred_type_source')='protocol' THEN 1 ELSE 0 END),0),
+		  COALESCE(SUM(CASE WHEN json_extract(scan_attributes,'$.inferred_type_source')='heuristic' THEN 1 ELSE 0 END),0),
+		  COALESCE(SUM(CASE WHEN COALESCE(json_extract(scan_attributes,'$.inferred_type'),'other')='other' THEN 1 ELSE 0 END),0)
+		FROM devices WHERE 1=1`+netFilter, netArgs...).Scan(&cov.Total, &cov.Protocol, &cov.Heuristic, &cov.Unidentified)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint coverage: %w", err)
+	}
+
+	rows, err := s.dbtx.QueryContext(ctx, `
+		SELECT device_uuid, COALESCE(name,''), ip_address, COALESCE(mac_address,''),
+		  COALESCE(json_extract(scan_attributes,'$.hostname'),''),
+		  COALESCE(json_extract(scan_attributes,'$.vendor'),''),
+		  COALESCE(json_extract(scan_attributes,'$.oui_vendor'),''),
+		  COALESCE(json_extract(scan_attributes,'$.os'),'')
+		FROM devices
+		WHERE COALESCE(json_extract(scan_attributes,'$.inferred_type'),'other')='other'`+netFilter+`
+		ORDER BY ip_address`, netArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint unidentified list: %w", err)
+	}
+	defer rows.Close()
+
+	devs := []UnidentifiedDevice{}
+	for rows.Next() {
+		var d UnidentifiedDevice
+		if err := rows.Scan(&d.UUID, &d.Name, &d.IP, &d.MAC, &d.Hostname, &d.Vendor, &d.OUIVendor, &d.OS); err != nil {
+			return nil, err
+		}
+		devs = append(devs, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(devs) > 0 {
+		if err := s.attachServices(ctx, devs); err != nil {
+			return nil, err
+		}
+	}
+	cov.Devices = devs
+	cov.Groups = groupUnidentified(devs)
+	return cov, nil
+}
+
+// attachServices fills Ports/Services from host_services for the given
+// unidentified devices (matched by IP — the service table's stable key).
+func (s *FingerprintReportService) attachServices(ctx context.Context, devs []UnidentifiedDevice) error {
+	ips := make([]string, len(devs))
+	byIP := map[string]*UnidentifiedDevice{}
+	for i := range devs {
+		ips[i] = devs[i].IP
+		byIP[devs[i].IP] = &devs[i]
+	}
+	placeholders := strings.Repeat("?,", len(ips))
+	args := make([]any, len(ips))
+	for i, ip := range ips {
+		args[i] = ip
+	}
+	rows, err := s.dbtx.QueryContext(ctx,
+		fmt.Sprintf("SELECT ip, service, port FROM host_services WHERE ip IN (%s)", placeholders[:len(placeholders)-1]),
+		args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ip, svc string
+		var port int
+		if err := rows.Scan(&ip, &svc, &port); err != nil {
+			return err
+		}
+		if d, ok := byIP[ip]; ok {
+			d.Ports = append(d.Ports, port)
+			d.Services = append(d.Services, svc)
+		}
+	}
+	return rows.Err()
+}
+
+// groupUnidentified clusters by OUI vendor, port signature, and hostname
+// prefix (first label), keeping the TOP groups of each kind.
+func groupUnidentified(devs []UnidentifiedDevice) []UnidentifiedGroup {
+	count := map[string]*UnidentifiedGroup{}
+	add := func(kind, sig string, ip string) {
+		key := kind + ":" + sig
+		g, ok := count[key]
+		if !ok {
+			g = &UnidentifiedGroup{Kind: kind, Signature: sig}
+			count[key] = g
+		}
+		g.Count++
+		if len(g.ExampleIPs) < 3 {
+			g.ExampleIPs = append(g.ExampleIPs, ip)
+		}
+	}
+	for _, d := range devs {
+		if d.OUIVendor != "" {
+			add("oui", d.OUIVendor, d.IP)
+		}
+		if len(d.Ports) > 0 {
+			ports := append([]int(nil), d.Ports...)
+			sort.Ints(ports)
+			parts := make([]string, len(ports))
+			for i, p := range ports {
+				parts[i] = fmt.Sprintf("%d", p)
+			}
+			add("ports", strings.Join(parts, ","), d.IP)
+		}
+		if d.Hostname != "" {
+			first := strings.SplitN(d.Hostname, ".", 2)[0]
+			if len(first) >= 3 { // too-short prefixes would over-merge
+				add("hostname_prefix", strings.ToLower(first), d.IP)
+			}
+		}
+	}
+	groups := make([]UnidentifiedGroup, 0, len(count))
+	for _, g := range count {
+		groups = append(groups, *g)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Count > groups[j].Count })
+	if len(groups) > 15 {
+		groups = groups[:15]
+	}
+	return groups
+}
+
+// networkFilter renders the WHERE fragment restricting devices to the
+// caller's granted networks. Empty string + nil args = unfiltered.
+func networkFilter(scope domain.Scope) (string, []any) {
+	if scope.IsGlobal() || len(scope.NetworkIDs) == 0 {
+		return "", nil
+	}
+	placeholders := strings.Repeat("?,", len(scope.NetworkIDs))
+	args := make([]any, len(scope.NetworkIDs))
+	for i, id := range scope.NetworkIDs {
+		args[i] = id
+	}
+	return " AND network_id IN (" + placeholders[:len(placeholders)-1] + ")", args
+}
+
+// --- Rule draft generation ---
+
+// draftRule mirrors the fingerprint rule YAML schema (subset the generator
+// emits). Round-trips through yaml.v3 with the same field names as
+// mibee-fingerprints-go's ruleFile.
+type draftRule struct {
+	ID     string `yaml:"id"`
+	Source string `yaml:"source"`
+	Match  struct {
+		Kind  string `yaml:"kind"`
+		Field string `yaml:"field"`
+		Op    string `yaml:"op"`
+		Value string `yaml:"value"`
+		CI    bool   `yaml:"ci"`
+	} `yaml:"match"`
+	Service    string            `yaml:"service"`
+	Protocol   string            `yaml:"protocol,omitempty"`
+	Confidence float64           `yaml:"confidence"`
+	Extract    *draftRuleExtract `yaml:"extract,omitempty"`
+}
+
+type draftRuleExtract struct {
+	DeviceType string `yaml:"device_type,omitempty"`
+}
+
+type draftRuleFile struct {
+	Version int         `yaml:"version"`
+	Rules   []draftRule `yaml:"rules"`
+}
+
+// evidenceRow is one service_evidence row relevant to draft generation.
+type evidenceRow struct {
+	Kind    string
+	Port    int
+	RawData map[string]string
+}
+
+// portServiceHints maps well-known ports to the service name used by the
+// classifier stack — used to pre-fill the draft's service field.
+var portServiceHints = map[int]string{
+	21: "ftp", 22: "ssh", 23: "telnet", 25: "smtp", 53: "dns", 80: "http",
+	110: "pop3", 123: "ntp", 143: "imap", 161: "snmp", 443: "https",
+	465: "smtps", 554: "rtsp", 587: "smtp", 636: "ldaps", 993: "imaps",
+	995: "pop3s", 2020: "http", 8000: "http", 8080: "http", 8443: "https",
+	8899: "http", 9443: "https", 5000: "upnp", 1900: "upnp", 5353: "mdns",
+}
+
+// RuleDraft generates a validated fingerprint-rule YAML draft for one
+// unidentified device, built from the evidence the scanner already collected
+// (SNMP sysDescr, TCP banners, HTTP title/server). The returned YAML parses
+// AND compiles through the real rule classifier (LoadFromDir on a temp dir),
+// so what the contributor downloads is guaranteed syntactically loadable —
+// they only fill in the service/device_type judgment calls.
+func (s *FingerprintReportService) RuleDraft(ctx context.Context, deviceUUID string, scope domain.Scope) (string, error) {
+	var ip string
+	var networkID sql.NullInt64
+	err := s.dbtx.QueryRowContext(ctx,
+		`SELECT ip_address, network_id FROM devices WHERE device_uuid = ?`, deviceUUID).Scan(&ip, &networkID)
+	if err != nil {
+		return "", fmt.Errorf("device not found: %w", err)
+	}
+	if !scope.IsGlobal() && (!networkID.Valid || !scope.AllowsNetwork(networkID.Int64)) {
+		return "", fmt.Errorf("device out of network scope")
+	}
+
+	rows, err := s.dbtx.QueryContext(ctx, `
+		SELECT kind, port, raw_data FROM service_evidence
+		WHERE (device_uuid = ? OR (device_uuid = '' AND ip = ?))
+		  AND kind IN ('banner','http','snmp','rtsp')
+		ORDER BY observed_at DESC LIMIT 50`, deviceUUID, ip)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	ev := []evidenceRow{}
+	for rows.Next() {
+		var e evidenceRow
+		var raw []byte
+		if err := rows.Scan(&e.Kind, &e.Port, &raw); err != nil {
+			return "", err
+		}
+		rd := map[string]string{}
+		_ = yaml.Unmarshal(raw, &rd)
+		e.RawData = rd
+		ev = append(ev, e)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	draft := draftRuleFile{Version: 1}
+	seen := map[string]bool{}
+	for _, e := range ev {
+		var r *draftRule
+		switch e.Kind {
+		case "snmp":
+			if v := significantToken(e.RawData["sys_descr"], 24); v != "" {
+				r = newDraftRule("snmp", "sys_descr", v, "snmp", e.Port, 0.9)
+			}
+		case "banner":
+			if v := significantToken(e.RawData["banner"], 20); v != "" {
+				r = newDraftRule("banner", "banner", v, portServiceHints[e.Port], e.Port, 0.9)
+			}
+		case "http":
+			for _, f := range []string{"title", "server"} {
+				if v := significantToken(e.RawData[f], 16); v != "" {
+					r = newDraftRule("http", f, v, portServiceHints[e.Port], e.Port, 0.85)
+					break
+				}
+			}
+		case "rtsp":
+			if v := significantToken(e.RawData["server"], 16); v != "" {
+				r = newDraftRule("rtsp", "server", v, "rtsp", e.Port, 0.9)
+			}
+		}
+		if r == nil || seen[r.Match.Value] {
+			continue
+		}
+		seen[r.Match.Value] = true
+		draft.Rules = append(draft.Rules, *r)
+	}
+
+	if len(draft.Rules) == 0 {
+		// No usable evidence — hand back the explanatory header alone so the
+		// contributor still gets the "how to contribute" pointers.
+		return draftHeader + draftNoRulesNote, nil
+	}
+
+	body, err := yaml.Marshal(&draft)
+	if err != nil {
+		return "", err
+	}
+	out := draftHeader + string(body)
+
+	if err := validateDraft(out); err != nil {
+		return "", fmt.Errorf("generated draft failed validation: %w", err)
+	}
+	return out, nil
+}
+
+func newDraftRule(kind, field, value, service string, _ int, confidence float64) *draftRule {
+	r := &draftRule{
+		ID:      fmt.Sprintf("draft-%s-%s", kind, strings.ToLower(strings.ReplaceAll(value, " ", "-"))),
+		Service: service, Protocol: "tcp",
+		Confidence: confidence,
+	}
+	r.Source = "community-draft"
+	r.Match.Kind = kind
+	r.Match.Field = field
+	r.Match.Op = "contains"
+	r.Match.CI = true
+	r.Match.Value = value
+	if service == "" {
+		r.Service = "TODO"
+	}
+	if kind == "snmp" {
+		r.Protocol = "udp"
+	}
+	return r
+}
+
+// significantToken picks a stable, distinctive substring from raw evidence
+// text: trimmed, capped at maxLen, empty when too generic to be a rule value.
+func significantToken(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) < 4 {
+		return ""
+	}
+	// Skip pure generics that would over-match: protocol greetings, "Server"
+	// alone, version-only strings.
+	generics := []string{"HTTP", "SSH-", "RTSP/", "Server", "nginx", "Apache", "LiteSpeed"}
+	for _, g := range generics {
+		if s == g || strings.HasPrefix(s, g) && len(s) <= len(g)+1 {
+			return ""
+		}
+	}
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	// A value with YAML-problematic characters is still fine (yaml.Marshal
+	// quotes as needed); but strip control chars that come from banners.
+	s = strings.Map(func(r rune) rune {
+		if r < 32 {
+			return -1
+		}
+		return r
+	}, s)
+	return strings.TrimSpace(s)
+}
+
+const draftHeader = `# MiBee Steward fingerprint rule draft (auto-generated — #282 contribution loop).
+#
+# This file PARSES AND COMPILES as-is — fill in the TODOs (service name),
+# tune the match values, then contribute it:
+#   1. Edit rules: pick the distinctive token for your device (see
+#      docs/en/fingerprint-spec.md for the match/extract grammar).
+#   2. Validate: this draft already compiles through the live rule
+#      classifier; re-check after edits by re-importing in MiBee.
+#   3. Contribute: PR against configs/fingerprints/ (CC-BY-SA 4.0 corpus).
+#
+# Generated from live scan evidence — match values are real observations
+# from your network.
+
+`
+
+const draftNoRulesNote = `# No banner / HTTP / SNMP / RTSP evidence is stored for this device, so no
+# rule could be pre-filled. Trigger a scan of this IP first (scanner → scan),
+# then generate the draft again — evidence older than the retention window
+# (default 14d) is pruned.
+`
+
+// validateDraft round-trips the generated YAML through the REAL rule
+// classifier (temp dir + LoadFromDir) — parse + compileMatch both run.
+func validateDraft(yamlText string) error {
+	dir, err := os.MkdirTemp("", "mibee-fp-draft-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+	if err := os.WriteFile(filepath.Join(dir, "draft.yaml"), []byte(yamlText), 0o600); err != nil {
+		return err
+	}
+	rc := &fp.RuleClassifier{}
+	if err := rc.LoadFromDir(dir); err != nil {
+		return err
+	}
+	if !rc.Loaded() || rc.RuleCount() == 0 {
+		return fmt.Errorf("draft compiled to zero rules")
+	}
+	return nil
+}

--- a/internal/service/fingerprint_report_test.go
+++ b/internal/service/fingerprint_report_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/testutil"
+)
+
+func newFingerprintTestService(t *testing.T) *FingerprintReportService {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return NewFingerprintReportService(db.New(conn), conn)
+}
+
+func insertCoverageDevice(t *testing.T, svc *FingerprintReportService, ip, uuid, attrs string) {
+	t.Helper()
+	_, err := svc.dbtx.ExecContext(context.Background(), `INSERT INTO devices (device_uuid, name, ip_address, mac_address, type, status, scan_attributes)
+		VALUES (?, ?, ?, ?, ?, 'online', ?)`, uuid, ip, ip, "", "other", attrs)
+	require.NoError(t, err)
+}
+
+func TestCoverage_TiersAndGrouping(t *testing.T) {
+	svc := newFingerprintTestService(t)
+	ctx := context.Background()
+
+	insertCoverageDevice(t, svc, "10.0.0.1", "u-prot", `{"inferred_type":"camera","inferred_type_source":"protocol","vendor":"Hikvision"}`)
+	insertCoverageDevice(t, svc, "10.0.0.2", "u-heur", `{"inferred_type":"pc","inferred_type_source":"heuristic","hostname":"DESKTOP-ABC"}`)
+	insertCoverageDevice(t, svc, "10.0.0.3", "u-un-1", `{"inferred_type":"other","oui_vendor":"TP-Link","hostname":"espresso-01"}`)
+	insertCoverageDevice(t, svc, "10.0.0.4", "u-un-2", `{"inferred_type":"other","oui_vendor":"TP-Link","hostname":"espresso-02"}`)
+	insertCoverageDevice(t, svc, "10.0.0.5", "u-un-3", `{"inferred_type":"other"}`)
+
+	// services for the port-signature grouping
+	_, err := svc.dbtx.ExecContext(ctx, `INSERT INTO host_services (ip, service, port, protocol, confidence, metadata)
+		VALUES ('10.0.0.3','http',80,'tcp',0.9,'{}'), ('10.0.0.4','http',80,'tcp',0.9,'{}')`)
+	require.NoError(t, err)
+
+	cov, err := svc.Coverage(ctx, domain.Scope{Global: true})
+	require.NoError(t, err)
+	require.EqualValues(t, 5, cov.Total)
+	require.EqualValues(t, 1, cov.Protocol)
+	require.EqualValues(t, 1, cov.Heuristic)
+	require.EqualValues(t, 3, cov.Unidentified)
+	require.Len(t, cov.Devices, 3)
+
+	// groups: oui TP-Link x2 tops; ports 80 x2; hostname espresso x2
+	require.NotEmpty(t, cov.Groups)
+	require.Equal(t, "oui", cov.Groups[0].Kind)
+	require.Equal(t, "TP-Link", cov.Groups[0].Signature)
+	require.EqualValues(t, 2, cov.Groups[0].Count)
+
+	var portsGroup *UnidentifiedGroup
+	for i := range cov.Groups {
+		if cov.Groups[i].Kind == "ports" {
+			portsGroup = &cov.Groups[i]
+		}
+	}
+	require.NotNil(t, portsGroup, "port-signature group expected")
+	require.Equal(t, "80", portsGroup.Signature)
+
+	// services attached to the device rows
+	for _, d := range cov.Devices {
+		if d.IP == "10.0.0.3" {
+			require.Equal(t, []int{80}, d.Ports)
+			require.Equal(t, []string{"http"}, d.Services)
+		}
+	}
+}
+
+func TestCoverage_RestrictedScopeFilters(t *testing.T) {
+	svc := newFingerprintTestService(t)
+	ctx := context.Background()
+
+	// net 1: one unidentified; net 2: one protocol-identified
+	_, err := svc.dbtx.ExecContext(ctx, `INSERT INTO networks (name, cidr) VALUES ('n1', '10.1.0.0/24')`)
+	require.NoError(t, err)
+	insertCoverageDevice(t, svc, "10.1.0.9", "u-n1", `{"inferred_type":"other"}`)
+	_, err = svc.dbtx.ExecContext(ctx, `UPDATE devices SET network_id = 1 WHERE device_uuid = 'u-n1'`)
+	require.NoError(t, err)
+	insertCoverageDevice(t, svc, "10.2.0.9", "u-n2", `{"inferred_type":"nas","inferred_type_source":"protocol"}`)
+	_, err = svc.dbtx.ExecContext(ctx, `UPDATE devices SET network_id = 2 WHERE device_uuid = 'u-n2'`)
+	require.NoError(t, err)
+
+	cov, err := svc.Coverage(ctx, domain.Scope{Global: false, NetworkIDs: []int64{1}})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cov.Total)
+	require.EqualValues(t, 1, cov.Unidentified)
+	require.Len(t, cov.Devices, 1)
+	require.Equal(t, "10.1.0.9", cov.Devices[0].IP)
+}
+
+func TestRuleDraft_GeneratesAndValidates(t *testing.T) {
+	svc := newFingerprintTestService(t)
+	ctx := context.Background()
+
+	insertCoverageDevice(t, svc, "10.0.0.50", "u-draft", `{"inferred_type":"other"}`)
+	_, err := svc.dbtx.ExecContext(ctx, `INSERT INTO service_evidence (ip, device_uuid, source, kind, port, protocol, raw_data, confidence)
+		VALUES
+		 ('10.0.0.50','u-draft','active:snmp','snmp',161,'udp','{"sys_descr":"RX3040 Revolution Router OS 1.2"}',0.9),
+		 ('10.0.0.50','u-draft','active:tcp','banner',9999,'tcp','{"banner":"ACME-DVR greet v2"}',0.8)`)
+	require.NoError(t, err)
+
+	draft, err := svc.RuleDraft(ctx, "u-draft", domain.Scope{Global: true})
+	require.NoError(t, err)
+	require.Contains(t, draft, "sys_descr")
+	require.Contains(t, draft, "RX3040 Revolution Router") // significant token survives
+	require.Contains(t, draft, "ACME-DVR greet v2")
+	require.Contains(t, draft, "version: 1")
+	// generated rules carry TODO service where no port hint exists
+	require.Contains(t, draft, "TODO")
+
+	// The draft is validated inside RuleDraft (fp.LoadFromDir compile); reaching
+	// here without error means the YAML parses AND compiles.
+}
+
+func TestRuleDraft_NoEvidenceReturnsHeader(t *testing.T) {
+	svc := newFingerprintTestService(t)
+	ctx := context.Background()
+	insertCoverageDevice(t, svc, "10.0.0.51", "u-empty", `{"inferred_type":"other"}`)
+
+	draft, err := svc.RuleDraft(ctx, "u-empty", domain.Scope{Global: true})
+	require.NoError(t, err)
+	require.Contains(t, draft, "No banner / HTTP / SNMP / RTSP evidence")
+}
+
+func TestRuleDraft_OutOfScopeRejected(t *testing.T) {
+	svc := newFingerprintTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.dbtx.ExecContext(ctx, `INSERT INTO networks (name, cidr) VALUES ('n1', '10.1.0.0/24')`)
+	require.NoError(t, err)
+	insertCoverageDevice(t, svc, "10.1.0.9", "u-scoped", `{"inferred_type":"other"}`)
+	_, err = svc.dbtx.ExecContext(ctx, `UPDATE devices SET network_id = 1 WHERE device_uuid = 'u-scoped'`)
+	require.NoError(t, err)
+
+	_, err = svc.RuleDraft(ctx, "u-scoped", domain.Scope{Global: false, NetworkIDs: []int64{99}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scope")
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -22,7 +22,8 @@
 		"Brand Logo Alt": "MiBee logo",
 		"Skip to Content": "Skip to content",
 		"Toggle Sidebar": "Toggle sidebar",
-		"Probes": "Probes"
+		"Probes": "Probes",
+		"Fingerprints": "Fingerprint Coverage"
 	},
 	"auth": {
 		"Username": "Username",
@@ -1275,5 +1276,31 @@
 		"Timeout Help": "Seconds per probe attempt (1–60), must be smaller than the interval",
 		"Cert Trusted": "Trusted",
 		"Cert Untrusted": "Untrusted"
+	},
+	"fingerprints": {
+		"Title": "Fingerprint Coverage",
+		"Description": "Identification coverage of your inventory — and the contribution loop for devices the rule library can't recognize yet.",
+		"Tier Protocol": "Protocol evidence (SNMP/RTSP/ONVIF)",
+		"Tier Heuristic": "Heuristic guess (hostname/brand)",
+		"Tier Unidentified": "Unidentified",
+		"Coverage Rate": "identified",
+		"Devices Unit": "devices",
+		"Top Groups": "Most-needed rule targets (shared features)",
+		"Group OUI": "NIC vendor",
+		"Group Ports": "Ports",
+		"Group Hostname": "Hostname",
+		"Unidentified List": "Unidentified devices",
+		"All Identified": "Everything identified",
+		"All Identified Desc": "No device falls into the unidentified tier — the rule library covers your inventory.",
+		"IP": "IP",
+		"Hostname": "Hostname",
+		"Vendor": "Vendor",
+		"OUI Vendor": "NIC vendor (OUI)",
+		"Ports": "Ports",
+		"Services": "Services",
+		"Generate Draft": "Rule draft",
+		"Draft Title": "Fingerprint rule draft",
+		"Draft Device": "Generated for",
+		"Download": "Download YAML"
 	}
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -22,7 +22,8 @@
 		"Brand Logo Alt": "MiBee 图标",
 		"Skip to Content": "跳到正文",
 		"Toggle Sidebar": "切换侧边栏",
-		"Probes": "拨测"
+		"Probes": "拨测",
+		"Fingerprints": "指纹覆盖"
 	},
 	"auth": {
 		"Username": "用户名",
@@ -1275,5 +1276,31 @@
 		"Timeout Help": "单次探测超时秒数（1–60），须小于间隔",
 		"Cert Trusted": "受信任",
 		"Cert Untrusted": "不受信任"
+	},
+	"fingerprints": {
+		"Title": "指纹覆盖率",
+		"Description": "资产清单的识别覆盖情况 —— 以及对规则库尚不能识别设备的贡献闭环入口。",
+		"Tier Protocol": "协议证据（SNMP/RTSP/ONVIF）",
+		"Tier Heuristic": "启发式推断（主机名/品牌）",
+		"Tier Unidentified": "未识别",
+		"Coverage Rate": "已识别",
+		"Devices Unit": "台设备",
+		"Top Groups": "最需要规则的特征（同类聚合）",
+		"Group OUI": "网卡厂商",
+		"Group Ports": "端口",
+		"Group Hostname": "主机名",
+		"Unidentified List": "未识别设备",
+		"All Identified": "全部已识别",
+		"All Identified Desc": "没有设备落入未识别层 —— 规则库已覆盖你的资产清单。",
+		"IP": "IP",
+		"Hostname": "主机名",
+		"Vendor": "厂商",
+		"OUI Vendor": "网卡厂商（OUI）",
+		"Ports": "端口",
+		"Services": "服务",
+		"Generate Draft": "规则草稿",
+		"Draft Title": "指纹规则草稿",
+		"Draft Device": "生成自",
+		"Download": "下载 YAML"
 	}
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -33,7 +33,8 @@
 		History,
 		Bot,
 		Network,
-		Activity
+		Activity,
+		Fingerprint
 	} from '@lucide/svelte';
 	import type { Component } from 'svelte';
 
@@ -104,7 +105,8 @@
 		{
 			labelKey: 'navigation.Group Library',
 			items: [
-				{ path: '/documents', label: m['navigation.Documents'](), icon: FileText }
+				{ path: '/documents', label: m['navigation.Documents'](), icon: FileText },
+				{ path: '/fingerprints', label: m['navigation.Fingerprints'](), icon: Fingerprint }
 			]
 		},
 		{

--- a/web/src/routes/fingerprints/+page.svelte
+++ b/web/src/routes/fingerprints/+page.svelte
@@ -1,0 +1,291 @@
+<!--
+  SPDX-License-Identifier: AGPL-3.0-or-later
+
+  Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+
+  This file is part of MiBee Steward, distributed under the GNU Affero General
+  Public License v3.0 or later. See LICENSE for the full text. A commercial
+  license is available for use cases the AGPL does not accommodate; see
+  LICENSE-COMMERCIAL.md.
+-->
+
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import { m } from '$lib/i18n-paraglide';
+	import { onMount } from 'svelte';
+	import { addToast } from '$lib/stores/toast';
+	import { getErrorMessage } from '$lib/utils/error';
+	import EmptyState from '$lib/components/EmptyState.svelte';
+	import PageSkeleton from '$lib/components/PageSkeleton.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import { RefreshCw, FileCode2, Copy, Download, Check, Fingerprint } from '@lucide/svelte';
+
+	interface UnidentifiedDevice {
+		device_uuid: string;
+		name: string;
+		ip_address: string;
+		mac_address: string;
+		hostname: string;
+		vendor: string;
+		oui_vendor: string;
+		os: string;
+		ports: number[];
+		services: string[];
+	}
+
+	interface UnidentifiedGroup {
+		kind: 'oui' | 'ports' | 'hostname_prefix';
+		signature: string;
+		count: number;
+		example_ips: string[];
+	}
+
+	interface Coverage {
+		total: number;
+		protocol: number;
+		heuristic: number;
+		unidentified: number;
+		devices: UnidentifiedDevice[];
+		groups: UnidentifiedGroup[];
+	}
+
+	let coverage = $state<Coverage | null>(null);
+	let loading = $state(true);
+	let error = $state('');
+
+	// Rule-draft modal
+	let draftOpen = $state(false);
+	let draftLoading = $state(false);
+	let draftText = $state('');
+	let draftDevice = $state<UnidentifiedDevice | null>(null);
+	let draftCopied = $state(false);
+
+	onMount(() => {
+		fetchCoverage();
+	});
+
+	async function fetchCoverage() {
+		loading = true;
+		error = '';
+		try {
+			coverage = await api.get<Coverage>('/fingerprints/coverage');
+		} catch (err: unknown) {
+			error = getErrorMessage(err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	const tierPct = $derived(
+		coverage && coverage.total > 0
+			? Math.round(((coverage.protocol + coverage.heuristic) / coverage.total) * 100)
+			: 0
+	);
+
+	async function generateDraft(device: UnidentifiedDevice) {
+		draftDevice = device;
+		draftOpen = true;
+		draftLoading = true;
+		draftText = '';
+		draftCopied = false;
+		try {
+			const res = await fetch(`/api/v1/devices/${device.device_uuid}/fingerprint-draft`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'X-CSRF-Token': (document.cookie.match(/csrf_token=([^;]+)/) || [])[1] || ''
+				}
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				throw new Error(body.error || `HTTP ${res.status}`);
+			}
+			draftText = await res.text();
+		} catch (err: unknown) {
+			addToast('error', getErrorMessage(err));
+			draftOpen = false;
+		} finally {
+			draftLoading = false;
+		}
+	}
+
+	function copyDraft() {
+		navigator.clipboard.writeText(draftText).then(() => {
+			draftCopied = true;
+			setTimeout(() => (draftCopied = false), 1500);
+		});
+	}
+
+	function downloadDraft() {
+		if (!draftDevice) return;
+		const blob = new Blob([draftText], { type: 'text/yaml' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `mibee-rule-draft-${draftDevice.ip_address}.yaml`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	function groupKindLabel(kind: string): string {
+		if (kind === 'oui') return m['fingerprints.Group OUI']();
+		if (kind === 'ports') return m['fingerprints.Group Ports']();
+		return m['fingerprints.Group Hostname']();
+	}
+</script>
+
+<div class="p-6 max-w-7xl mx-auto space-y-6">
+	<div class="flex items-center justify-between">
+		<div>
+			<h1 class="text-xl font-semibold text-text flex items-center gap-2">
+				<Fingerprint class="w-5 h-5 text-primary" />
+				{m['fingerprints.Title']()}
+			</h1>
+			<p class="text-sm text-text-muted mt-1">{m['fingerprints.Description']()}</p>
+		</div>
+		<button
+			type="button"
+			onclick={fetchCoverage}
+			class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-border
+				hover:border-primary hover:text-primary transition-colors"
+		>
+			<RefreshCw class="w-4 h-4" />
+			{m['common.Refresh']()}
+		</button>
+	</div>
+
+	{#if loading}
+		<PageSkeleton type="table" />
+	{:else if error}
+		<div class="rounded-lg border border-error/30 bg-error/5 p-4 text-sm text-error">{error}</div>
+	{:else if coverage}
+		<!-- Tier cards -->
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+			<div class="rounded-xl border border-border bg-surface p-4">
+				<div class="text-2xl font-semibold text-success">{coverage.protocol}</div>
+				<div class="text-xs text-text-muted mt-1">{m['fingerprints.Tier Protocol']()}</div>
+			</div>
+			<div class="rounded-xl border border-border bg-surface p-4">
+				<div class="text-2xl font-semibold text-primary">{coverage.heuristic}</div>
+				<div class="text-xs text-text-muted mt-1">{m['fingerprints.Tier Heuristic']()}</div>
+			</div>
+			<div class="rounded-xl border border-border bg-surface p-4">
+				<div class="text-2xl font-semibold text-warning">{coverage.unidentified}</div>
+				<div class="text-xs text-text-muted mt-1">{m['fingerprints.Tier Unidentified']()}</div>
+			</div>
+			<div class="rounded-xl border border-border bg-surface p-4">
+				<div class="text-2xl font-semibold text-text">{tierPct}%</div>
+				<div class="text-xs text-text-muted mt-1">
+					{m['fingerprints.Coverage Rate']()} · {coverage.total} {m['fingerprints.Devices Unit']()}
+				</div>
+			</div>
+		</div>
+
+		<!-- TOP groups -->
+		{#if coverage.groups.length > 0}
+			<div class="rounded-xl border border-border bg-surface p-4">
+				<h2 class="text-sm font-medium text-text mb-3">{m['fingerprints.Top Groups']()}</h2>
+				<div class="flex flex-wrap gap-2">
+					{#each coverage.groups as g (g.kind + g.signature)}
+						<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-bg border border-border">
+							<span class="text-text-muted">{groupKindLabel(g.kind)}</span>
+							<span class="font-mono text-text">{g.signature}</span>
+							<span class="px-1.5 rounded-full bg-primary/15 text-primary font-medium">{g.count}</span>
+						</span>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<!-- Unidentified devices -->
+		<div class="rounded-xl border border-border bg-surface overflow-hidden">
+			<div class="px-4 py-3 border-b border-border">
+				<h2 class="text-sm font-medium text-text">{m['fingerprints.Unidentified List']()}</h2>
+			</div>
+			{#if coverage.devices.length === 0}
+				<EmptyState
+					title={m['fingerprints.All Identified']()}
+					description={m['fingerprints.All Identified Desc']()}
+				/>
+			{:else}
+				<div class="overflow-x-auto">
+					<table class="w-full text-sm">
+						<thead>
+							<tr class="text-left text-xs text-text-muted border-b border-border">
+								<th class="px-4 py-2.5">{m['fingerprints.IP']()}</th>
+								<th class="px-4 py-2.5">{m['fingerprints.Hostname']()}</th>
+								<th class="px-4 py-2.5">{m['fingerprints.Vendor']()}</th>
+								<th class="px-4 py-2.5">{m['fingerprints.OUI Vendor']()}</th>
+								<th class="px-4 py-2.5">{m['fingerprints.Ports']()}</th>
+								<th class="px-4 py-2.5">{m['fingerprints.Services']()}</th>
+								<th class="px-4 py-2.5 text-right">{m['common.Actions']()}</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each coverage.devices as d (d.device_uuid)}
+								<tr class="border-b border-border/50 hover:bg-bg/50 transition-colors">
+									<td class="px-4 py-2.5 font-mono text-xs">{d.ip_address}</td>
+									<td class="px-4 py-2.5 text-xs">{d.hostname || '—'}</td>
+									<td class="px-4 py-2.5 text-xs">{d.vendor || '—'}</td>
+									<td class="px-4 py-2.5 text-xs">{d.oui_vendor || '—'}</td>
+									<td class="px-4 py-2.5 font-mono text-xs">{d.ports.join(', ') || '—'}</td>
+									<td class="px-4 py-2.5 text-xs">{d.services.join(', ') || '—'}</td>
+									<td class="px-4 py-2.5 text-right">
+										<button
+											type="button"
+											onclick={() => generateDraft(d)}
+											class="inline-flex items-center gap-1 px-2.5 py-1 text-xs rounded-lg
+												bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+										>
+											<FileCode2 class="w-3.5 h-3.5" />
+											{m['fingerprints.Generate Draft']()}
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<Modal bind:open={draftOpen} title={m['fingerprints.Draft Title']()} maxWidth="48rem">
+	{#if draftLoading}
+		<div class="py-8 text-center text-sm text-text-muted">...</div>
+	{:else}
+		<div class="space-y-3">
+			<p class="text-xs text-text-muted">
+				{m['fingerprints.Draft Device']()}: <span class="font-mono">{draftDevice?.ip_address}</span>
+				{draftDevice?.hostname ? ` (${draftDevice.hostname})` : ''}
+			</p>
+			<pre class="max-h-[50vh] overflow-auto rounded-lg bg-bg border border-border p-3 text-xs
+				font-mono text-text whitespace-pre">{draftText}</pre>
+			<div class="flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={copyDraft}
+					class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-border
+						hover:border-primary hover:text-primary transition-colors"
+				>
+					{#if draftCopied}
+						<Check class="w-4 h-4 text-success" />
+					{:else}
+						<Copy class="w-4 h-4" />
+					{/if}
+					{m['common.Copy']()}
+				</button>
+				<button
+					type="button"
+					onclick={downloadDraft}
+					class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-primary text-white
+						hover:bg-primary/90 transition-colors"
+				>
+					<Download class="w-4 h-4" />
+					{m['fingerprints.Download']()}
+				</button>
+			</div>
+		</div>
+	{/if}
+</Modal>


### PR DESCRIPTION
Closes #282。

## 覆盖率报表（识别分层）

- `FingerprintReportService.Coverage`：基于 `devices.scan_attributes` 的 json_extract 分层 —— **protocol**（SNMP/RTSP/ONVIF/mDNS 证据）/ **heuristic**（主机名·品牌关键字，可伪造）/ **unidentified**（回落 other）
- 未识别清单附带 host_services 的端口/服务；**特征聚类**（OUI 网卡厂商 / 开放端口签名 / 主号名前缀）给出「最需要规则的 TOP 特征」—— 一条规则可一次覆盖 N 台同类设备
- 网络 scope 强制：restricted 用户只见授权网络的设备（复用 domain.Scope，coverage SQL 过滤）

## 规则草稿贡献闭环（验收：从未识别设备 3 分钟得到可加载草稿）

- `POST /api/v1/devices/{uuid}/fingerprint-draft`：从 service_evidence 已采集证据（snmp sys_descr / banner / http title·server / rtsp server）预填生成 YAML，**返回前经真实 RuleClassifier 编译验证**（临时目录 LoadFromDir）—— 下载即可加载，只需补 service 判断
- 端口→服务提示（22→ssh 等）、通用值过滤（纯 SSH-/HTTP 问候不生成规则）、控制字符清洗
- 无证据设备返回带指引的说明头；draft 端点独立 scope 校验（越权 404）

## 指标与前端

- `mibee_fingerprint_identified_devices{source}` 随 UpdateDeviceMetrics 刷新（Prometheus 可告警识别率下降）
- `/fingerprints` 页面：分层卡片 + 覆盖率、TOP 特征 chips、未识别表、草稿弹窗（复制/下载 YAML）；侧边栏入口 + 中英 i18n

## 文档

fingerprint-spec.md §10（双语）：覆盖分层、聚类、草稿闭环 + API 说明。

## 测试

5 个新用例：分层与聚类数值、restricted scope 过滤、草稿生成+编译验证、无证据头、越权拒绝。`go test ./...` + vitest 197 全绿。