### PR TITLE
fix: 真机部署实测三修复 — coverage nil 切片 / 渠道 CHECK 迁移 + 测试发送 ctx / 敏感字段掩码（#282 #284 hotfix）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,4 @@ internal/service/scannerv2/ebpf/tcIngress_*.go
 internal/service/scannerv2/ebpf/tcIngress*.o
 cover.out
 *.prof
-agent
+/agent

--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -232,6 +232,12 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		return fmt.Errorf("scan_task_runs status migration: %w", err)
 	}
 
+	// Widen notification_channels' type CHECK to the chat-platform family
+	// (#284: feishu/wecom/telegram/discord). Same probe-first rebuild pattern.
+	if err := extendNotificationChannelTypeCheck(context.Background(), db); err != nil {
+		return fmt.Errorf("notification_channels type migration: %w", err)
+	}
+
 	// Add the scan_attributes generated columns (scan_vendor/scan_mac/scan_os/
 	// scan_hostname) to existing DBs. SQLite can't ALTER ADD COLUMN with a
 	// non-constant expression, so a table rebuild is required. Fresh installs
@@ -1090,6 +1096,63 @@ func extendScanRunStatusCheck(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("commit rebuild: %w", err)
 	}
 	slog.Info("scan_task_runs rebuilt with 'cancelled' status")
+	return nil
+}
+
+// extendNotificationChannelTypeCheck widens notification_channels' type CHECK
+// to the chat-platform channel family (#284): feishu / wecom / telegram /
+// discord join webhook + email. Existing installs carry the 2-value CHECK from
+// the original CREATE TABLE, so a rebuild (create-new → copy → drop → rename)
+// is required; schema.sql already ships the widened CHECK for fresh installs.
+// Probe-first keeps it a no-op on rebuilt/new databases.
+func extendNotificationChannelTypeCheck(ctx context.Context, db *sql.DB) error {
+	probe, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin probe tx: %w", err)
+	}
+	probeErr := func() error {
+		_, err := probe.ExecContext(ctx,
+			`INSERT INTO notification_channels (name, type) VALUES ('_probe', 'feishu')`)
+		return err
+	}()
+	_ = probe.Rollback()
+	if probeErr == nil {
+		return nil // CHECK already permits the new types
+	}
+	if !strings.Contains(probeErr.Error(), "CHECK constraint failed") {
+		return fmt.Errorf("probe notification_channels CHECK: %w", probeErr)
+	}
+
+	slog.Info("rebuilding notification_channels to widen the type CHECK (feishu/wecom/telegram/discord)")
+	stmts := []string{
+		`CREATE TABLE notification_channels_new (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL CHECK(type IN ('webhook', 'email', 'feishu', 'wecom', 'telegram', 'discord')),
+			config TEXT NOT NULL DEFAULT '{}',
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`INSERT INTO notification_channels_new (id, name, type, config, enabled, created_at, updated_at)
+		 SELECT id, name, type, config, enabled, created_at, updated_at FROM notification_channels`,
+		`DROP TABLE notification_channels`,
+		`ALTER TABLE notification_channels_new RENAME TO notification_channels`,
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin rebuild tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, st := range stmts {
+		if _, err := tx.ExecContext(ctx, st); err != nil {
+			return fmt.Errorf("rebuild step failed: %w (stmt: %s)", err, st)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit rebuild: %w", err)
+	}
+	slog.Info("notification_channels rebuilt with the widened type CHECK")
 	return nil
 }
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -259,7 +259,7 @@ CREATE INDEX IF NOT EXISTS idx_device_systems_metrics_enabled ON device_systems(
 CREATE TABLE IF NOT EXISTS notification_channels (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    type TEXT NOT NULL CHECK(type IN ('webhook', 'email')),
+    type TEXT NOT NULL CHECK(type IN ('webhook', 'email', 'feishu', 'wecom', 'telegram', 'discord')), -- widened #284
     config TEXT NOT NULL DEFAULT '{}',
     enabled INTEGER NOT NULL DEFAULT 1,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -10,6 +10,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -253,7 +254,12 @@ func (h *NotificationHandler) TestChannel(w http.ResponseWriter, r *http.Request
 		Recipient: "test",
 	}
 
-	h.dispatcher.Dispatch(r.Context(), domain.ChannelType(ch.Type), ch.Config, payload, nil, ch.ID)
+	// Detach from the request lifecycle: the worker pool processes this job
+	// AFTER the HTTP response returns (async by design), and r.Context() is
+	// canceled the moment the response is written — a request-scoped ctx made
+	// every test-send fail before dialing AND made the result-log write fail
+	// ("context canceled"), so the notification_log row never appeared.
+	h.dispatcher.Dispatch(context.WithoutCancel(r.Context()), domain.ChannelType(ch.Type), ch.Config, payload, nil, ch.ID)
 
 	Success(w, map[string]string{"message": "test notification dispatched"})
 }
@@ -331,17 +337,30 @@ func (h *NotificationHandler) maskChannelPassword(ch *domain.ChannelResponse) *d
 	return ch
 }
 
-// maskChannelPasswordInPlace masks the SMTP password in the channel config if type is email.
+// maskChannelPasswordInPlace masks credential-bearing config fields before a
+// channel is serialized to a client: the SMTP password (email) plus the
+// chat-platform secrets (#284) — feishu sign secret, telegram bot token. The
+// dedicated enabled-toggle PATCH and the edit form's keep-if-blank convention
+// prevent masked values from ever being written back.
 func (h *NotificationHandler) maskChannelPasswordInPlace(ch *domain.ChannelResponse) {
-	if ch.Type == string(domain.ChannelTypeEmail) && len(ch.Config) > 0 {
-		var config map[string]interface{}
-		if json.Unmarshal(ch.Config, &config) == nil {
-			if _, ok := config["password"]; ok {
-				config["password"] = "*****"
-			}
-			if masked, err := json.Marshal(config); err == nil {
-				ch.Config = json.RawMessage(masked)
-			}
+	if len(ch.Config) == 0 {
+		return
+	}
+	var touched bool
+	var config map[string]interface{}
+	if json.Unmarshal(ch.Config, &config) != nil {
+		return
+	}
+	for _, f := range []string{"password", "secret", "bot_token"} {
+		if _, ok := config[f]; ok {
+			config[f] = "*****"
+			touched = true
 		}
+	}
+	if !touched {
+		return
+	}
+	if masked, err := json.Marshal(config); err == nil {
+		ch.Config = json.RawMessage(masked)
 	}
 }

--- a/internal/service/fingerprint_report.go
+++ b/internal/service/fingerprint_report.go
@@ -130,8 +130,22 @@ func (s *FingerprintReportService) Coverage(ctx context.Context, scope domain.Sc
 			return nil, err
 		}
 	}
+	// Never ship nil slices: encoding/json renders nil as JSON null, and the
+	// UI's .join()/.length on null throws mid-render (the whole coverage
+	// section goes blank). Empty arrays instead.
+	for i := range devs {
+		if devs[i].Ports == nil {
+			devs[i].Ports = []int{}
+		}
+		if devs[i].Services == nil {
+			devs[i].Services = []string{}
+		}
+	}
 	cov.Devices = devs
 	cov.Groups = groupUnidentified(devs)
+	if cov.Groups == nil {
+		cov.Groups = []UnidentifiedGroup{}
+	}
 	return cov, nil
 }
 


### PR DESCRIPTION
真机部署（63.101 center + 62.174 agent）浏览器实测中发现并修复三个问题：

## 1. coverage nil 切片 → 前端渲染崩（#282）
未识别设备无 host_services 行时 `ports`/`services` 为 Go nil → JSON `null` → 前端 `d.ports.join()` 抛 TypeError，整个覆盖区块静默空白。统一初始化空数组。
**实测**：89 设备（45/33/34，88%）渲染正常，15 聚类组，34 行清单。

## 2. 渠道 CHECK 约束 + 测试发送 ctx（#284）
- `notification_channels` 表 `CHECK(type IN ('webhook','email'))` 在 DB 层挡住新渠道类型 → probe-first 表重建迁移（照 extendScanRunStatusCheck 既有模式）+ schema.sql 同步
- TestChannel 的 Dispatch 携带 `r.Context()` — 响应写回即取消，异步 worker 发送前失败且 notification_log 写入同样失败（静默丢失）→ `context.WithoutCancel`
**实测**：飞书渠道创建 → 测试发送 → 63.101 本机 mock 接收器收到 `msg_type=text` 载荷 + `X-Lark-Request-Timestamp/Signature` 头，**HMAC-SHA256 签名经独立 python 复算逐字节匹配**，notification_log 记录 sent。

## 3. 敏感字段掩码
渠道配置掩码从仅 SMTP password 扩展到 feishu `secret` / telegram `bot_token`。GET 响应实测返回 `"*****"`。

（顺带：.gitignore 裸 `agent` 模式锚定为 `/agent`，避免吞掉 internal/agent/ 新文件 —— #309 CI 曾因此挂过。）