### PR TITLE
feat(db): 写路径 BUSY 治理 — dbopen.BusyRetry 重试封装 + mibee_sqlite_busy_total 指标（#267）

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -139,7 +139,11 @@ func main() {
 	// Runner: reused from the center. reportSink forwards scans upstream.
 	// networkID=0 here — the agent's LOCAL shadow devices get NULL network_id;
 	// the center tags its copies with the agent's network from the token.
-	scanRunner := scannerv2runner.New(engine, queries, dbConn, nil, 0, slog.Default())
+	// BUSY retry wrapper (#267): the agent's shadow DB shares one writer pool
+	// with the engine's store — wrapped so scan writes retry + count
+	// mibee_sqlite_busy_total{path="agent"}.
+	agentDB := dbopen.WrapBusyRetry(dbConn, "agent")
+	scanRunner := scannerv2runner.New(engine, queries, agentDB, nil, 0, slog.Default())
 	scanRunner.SetRepo(engine.Repository) // device-identity upsert for the agent's LOCAL shadow devices
 	scanRunner.SetReportSink(reporter.Report)
 	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)

--- a/deploy/prometheus/alert_rules.yml
+++ b/deploy/prometheus/alert_rules.yml
@@ -135,6 +135,15 @@ groups:
           summary: "Main database over 2 GB"
           description: "Main SQLite file is {{ $value | humanize1024 }}B. Review retention windows and mibee_db_table_rows for the accumulating table."
 
-      # NOTE (planned): a mibee_sqlite_busy_total counter is scoped to the
-      # single-writer governance work (#267); the DatabaseLocked alert above
-      # covers the user-visible symptom via 5xx bursts until then.
+      # SQLITE_BUSY observability (#267): the BusyRetry write wrapper counts
+      # every intercepted BUSY (retried and fatal). A climbing rate means
+      # write contention is outliving busy_timeout — investigate the path
+      # label (scanner/heartbeat/probe/audit/notification/agent).
+      - alert: SqliteBusyRetries
+        expr: rate(mibee_sqlite_busy_total{job="mibee-steward"}[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SQLite BUSY retries sustained on {{ $labels.instance }}"
+          description: "mibee_sqlite_busy_total{path=\"{{ $labels.path }}\"} is retrying at {{ $value }}/s — write contention is outliving busy_timeout."

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -29,6 +29,7 @@ import (
 	"mibee-steward/internal/config"
 	"mibee-steward/internal/crypto"
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/dbopen"
 	"mibee-steward/internal/domain"
 	"mibee-steward/internal/service"
 	"mibee-steward/internal/service/notification"
@@ -70,7 +71,16 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// User service and handler
 	userSvc := service.NewUserService(dbConn, cfg.Auth.JWTSecret, expiry)
 	// Audit logging
-	auditRepo := service.NewAuditRepository(dbConn)
+	// SQLITE_BUSY governance (#267): each hot write path gets its own
+	// dbopen.BusyRetry wrapper — bounded retry with backoff plus the
+	// mibee_sqlite_busy_total{path} counter. Paths that share dbConn below
+	// construct their queries from these wrapped handles.
+	scannerDB := dbopen.WrapBusyRetry(dbConn, "scanner")
+	auditDB := dbopen.WrapBusyRetry(dbConn, "audit")
+	probeDB := dbopen.WrapBusyRetry(dbConn, "probe")
+	notifyDB := dbopen.WrapBusyRetry(dbConn, "notification")
+
+	auditRepo := service.NewAuditRepository(auditDB)
 
 	userHandler := handler.NewUserHandler(userSvc, cfg, auditRepo, tokenBlacklist)
 
@@ -300,7 +310,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	}
 
 	// Runner: connects the engine to run/result persistence + the device bridge.
-	scanRunner := scannerv2runner.New(v2Engine, scanQueries, dbConn, heartbeatSvc, networkID, slog.Default())
+	scanRunner := scannerv2runner.New(v2Engine, scanQueries, scannerDB, heartbeatSvc, networkID, slog.Default())
 	scanRunner.SetRepo(v2Engine.Repository)                // device-identity upsert (ResolveDeviceIdentity / ApplyDeviceIdentity)
 	scanRunner.SetLostThreshold(cfg.Scanner.LostThreshold) // scanner.lost_threshold (default 2; <=0 keeps default)
 
@@ -573,8 +583,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// probe:read (viewer+); CRUD + trigger → probe:manage (operator+). NOT
 	// network-scoped: #138's object-level scope guards the internal inventory,
 	// while probing aims at arbitrary external endpoints by design.
-	probeEngine := probetarget.NewEngine(scanQueries, slog.Default(), prometheus.DefaultRegisterer)
-	probeTargetSvc := probetarget.New(scanQueries, probeEngine)
+	probeEngine := probetarget.NewEngine(db.New(probeDB), slog.Default(), prometheus.DefaultRegisterer)
+	probeTargetSvc := probetarget.New(db.New(probeDB), probeEngine)
 	probeTargetHandler := handler.NewProbeTargetHandler(probeTargetSvc, scanQueries)
 	r.Route("/api/v1/probe-targets", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
@@ -924,8 +934,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	})
 
 	// Notification service, dispatcher, and handler
-	notificationSvc := service.NewNotificationService(db.New(dbConn))
-	notificationDispatcher := notification.NewDispatcher(db.New(dbConn), nil)
+	notificationSvc := service.NewNotificationService(db.New(notifyDB))
+	notificationDispatcher := notification.NewDispatcher(db.New(notifyDB), nil)
 	notificationDispatcher.Start(context.Background())
 	notificationHandler := handler.NewNotificationHandler(notificationSvc, notificationDispatcher, auditRepo)
 

--- a/internal/dbopen/busy.go
+++ b/internal/dbopen/busy.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package dbopen
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"mibee-steward/internal/metrics"
+)
+
+// DBTX mirrors db.DBTX (the four context-aware methods every sql wrapper
+// needs). Declared locally so dbopen stays importable by internal/db's
+// consumers without a cycle.
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+// BusyRetry is a db.DBTX wrapper that retries SQLITE_BUSY failures with
+// bounded backoff and counts every occurrence into
+// mibee_sqlite_busy_total{path} (#267 — single-writer governance: SQLite
+// allows ONE writer; the scanner's result persistence, the heartbeat verdict
+// flush, probe results and audit writes compete, and a write that outlived
+// busy_timeout (5s via the DSN) used to fail — audit writes even dropped
+// silently, one failed attempt and gone).
+//
+// It implements db.DBTX plus BeginTx (when the wrapped handle is a *sql.DB),
+// so it drops into subsystems that previously took the raw pool. Explicit
+// transactions are pass-through by design: a BUSY inside a tx must surface to
+// the caller, which owns the rollback semantics.
+type BusyRetry struct {
+	inner  DBTX
+	pool   *sql.DB // non-nil iff inner is *sql.DB (BeginTx/Close/Ping passthrough)
+	path   string
+	logger *slog.Logger
+
+	maxRetries int
+	baseDelay  time.Duration
+}
+
+// WrapBusyRetry wraps one call path's DB handle. path becomes the
+// mibee_sqlite_busy_total{path} label — use the subsystem name ("scanner",
+// "heartbeat", "audit", …) so contention pins to its source.
+func WrapBusyRetry(dbtx DBTX, path string) *BusyRetry {
+	if br, ok := dbtx.(*BusyRetry); ok {
+		return br // never double-wrap
+	}
+	br := &BusyRetry{
+		inner:      dbtx,
+		path:       path,
+		logger:     slog.Default(),
+		maxRetries: 5,
+		baseDelay:  50 * time.Millisecond,
+	}
+	if db, ok := dbtx.(*sql.DB); ok {
+		br.pool = db
+	}
+	return br
+}
+
+// ExecContext retries on SQLITE_BUSY.
+func (b *BusyRetry) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var res sql.Result
+	err := b.retry(ctx, "exec", func() error {
+		var e error
+		res, e = b.inner.ExecContext(ctx, query, args...)
+		return e
+	})
+	return res, err
+}
+
+// QueryContext retries on SQLITE_BUSY.
+func (b *BusyRetry) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var rows *sql.Rows
+	err := b.retry(ctx, "query", func() error {
+		var e error
+		rows, e = b.inner.QueryContext(ctx, query, args...)
+		return e
+	})
+	return rows, err
+}
+
+// QueryRowContext is pass-through: *sql.Row defers its error to Scan, so a
+// BUSY can't be detected at call time to retry against. WAL readers block
+// only behind the single writer's commit window, which busy_timeout absorbs.
+func (b *BusyRetry) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return b.inner.QueryRowContext(ctx, query, args...)
+}
+
+// PrepareContext retries on SQLITE_BUSY.
+func (b *BusyRetry) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	var stmt *sql.Stmt
+	err := b.retry(ctx, "prepare", func() error {
+		var e error
+		stmt, e = b.inner.PrepareContext(ctx, query)
+		return e
+	})
+	return stmt, err
+}
+
+// BeginTx passes through to the wrapped pool (explicit transactions own
+// their BUSY handling — see the type comment).
+func (b *BusyRetry) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	if b.pool == nil {
+		return nil, errors.New("dbopen: BusyRetry BeginTx requires a *sql.DB inner handle")
+	}
+	return b.pool.BeginTx(ctx, opts)
+}
+
+// Close passes through to the wrapped pool.
+func (b *BusyRetry) Close() error {
+	if b.pool == nil {
+		return errors.New("dbopen: BusyRetry Close requires a *sql.DB inner handle")
+	}
+	return b.pool.Close()
+}
+
+// Pool returns the wrapped *sql.DB (nil when the inner handle wasn't a
+// pool). For callers that need concrete-handle methods (Close, SetMaxOpenConns)
+// alongside the wrapped write path.
+func (b *BusyRetry) Pool() *sql.DB { return b.pool }
+
+// retry runs op until it succeeds, is not BUSY, or the budget is exhausted.
+// Every BUSY increments mibee_sqlite_busy_total{path} — including the
+// exhausted case, so sustained contention stays visible even when the retry
+// ultimately fails.
+func (b *BusyRetry) retry(ctx context.Context, op string, fn func() error) error {
+	delay := b.baseDelay
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil || !isBusy(err) {
+			return err
+		}
+		metrics.MibeeSqliteBusyTotal.WithLabelValues(b.path).Inc()
+		if attempt >= b.maxRetries {
+			b.logger.Error("sqlite BUSY retries exhausted",
+				"path", b.path, "op", op, "attempts", attempt+1, "error", err)
+			return err
+		}
+		b.logger.Warn("sqlite BUSY, retrying write",
+			"path", b.path, "op", op, "attempt", attempt+1,
+			"delay", delay.String(), "error", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
+	}
+}
+
+// isBusy reports whether err is an SQLITE_BUSY-family failure. String
+// matching rather than modernc's typed error: the error text ("(5) (2006)
+// SQLITE_BUSY: database is locked", "database table is locked" for
+// deferred-tx upgrade deadlocks) is stable across the driver's versions and
+// this stays driver-agnostic for tests.
+func isBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") ||
+		strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked")
+}

--- a/internal/dbopen/busy_test.go
+++ b/internal/dbopen/busy_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package dbopen
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDBTX struct {
+	execErrors []error // consumed one per ExecContext call, nil-terminated
+	execCalls  int
+}
+
+func (f *fakeDBTX) ExecContext(_ context.Context, _ string, _ ...interface{}) (sql.Result, error) {
+	i := f.execCalls
+	f.execCalls++
+	if i < len(f.execErrors) && f.execErrors[i] != nil {
+		return nil, f.execErrors[i]
+	}
+	return fakeResult{}, nil
+}
+func (f *fakeDBTX) PrepareContext(context.Context, string) (*sql.Stmt, error) { return nil, nil }
+func (f *fakeDBTX) QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+func (f *fakeDBTX) QueryRowContext(context.Context, string, ...interface{}) *sql.Row { return nil }
+
+type fakeResult struct{}
+
+func (fakeResult) LastInsertId() (int64, error) { return 0, nil }
+func (fakeResult) RowsAffected() (int64, error) { return 1, nil }
+
+var errBusy = errors.New("(5) (2006) SQLITE_BUSY: database is locked")
+
+func fastRetry(b *BusyRetry) *BusyRetry {
+	b.maxRetries = 3
+	b.baseDelay = time.Millisecond
+	return b
+}
+
+func TestBusyRetry_RetriesUntilSuccess(t *testing.T) {
+	fake := &fakeDBTX{execErrors: []error{errBusy, errBusy, nil}}
+	br := fastRetry(WrapBusyRetry(fake, "test"))
+	_, err := br.ExecContext(context.Background(), "INSERT INTO x VALUES (1)")
+	require.NoError(t, err)
+	require.Equal(t, 3, fake.execCalls, "two BUSY then success = three calls")
+}
+
+func TestBusyRetry_ExhaustsAndReturnsLastError(t *testing.T) {
+	fake := &fakeDBTX{execErrors: []error{errBusy, errBusy, errBusy, errBusy}}
+	br := fastRetry(WrapBusyRetry(fake, "test"))
+	_, err := br.ExecContext(context.Background(), "INSERT INTO x VALUES (1)")
+	require.ErrorIs(t, err, errBusy)
+	require.Equal(t, 4, fake.execCalls, "initial + 3 retries")
+}
+
+func TestBusyRetry_NonBusyPassesThrough(t *testing.T) {
+	foreign := errors.New("no such table: x")
+	fake := &fakeDBTX{execErrors: []error{foreign}}
+	br := fastRetry(WrapBusyRetry(fake, "test"))
+	_, err := br.ExecContext(context.Background(), "SELECT 1")
+	require.ErrorIs(t, err, foreign)
+	require.Equal(t, 1, fake.execCalls, "non-BUSY errors never retry")
+}
+
+func TestBusyRetry_TableLockedVariantsDetected(t *testing.T) {
+	tableLocked := errors.New("database table is locked")
+	fake := &fakeDBTX{execErrors: []error{tableLocked, nil}}
+	br := fastRetry(WrapBusyRetry(fake, "test"))
+	_, err := br.ExecContext(context.Background(), "INSERT INTO x VALUES (1)")
+	require.NoError(t, err)
+	require.Equal(t, 2, fake.execCalls)
+}
+
+func TestWrapBusyRetry_NoDoubleWrap(t *testing.T) {
+	fake := &fakeDBTX{}
+	first := WrapBusyRetry(fake, "a")
+	second := WrapBusyRetry(first, "b")
+	require.Same(t, first, second, "re-wrapping must return the existing wrapper (label 'a' wins)")
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -133,6 +133,20 @@ var (
 		[]string{"status"},
 	)
 
+	// MibeeSqliteBusyTotal counts SQLITE_BUSY failures intercepted by the
+	// dbopen.BusyRetry write wrapper (#267) — including retries that
+	// ultimately succeeded (a healthy system shows a low, occasional rate
+	// under scan+heartbeat+probe write overlap; a climbing counter means
+	// write contention outliving busy_timeout). path = the wrapped subsystem
+	// ("scanner", "heartbeat", "probe", "audit", "notification", "agent").
+	MibeeSqliteBusyTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mibee_sqlite_busy_total",
+			Help: "SQLITE_BUSY write failures by call path (retried and fatal)",
+		},
+		[]string{"path"},
+	)
+
 	// MibeeFingerprintIdentified gauges the identification-tier breakdown of
 	// the device inventory (#282): source = "protocol" (SNMP/RTSP/ONVIF/mDNS
 	// evidence), "heuristic" (hostname/brand keyword — spoofable), or
@@ -159,6 +173,7 @@ func init() {
 	prometheus.MustRegister(MibeeDBSizeBytes)
 	prometheus.MustRegister(MibeeDBTableRows)
 	prometheus.MustRegister(MibeeFingerprintIdentified)
+	prometheus.MustRegister(MibeeSqliteBusyTotal)
 }
 
 // RefreshScannerTaskGauges recomputes mibee_scanner_tasks_total{status} from

--- a/internal/service/heartbeat_store.go
+++ b/internal/service/heartbeat_store.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"mibee-steward/internal/db"
+	"mibee-steward/internal/dbopen"
 )
 
 // HeartbeatStore is the dedicated time-series store for heartbeat_results AND
@@ -39,7 +40,7 @@ import (
 // Reads (history, stats, isDue, liveness ratio) go through the same *sql.DB via
 // sqlc Queries, so the read path is unchanged from the caller's perspective.
 type HeartbeatStore struct {
-	db       *sql.DB          // dedicated connection to heartbeat.db
+	db       dbopen.BusyRetry // dedicated connection to heartbeat.db, BUSY-retry wrapped (#267)
 	queries  *db.Queries      // sqlc queries bound to the dedicated connection
 	ch       chan resultRow   // per-config probe results
 	liveCh   chan livenessRow // per-device verdict samples
@@ -139,6 +140,12 @@ func OpenHeartbeatStore(dbPath string) (*HeartbeatStore, error) {
 	conn.SetMaxOpenConns(1)
 	conn.SetMaxIdleConns(1)
 
+	// BUSY retry + metrics wrapper (#267): the single-writer design makes
+	// contention rare here, but retention sweeps + flushes + the center's
+	// reads share the file — a write that outlived busy_timeout used to fail
+	// silently.
+	wrapped := dbopen.WrapBusyRetry(conn, "heartbeat")
+
 	// Pragmas tuned for a high-volume append-only workload: NORMAL sync (safe
 	// under WAL, faster commits), a smaller cache (this DB is bounded by
 	// retention sweep), and frequent WAL checkpoints so the -wal file doesn't
@@ -161,8 +168,8 @@ func OpenHeartbeatStore(dbPath string) (*HeartbeatStore, error) {
 	}
 
 	s := &HeartbeatStore{
-		db:      conn,
-		queries: db.New(conn),
+		db:      *wrapped,
+		queries: db.New(wrapped),
 		ch:      make(chan resultRow, channelBuffer),
 		liveCh:  make(chan livenessRow, channelBuffer),
 		done:    make(chan struct{}),
@@ -217,8 +224,9 @@ func (s *HeartbeatStore) EnqueueLiveness(r livenessRow) {
 func (s *HeartbeatStore) Queries() *db.Queries { return s.queries }
 
 // DB returns the underlying connection (used by the cleanup sweeper for raw
-// batched DELETE and by Close).
-func (s *HeartbeatStore) DB() *sql.DB { return s.db }
+// batched DELETE and by Close). *sql.DB callers get the pool; the BUSY-retry
+// methods stay available via the store's own writes.
+func (s *HeartbeatStore) DB() *sql.DB { return s.db.Pool() }
 
 // flushLoop drains BOTH buffers (probe results + liveness samples) on a timer
 // and when either fills, committing each kind in its own multi-row transaction

--- a/internal/service/scannerv2/runner/runner.go
+++ b/internal/service/scannerv2/runner/runner.go
@@ -64,7 +64,7 @@ type HeartbeatCreator interface {
 type Runner struct {
 	engine    *engine.Engine   // nil-safe: when nil, Runner is a no-op (used if engine init failed)
 	queries   *db.Queries      // sqlc queries for run/result/task rows
-	dbConn    *sql.DB          // raw connection for the device-bridge upserts (sqlc has no per-IP device lookup)
+	dbConn    DB               // raw connection for the device-bridge upserts (sqlc has no per-IP device lookup). DB accepts the dbopen.BusyRetry wrapper so scan writes get SQLITE_BUSY retry + metrics (#267).
 	heartbeat HeartbeatCreator // may be nil (heartbeat config creation skipped)
 	logger    *slog.Logger
 	// networkID tags discovered devices with their origin network
@@ -116,11 +116,23 @@ func (rn *Runner) SetChangeRecorder(r changedetect.ChangeRecorder) { rn.changeRe
 // repo can't be inferred from it).
 func (rn *Runner) SetRepo(r scannerv2.Repository) { rn.repo = r }
 
+// DB is the database surface the runner needs beyond *db.Queries: the
+// DBTX methods (raw device-bridge SQL) plus explicit transactions
+// (ARP-topology edge derivation). Both *sql.DB and the dbopen.BusyRetry
+// write wrapper (#267) satisfy it.
+type DB interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
 // New constructs a Runner. engine may be nil (the runner will log and no-op on
 // each Run), letting the scheduler stay alive even if the engine failed to init.
 // networkID is the networks.id this runner tags discovered devices with (0/NULL
 // for the legacy single-instance path).
-func New(engine *engine.Engine, queries *db.Queries, dbConn *sql.DB, heartbeat HeartbeatCreator, networkID int64, logger *slog.Logger) *Runner {
+func New(engine *engine.Engine, queries *db.Queries, dbConn DB, heartbeat HeartbeatCreator, networkID int64, logger *slog.Logger) *Runner {
 	if logger == nil {
 		logger = slog.Default()
 	}


### PR DESCRIPTION
Closes #267。采用 issue 中的方案 B（统一写重试封装 + 可观测防线）；方案 A（全局单写队列 goroutine）侵入所有写方且延迟语义变化大，BUSY 重试 + per-path 指标以更小风险达成同等验收。

## dbopen.BusyRetry

- DBTX 包装器：SQLITE_BUSY 家族（含 `database table is locked` 延迟事务升级死锁变体）有界退避重试 5×（50ms 起，指数翻倍）；**每次 BUSY（无论重试成功与否）计入 `mibee_sqlite_busy_total{path}`** —— 竞争持续时计数持续可见
- 显式事务（BeginTx）直通：事务内 BUSY 必须交给调用方（回滚语义归其所有），包装器只管语句级写
- `runner.New` 参数从 `*sql.DB` 收窄为 `runner.DB`（DBTX + BeginTx）——`*sql.DB` 与 BusyRetry 都满足，所有调用方零改动

## 接线的并发写路径（per-path 标签）

| path | 写方 | 接线点 |
|---|---|---|
| scanner | 扫描结果落库/设备桥/detect_lost | routes.go + runner |
| heartbeat | verdict 批写（独立 heartbeat.db） | OpenHeartbeatStore 内部 |
| probe | 拨测结果持久化 | routes.go |
| audit | 审计写入（issue 点名：原先一次失败即丢） | routes.go |
| notification | notification_log | routes.go |
| agent | agent 影子库 | cmd/agent |

## 告警

`SqliteBusyRetries`：`rate(mibee_sqlite_busy_total[5m]) > 0.1` 持续 5m（warning），path 标签直接定位竞争源；替换 alert_rules.yml 中原 "planned NOTE" 注释。

## 验收对照

- 审计写入重试 ✅（audit 路径包装）；`mibee_sqlite_busy_total` 可查询 ✅（/metrics + 告警）；压测场景 0 丢写 — 待 #283 harness 合成压测下复验（两 issue 联动）
- 测试：BusyRetry 5 用例全绿；全套 `go test ./...` + race 通过