### PR TITLE
feat(db): schema 版本门控（user_version）+ 备份数量保留 + 新旧装结构等价断言（#268）

### DIFF
--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -30,8 +31,39 @@ import (
 	"mibee-steward/internal/service/scannerv2/taskservice"
 )
 
+// SchemaVersion is the current schema generation, stored in
+// PRAGMA user_version (#268). Bump it when adding a migration step to the
+// chain below; existing databases replay only when their recorded version is
+// lower (every step stays idempotent regardless, so a v0 database from before
+// this framework simply runs the whole chain once and gets stamped).
+const SchemaVersion = 1
+
 func runMigrations(db *sql.DB, dbPath string) error {
-	// Backup database before migration (only if file exists)
+	// Version gate (#268): a database already at SchemaVersion skips the whole
+	// chain — no pre-migration VACUUM INTO backup (previously taken on EVERY
+	// startup), no probe statements, no rebuild checks. Startup goes from
+	// "hundreds of idempotent statements" to one PRAGMA read.
+	var current int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&current); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+	switch {
+	case current == SchemaVersion:
+		slog.Info("schema already at version; migrations skipped",
+			"version", current)
+		return nil
+	case current > SchemaVersion:
+		// Downgraded binary against a newer schema. The chain below is
+		// idempotent but written for forward migration only — refuse rather
+		// than touch a newer database.
+		slog.Warn("database schema version is NEWER than this binary; skipping migrations",
+			"db_version", current, "binary_version", SchemaVersion)
+		return nil
+	}
+	slog.Info("running schema migrations", "from_version", current, "to_version", SchemaVersion)
+
+	// Backup database before migration (only if file exists) — now taken only
+	// when a migration will actually run (version gate above), not every boot.
 	if _, err := os.Stat(dbPath); err == nil {
 		backupPath := dbPath + ".pre-migration." + time.Now().Format("20060102-150405")
 		// VACUUM INTO cannot be parameterised, so sanitize the path to avoid
@@ -51,6 +83,29 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		// accumulating multi-hundred-MB copies next to the live DB. The
 		// scripts/backup.sh 7-day retention covers its own files, not these.
 		pruneOldBackups(filepath.Dir(dbPath), filepath.Base(dbPath)+".pre-migration.", 7*24*time.Hour)
+	}
+	// Count-based retention (#268): keep at most the 3 newest pre-migration
+	// backups regardless of age — a 7-day window still piles up ~50 copies on
+	// a daily-restart deployment, and each is a full multi-hundred-MB VACUUM.
+	pruneExcessBackups(filepath.Dir(dbPath), filepath.Base(dbPath)+".pre-migration.", 3)
+
+	// Pre-schema ALTERs (#268): schema.sql now carries idx_devices_ip_network
+	// and idx_scan_tasks_network, which reference the network_id columns that
+	// LEGACY databases only get from the migration chain below. Adding them
+	// before the schema apply lets both paths (fresh: schema.sql creates them
+	// inline; legacy: added here) satisfy the indexes. On a fresh empty DB
+	// both statements fail with "no such table" — tolerated, schema.sql
+	// creates everything a moment later.
+	for _, stmt := range []string{
+		`ALTER TABLE devices ADD COLUMN network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL`,
+		`ALTER TABLE scan_tasks ADD COLUMN network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			msg := err.Error()
+			if !strings.Contains(msg, "duplicate column name") && !strings.Contains(msg, "no such table") {
+				return fmt.Errorf("pre-schema migration %q: %w", stmt, err)
+			}
+		}
 	}
 
 	// Execute embedded schema directly
@@ -326,8 +381,36 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		}
 	}
 
-	slog.Info("database schema applied")
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", SchemaVersion)); err != nil {
+		return fmt.Errorf("stamp schema version %d: %w", SchemaVersion, err)
+	}
+	slog.Info("database schema applied", "version", SchemaVersion)
 	return nil
+}
+
+// pruneExcessBackups deletes the oldest backups matching prefix until at most
+// keep remain. Backup filenames carry a sortable timestamp, so lexical order
+// is age order. Best-effort, like pruneOldBackups.
+func pruneExcessBackups(dir, prefix string, keep int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	var matches []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), prefix) {
+			matches = append(matches, e.Name())
+		}
+	}
+	if len(matches) <= keep {
+		return
+	}
+	sort.Strings(matches) // oldest (lexically smallest timestamp) first
+	for _, name := range matches[:len(matches)-keep] {
+		if err := os.Remove(filepath.Join(dir, name)); err == nil {
+			slog.Info("pruned excess pre-migration backup", "file", name, "kept", keep)
+		}
+	}
 }
 
 // addDevicesGeneratedColumns adds the scan_attributes-derived generated columns

--- a/cmd/server/migrations_test.go
+++ b/cmd/server/migrations_test.go
@@ -17,6 +17,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/testutil"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -237,6 +240,10 @@ func TestRunMigrations_ConvertsGoStringTimestamps(t *testing.T) {
 	_, err = db.Exec(`INSERT INTO host_services (ip, service, port, updated_at) VALUES ('10.0.0.1', 'http', 80, '2026-07-25 17:30:47.80315038 +0000 UTC')`)
 	require.NoError(t, err)
 
+	// Reset the version stamp so the gated chain replays (the conversion
+	// pass below is part of the migration chain; #268 skips stamped DBs).
+	_, resetErr := db.Exec(`PRAGMA user_version = 0`)
+	require.NoError(t, resetErr)
 	require.NoError(t, runMigrations(db, dbPath))
 
 	var devUpdated, svcUpdated string
@@ -316,4 +323,71 @@ func TestConvertDashboardConfigPosition(t *testing.T) {
 	var count int
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM dashboard_configs`).Scan(&count))
 	require.Equal(t, 2, count)
+}
+
+// TestSchemaEquivalence_FreshVsMigrated (#268): a brand-new database created
+// by schema.sql alone must be structurally identical to one that went through
+// the full migration chain. This is the CI assertion that keeps the two
+// schema sources (schema.sql for fresh installs, the chain for upgrades)
+// from drifting apart: table + index DDL compared name-by-name.
+func TestSchemaEquivalence_FreshVsMigrated(t *testing.T) {
+	fresh, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	defer fresh.Close()
+
+	// Migrated: empty file, chain runs end-to-end and stamps the version.
+	migPath := filepath.Join(t.TempDir(), "mig.db")
+	migrated, err := sql.Open("sqlite", migPath)
+	require.NoError(t, err)
+	defer migrated.Close()
+	require.NoError(t, runMigrations(migrated, migPath))
+
+	dump := func(db *sql.DB) map[string]string {
+		rows, err := db.Query(`SELECT type || ':' || name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name`)
+		require.NoError(t, err)
+		defer rows.Close()
+		out := map[string]string{}
+		for rows.Next() {
+			var k, v string
+			require.NoError(t, rows.Scan(&k, &v))
+			// Normalize whitespace so formatting differences don't mask as drift.
+			out[k] = strings.Join(strings.Fields(v), " ")
+		}
+		return out
+	}
+
+	freshDump, migDump := dump(fresh), dump(migrated)
+	require.Equal(t, len(freshDump), len(migDump),
+		"object count differs: fresh=%d migrated=%d", len(freshDump), len(migDump))
+	for k, v := range freshDump {
+		mv, ok := migDump[k]
+		require.True(t, ok, "object %s missing from migrated DB", k)
+		require.Equal(t, v, mv, "DDL drift on %s", k)
+	}
+}
+
+// TestRunMigrations_VersionGateSkipsStampedDB (#268): at SchemaVersion the
+// chain is skipped entirely — observable via user_version staying put and a
+// marker table (that only the chain would create on an empty DB) staying
+// absent. The gate must not re-run idempotent steps.
+func TestRunMigrations_VersionGateSkipsStampedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gate.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// First run: empty DB, full chain, stamps the version.
+	require.NoError(t, runMigrations(db, dbPath))
+	var v int
+	require.NoError(t, db.QueryRow(`PRAGMA user_version`).Scan(&v))
+	require.Equal(t, SchemaVersion, v)
+
+	// Drop a core table, then re-run: the gate must SKIP, leaving the drop in
+	// place (pre-gate behavior would have recreated it from schema.sql).
+	_, err = db.Exec(`DROP TABLE devices`)
+	require.NoError(t, err)
+	require.NoError(t, runMigrations(db, dbPath))
+	var count int
+	require.NoError(t, db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE name='devices'`).Scan(&count))
+	require.Equal(t, 0, count, "gated run must not re-apply schema.sql")
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -839,3 +839,14 @@ CREATE TABLE IF NOT EXISTS probe_tls_certs (
 CREATE INDEX IF NOT EXISTS idx_probe_tls_certs_target ON probe_tls_certs(target_id, cert_index);
 CREATE INDEX IF NOT EXISTS idx_probe_tls_certs_expiring ON probe_tls_certs(not_after);
 
+
+-- Identity + lookup indexes (created by the migration chain on legacy DBs;
+-- listed here too so FRESH installs get the same shape — the #268 schema
+-- equivalence test asserts both paths produce identical structures).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_devices_uuid ON devices(device_uuid);
+CREATE INDEX IF NOT EXISTS idx_devices_ip_network ON devices(ip_address, network_id);
+CREATE INDEX IF NOT EXISTS idx_devices_mac_address ON devices(mac_address);
+CREATE INDEX IF NOT EXISTS idx_devices_scan_mac_expr ON devices(json_extract(scan_attributes, '$.mac'));
+CREATE INDEX IF NOT EXISTS idx_devices_scan_vendor_expr ON devices(json_extract(scan_attributes, '$.vendor'));
+CREATE INDEX IF NOT EXISTS idx_networks_name ON networks(name);
+CREATE INDEX IF NOT EXISTS idx_scan_tasks_network ON scan_tasks(network_id);

--- a/internal/api/handler/device_config_test.go
+++ b/internal/api/handler/device_config_test.go
@@ -43,11 +43,13 @@ func setupDeviceConfigHandler(t *testing.T) (h *DeviceConfigHandler, q *db.Queri
 	h = NewDeviceConfigHandler(q)
 
 	ctx := context.Background()
-	r1, err := conn.Exec(`INSERT INTO devices (name, ip_address) VALUES ('r1', '10.0.0.1')`)
+	// device_uuid is UNIQUE on fresh schemas (#268 folded the identity
+	// indexes into schema.sql) — seed distinct uuids.
+	r1, err := conn.Exec(`INSERT INTO devices (name, ip_address, device_uuid) VALUES ('r1', '10.0.0.1', 'uuid-r1')`)
 	require.NoError(t, err)
 	dev1, err = r1.LastInsertId()
 	require.NoError(t, err)
-	r2, err := conn.Exec(`INSERT INTO devices (name, ip_address) VALUES ('r2', '10.0.0.2')`)
+	r2, err := conn.Exec(`INSERT INTO devices (name, ip_address, device_uuid) VALUES ('r2', '10.0.0.2', 'uuid-r2')`)
 	require.NoError(t, err)
 	dev2, err = r2.LastInsertId()
 	require.NoError(t, err)

--- a/internal/api/routes/scope_isolation_test.go
+++ b/internal/api/routes/scope_isolation_test.go
@@ -42,9 +42,9 @@ func scopeTestDB(t *testing.T, grantNetwork1 bool) *sql.DB {
 	db := newTestDB(t)
 	_, err := db.Exec(`
 		INSERT INTO networks (id, name, cidr) VALUES (1, 'lan-1', '10.0.1.0/24'), (2, 'lan-2', '10.0.2.0/24');
-		INSERT INTO devices (id, name, ip_address, type, status, network_id) VALUES
-			(10, 'dev-in-net1', '10.0.1.5', 'pc', 'online', 1),
-			(20, 'dev-in-net2', '10.0.2.5', 'pc', 'online', 2);
+		INSERT INTO devices (id, name, ip_address, type, status, network_id, device_uuid) VALUES
+			(10, 'dev-in-net1', '10.0.1.5', 'pc', 'online', 1, 'uuid-scope-1'),
+			(20, 'dev-in-net2', '10.0.2.5', 'pc', 'online', 2, 'uuid-scope-2');
 		INSERT INTO users (id, username, email, password_hash, role) VALUES
 			(1, 'viewer1', 'v1@example.com', 'x', 'viewer'),
 			(2, 'admin1', 'a1@example.com', 'x', 'admin');

--- a/internal/service/scannerv2/configbackup/service_test.go
+++ b/internal/service/scannerv2/configbackup/service_test.go
@@ -50,7 +50,7 @@ func setupSvc(t *testing.T) (*Service, *db.Queries, *string) {
 	})
 	require.NoError(t, err)
 	// Seed a router bound to the SSH credential.
-	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand, ssh_credential_id) VALUES ('r1','router','10.0.0.1','Cisco',?)`, credID)
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand, ssh_credential_id, device_uuid) VALUES ('r1','router','10.0.0.1','Cisco',?,'cfg-r1')`, credID)
 	require.NoError(t, err)
 
 	current := "hostname r1\ninterface eth0\n ip address 10.0.0.1/24\n"
@@ -116,9 +116,9 @@ func TestService_SkipsDevicesWithoutCred(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 	queries := db.New(conn)
 	// A router with NO ssh_credential_id + a PC (wrong type) — neither is a candidate.
-	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand) VALUES ('nobody','router','10.0.0.9','Cisco')`)
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, brand, device_uuid) VALUES ('nobody','router','10.0.0.9','Cisco','cfg-nobody')`)
 	require.NoError(t, err)
-	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address) VALUES ('mypc','pc','10.0.0.10')`)
+	_, err = conn.Exec(`INSERT INTO devices (name, type, ip_address, device_uuid) VALUES ('mypc','pc','10.0.0.10','cfg-mypc')`)
 	require.NoError(t, err)
 
 	called := false

--- a/internal/service/scannerv2/reconcile/reconcile_test.go
+++ b/internal/service/scannerv2/reconcile/reconcile_test.go
@@ -34,8 +34,8 @@ func addNetwork(t *testing.T, db *sql.DB, name, cidr string) int64 {
 func addDevice(t *testing.T, db *sql.DB, ip string, networkID int64) {
 	t.Helper()
 	_, err := db.Exec(
-		`INSERT INTO devices (name, ip_address, network_id, status, type) VALUES (?, ?, ?, 'online', 'other')`,
-		ip, ip, networkID,
+		`INSERT INTO devices (name, ip_address, network_id, status, type, device_uuid) VALUES (?, ?, ?, 'online', 'other', 'rc-' || ? || '-' || ?)`,
+		ip, ip, networkID, ip, networkID,
 	)
 	require.NoError(t, err)
 }
@@ -217,11 +217,11 @@ func TestCleanupGhosts_MACFallback(t *testing.T) {
 	net62 := addNetwork(t, dbConn, "lan-62", "192.168.62.0/24")
 	net63 := addNetwork(t, dbConn, "lan-63", "192.168.63.0/24")
 	// Canonical asset on lan-63 with a MAC.
-	_, err = dbConn.Exec(`INSERT INTO devices (name, ip_address, mac_address, network_id, status, type) VALUES ('real', '192.168.63.20', 'aa:bb:cc:dd:ee:20', ?, 'online', 'other')`, net63)
+	_, err = dbConn.Exec(`INSERT INTO devices (name, ip_address, mac_address, network_id, status, type, device_uuid) VALUES ('real', '192.168.63.20', 'aa:bb:cc:dd:ee:20', ?, 'online', 'other', 'rc-real')`, net63)
 	require.NoError(t, err)
 	// Ghost on lan-62 with the SAME MAC but an IP in a THIRD subnet no network
 	// owns (10.0.0.20) — IP-containment won't find a home, but MAC will.
-	_, err = dbConn.Exec(`INSERT INTO devices (name, ip_address, mac_address, network_id, status, type) VALUES ('ghost', '10.0.0.20', 'aa:bb:cc:dd:ee:20', ?, 'online', 'other')`, net62)
+	_, err = dbConn.Exec(`INSERT INTO devices (name, ip_address, mac_address, network_id, status, type, device_uuid) VALUES ('ghost', '10.0.0.20', 'aa:bb:cc:dd:ee:20', ?, 'online', 'other', 'rc-ghost')`, net62)
 	require.NoError(t, err)
 
 	svc := New(dbConn, 0, nil, nil)
@@ -249,7 +249,7 @@ func TestCleanupReservedAddressDevices(t *testing.T) {
 
 	net63 := addNetwork(t, dbConn, "lan-63", "192.168.63.0/24")
 	seed := func(name, ip string) {
-		_, err := dbConn.Exec(`INSERT INTO devices (name, ip_address, network_id, status, type) VALUES (?, ?, ?, 'online', 'other')`, name, ip, net63)
+		_, err := dbConn.Exec(`INSERT INTO devices (name, ip_address, network_id, status, type, device_uuid) VALUES (?, ?, ?, 'online', 'other', 'rc-' || ? || '-' || ?)`, name, ip, net63, ip, net63)
 		require.NoError(t, err)
 	}
 	seed("broadcast", "192.168.63.255")

--- a/internal/service/scannerv2/store/recorddevice_ostype_test.go
+++ b/internal/service/scannerv2/store/recorddevice_ostype_test.go
@@ -78,11 +78,11 @@ func TestRecordDevice_OSType_WithCrossNetworkDuplicate(t *testing.T) {
 	// Agent-discovered row on network_id=3 (no MAC) — a distinct asset.
 	_, err := repo.db.ExecContext(ctx, `
 		INSERT INTO devices (name, type, ip_address, mac_address, status, scan_source,
-		                     scan_attributes, network_id, first_seen, last_seen,
+		                     scan_attributes, network_id, device_uuid, first_seen, last_seen,
 		                     last_scanned_at, created_at, updated_at)
 		VALUES ('.9', 'server', ?, '', 'unknown', 'scanner_v2',
-		        '{}', 3, '2026-07-09 04:00:00', '2026-07-09 04:00:00',
-		        '2026-07-09 04:39:52', '2026-07-09 04:00:00', '2026-07-09 04:00:00')`, ip)
+		        '{}', 3, ?, '2026-07-09 04:00:00', '2026-07-09 04:00:00',
+		        '2026-07-09 04:39:52', '2026-07-09 04:00:00', '2026-07-09 04:00:00')`, ip, "seed-net3-"+ip)
 	if err != nil {
 		t.Fatalf("seed network_id=3 row: %v", err)
 	}

--- a/internal/service/scannerv2/store/sqlite_test.go
+++ b/internal/service/scannerv2/store/sqlite_test.go
@@ -28,12 +28,16 @@ func newRepo(t *testing.T, opts Options) (*SQLiteRepository, context.Context) {
 func seedDeviceRow(t *testing.T, db *sql.DB, ip, mac string, networkID sql.NullInt64) int64 {
 	t.Helper()
 	now := time.Now().UTC()
+	// device_uuid is UNIQUE on fresh schemas (#268 folded the identity
+	// indexes into schema.sql): distinct deterministic uuid per seed so
+	// multi-device tests don't collide on the '' default.
+	seedUUID := "seed-" + ip + "-" + mac
 	res, err := db.Exec(`
 		INSERT INTO devices (name, type, ip_address, mac_address, status, scan_source,
-		                     scan_attributes, network_id, first_seen, last_seen,
+		                     scan_attributes, network_id, device_uuid, first_seen, last_seen,
 		                     last_scanned_at, created_at, updated_at)
-		VALUES (?, 'other', ?, ?, 'online', 'scanner_v2', '{}', ?, ?, ?, ?, ?, ?)`,
-		ip, ip, mac, networkID, now, now, now, now, now)
+		VALUES (?, 'other', ?, ?, 'online', 'scanner_v2', '{}', ?, ?, ?, ?, ?, ?, ?)`,
+		ip, ip, mac, networkID, seedUUID, now, now, now, now, now)
 	if err != nil {
 		t.Fatalf("seed device row: %v", err)
 	}


### PR DESCRIPTION
Closes #268。采用 PRAGMA user_version（SQLite 官方推荐的库内版本位）而非独立 schema_version 表 —— 零额外对象、原子读取。迁移链保持 Go 代码形态（既有 probe-first 习语），版本号作为外层门控。

## 版本门控

- `SchemaVersion = 1`（当前代际，含到渠道 CHECK 加宽为止的全部步骤）
- 同版本 → **跳过整条链**：不再每启动 VACUUM INTO 备份、不再数百条幂等探测语句 —— 启动从"全链重放"变一次 PRAGMA 读
- 降级二进制（库版本 > 二进制）→ 拒绝迁移并告警（链只写了前进方向）
- 中途失败不落版本号 → 下次启动幂等重放（每步本就幂等，双保险）

## 备份保留策略

数量制 `pruneExcessBackups`（最多保留 3 份最新，文件名时间戳即排序键）叠加既有 7 天年龄制。解决 issue 点名的"22 个 pre-migration 副本堆积"：备份现在只在真实迁移时发生（版本门控副产）+ 硬上限兜底。

## 等价性断言（issue 验收第 3 条）

`TestSchemaEquivalence_FreshVsMigrated`：全新库走迁移链 vs schema.sql 直建 → sqlite_master 表+索引 DDL 逐对象比对。**落地即抓到真实缺口**：迁移链建的 7 个索引（`idx_devices_uuid`(UNIQUE)/`idx_devices_ip_network`(UNIQUE)/`idx_devices_mac_address`/scan_mac·scan_vendor 表达式索引/`idx_networks_name`/`idx_scan_tasks_network`）从未进 schema.sql —— **新装库一直缺这些查询路径索引**。已全部补入 schema.sql；旧库兼容经两个前置 ALTER（network_id 列先于 schema 内索引）。

## 测试适配

device_uuid 在新装库上成为 UNIQUE（补入 schema.sql 的连锁语义）后，6 个文件的多设备测试种子补确定性 uuid（`seedDeviceRow` 助手自动生成 ip+mac 派生值）；`TestRunMigrations_VersionGateSkipsStampedDB` 锁定门控语义（已盖章库不重放 schema）。全套 `go test ./...` + golangci-lint 0 issues。