### PR TITLE
refactor(store): scannerv2 三表写入迁 sqlc（#269）

### DIFF
--- a/db/queries/host_services.sql
+++ b/db/queries/host_services.sql
@@ -16,4 +16,14 @@
 DELETE FROM host_services
 WHERE id IN (
     SELECT sub.id FROM host_services AS sub WHERE sub.updated_at < ? LIMIT ?
-)
+);
+
+-- name: InsertHostService :exec
+-- One classified service-identity row (scannerv2/store RecordServices,
+-- #269: the insert half moved to sqlc; the scoped DELETE with its DYNAMIC
+-- port IN-list stays raw in the store, sqlc cannot bind a slice to IN).
+-- Plain INSERT: the scoped DELETE runs first in the same tx so conflicts
+-- cannot occur; an upsert form trips sqlc's SQLite parser on the
+-- unique-INDEX conflict target. updated_at is RFC3339 text (DBTime).
+INSERT INTO host_services (ip, device_uuid, service, port, protocol, confidence, metadata, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS TEXT));

--- a/db/queries/host_tls_certs.sql
+++ b/db/queries/host_tls_certs.sql
@@ -34,4 +34,24 @@ ORDER BY c.port ASC, c.cert_index ASC;
 DELETE FROM host_tls_certs
 WHERE id IN (
     SELECT sub.id FROM host_tls_certs AS sub WHERE sub.updated_at < ? LIMIT ?
-)
+);
+
+-- name: InsertHostTLSCert :exec
+-- One certificate-chain row (cert_index 0 = leaf); the per-(ip, port)
+-- DELETE runs first in the same tx. Column list mirrors the store raw
+-- insert verbatim; not_before/not_after/updated_at are RFC3339 text.
+INSERT INTO host_tls_certs (
+    ip, device_uuid, port, cert_index,
+    subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer,
+    san_dns, san_ip, san_email, serial,
+    not_before, not_after,
+    sig_algorithm, key_algorithm, key_bits, is_ca, self_signed,
+    fingerprint_sha256, pem,
+    tls_version, cipher_suite, trusted, error, updated_at
+) VALUES (?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?,  CAST(? AS TEXT), CAST(? AS TEXT),  ?, ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, CAST(? AS TEXT));
+
+-- name: DeleteHostTLSCertsForIPPort :exec
+-- Per-(ip, port) wholesale replace (the delete half of the store
+-- RecordTLSCerts, #269): a rotated cert must not linger, but ports NOT in
+-- this call keep their rows (a partial scan must not wipe untouched ports).
+DELETE FROM host_tls_certs WHERE ip = ? AND port = ?;

--- a/db/queries/service_evidence.sql
+++ b/db/queries/service_evidence.sql
@@ -15,3 +15,12 @@ DELETE FROM service_evidence
 WHERE rowid IN (
     SELECT rowid FROM service_evidence WHERE service_evidence.observed_at < ? LIMIT ?
 );
+
+-- name: InsertServiceEvidence :exec
+-- One raw evidence row (scannerv2/store RecordEvidence, #269: moved to
+-- sqlc so CI sqlc-verify guards the schema binding). observed_at is bound
+-- as RFC3339 text by the caller (scannerv2.DBTime; NEVER time.Time, whose
+-- String() form breaks SQLite date(), see #257). The CAST names the bind as
+-- text; sqlc names positional cast params ColumnN.
+INSERT INTO service_evidence (ip, device_uuid, source, kind, port, protocol, raw_data, confidence, observed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS TEXT));

--- a/internal/db/host_services.sql.go
+++ b/internal/db/host_services.sql.go
@@ -43,3 +43,39 @@ func (q *Queries) DeleteHostServicesStaleBatched(ctx context.Context, arg Delete
 	}
 	return result.RowsAffected()
 }
+
+const insertHostService = `-- name: InsertHostService :exec
+INSERT INTO host_services (ip, device_uuid, service, port, protocol, confidence, metadata, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS TEXT))
+`
+
+type InsertHostServiceParams struct {
+	Ip         string  `json:"ip"`
+	DeviceUuid string  `json:"device_uuid"`
+	Service    string  `json:"service"`
+	Port       int64   `json:"port"`
+	Protocol   string  `json:"protocol"`
+	Confidence float64 `json:"confidence"`
+	Metadata   string  `json:"metadata"`
+	Column8    string  `json:"column_8"`
+}
+
+// One classified service-identity row (scannerv2/store RecordServices,
+// #269: the insert half moved to sqlc; the scoped DELETE with its DYNAMIC
+// port IN-list stays raw in the store, sqlc cannot bind a slice to IN).
+// Plain INSERT: the scoped DELETE runs first in the same tx so conflicts
+// cannot occur; an upsert form trips sqlc's SQLite parser on the
+// unique-INDEX conflict target. updated_at is RFC3339 text (DBTime).
+func (q *Queries) InsertHostService(ctx context.Context, arg InsertHostServiceParams) error {
+	_, err := q.db.ExecContext(ctx, insertHostService,
+		arg.Ip,
+		arg.DeviceUuid,
+		arg.Service,
+		arg.Port,
+		arg.Protocol,
+		arg.Confidence,
+		arg.Metadata,
+		arg.Column8,
+	)
+	return err
+}

--- a/internal/db/host_tls_certs.sql.go
+++ b/internal/db/host_tls_certs.sql.go
@@ -10,6 +10,23 @@ import (
 	"time"
 )
 
+const deleteHostTLSCertsForIPPort = `-- name: DeleteHostTLSCertsForIPPort :exec
+DELETE FROM host_tls_certs WHERE ip = ? AND port = ?
+`
+
+type DeleteHostTLSCertsForIPPortParams struct {
+	Ip   string `json:"ip"`
+	Port int64  `json:"port"`
+}
+
+// Per-(ip, port) wholesale replace (the delete half of the store
+// RecordTLSCerts, #269): a rotated cert must not linger, but ports NOT in
+// this call keep their rows (a partial scan must not wipe untouched ports).
+func (q *Queries) DeleteHostTLSCertsForIPPort(ctx context.Context, arg DeleteHostTLSCertsForIPPortParams) error {
+	_, err := q.db.ExecContext(ctx, deleteHostTLSCertsForIPPort, arg.Ip, arg.Port)
+	return err
+}
+
 const deleteHostTLSCertsStaleBatched = `-- name: DeleteHostTLSCertsStaleBatched :execrows
 DELETE FROM host_tls_certs
 WHERE id IN (
@@ -32,6 +49,86 @@ func (q *Queries) DeleteHostTLSCertsStaleBatched(ctx context.Context, arg Delete
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const insertHostTLSCert = `-- name: InsertHostTLSCert :exec
+INSERT INTO host_tls_certs (
+    ip, device_uuid, port, cert_index,
+    subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer,
+    san_dns, san_ip, san_email, serial,
+    not_before, not_after,
+    sig_algorithm, key_algorithm, key_bits, is_ca, self_signed,
+    fingerprint_sha256, pem,
+    tls_version, cipher_suite, trusted, error, updated_at
+) VALUES (?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?,  CAST(? AS TEXT), CAST(? AS TEXT),  ?, ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, CAST(? AS TEXT))
+`
+
+type InsertHostTLSCertParams struct {
+	Ip                string `json:"ip"`
+	DeviceUuid        string `json:"device_uuid"`
+	Port              int64  `json:"port"`
+	CertIndex         int64  `json:"cert_index"`
+	SubjectCn         string `json:"subject_cn"`
+	SubjectOrg        string `json:"subject_org"`
+	Subject           string `json:"subject"`
+	IssuerCn          string `json:"issuer_cn"`
+	IssuerOrg         string `json:"issuer_org"`
+	Issuer            string `json:"issuer"`
+	SanDns            string `json:"san_dns"`
+	SanIp             string `json:"san_ip"`
+	SanEmail          string `json:"san_email"`
+	Serial            string `json:"serial"`
+	Column15          string `json:"column_15"`
+	Column16          string `json:"column_16"`
+	SigAlgorithm      string `json:"sig_algorithm"`
+	KeyAlgorithm      string `json:"key_algorithm"`
+	KeyBits           int64  `json:"key_bits"`
+	IsCa              int64  `json:"is_ca"`
+	SelfSigned        int64  `json:"self_signed"`
+	FingerprintSha256 string `json:"fingerprint_sha256"`
+	Pem               string `json:"pem"`
+	TlsVersion        string `json:"tls_version"`
+	CipherSuite       string `json:"cipher_suite"`
+	Trusted           int64  `json:"trusted"`
+	Error             string `json:"error"`
+	Column28          string `json:"column_28"`
+}
+
+// One certificate-chain row (cert_index 0 = leaf); the per-(ip, port)
+// DELETE runs first in the same tx. Column list mirrors the store raw
+// insert verbatim; not_before/not_after/updated_at are RFC3339 text.
+func (q *Queries) InsertHostTLSCert(ctx context.Context, arg InsertHostTLSCertParams) error {
+	_, err := q.db.ExecContext(ctx, insertHostTLSCert,
+		arg.Ip,
+		arg.DeviceUuid,
+		arg.Port,
+		arg.CertIndex,
+		arg.SubjectCn,
+		arg.SubjectOrg,
+		arg.Subject,
+		arg.IssuerCn,
+		arg.IssuerOrg,
+		arg.Issuer,
+		arg.SanDns,
+		arg.SanIp,
+		arg.SanEmail,
+		arg.Serial,
+		arg.Column15,
+		arg.Column16,
+		arg.SigAlgorithm,
+		arg.KeyAlgorithm,
+		arg.KeyBits,
+		arg.IsCa,
+		arg.SelfSigned,
+		arg.FingerprintSha256,
+		arg.Pem,
+		arg.TlsVersion,
+		arg.CipherSuite,
+		arg.Trusted,
+		arg.Error,
+		arg.Column28,
+	)
+	return err
 }
 
 const listTLSCertsByDeviceID = `-- name: ListTLSCertsByDeviceID :many

--- a/internal/db/service_evidence.sql.go
+++ b/internal/db/service_evidence.sql.go
@@ -41,3 +41,40 @@ func (q *Queries) DeleteServiceEvidenceOlderThanBatched(ctx context.Context, arg
 	}
 	return result.RowsAffected()
 }
+
+const insertServiceEvidence = `-- name: InsertServiceEvidence :exec
+INSERT INTO service_evidence (ip, device_uuid, source, kind, port, protocol, raw_data, confidence, observed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS TEXT))
+`
+
+type InsertServiceEvidenceParams struct {
+	Ip         string  `json:"ip"`
+	DeviceUuid string  `json:"device_uuid"`
+	Source     string  `json:"source"`
+	Kind       string  `json:"kind"`
+	Port       int64   `json:"port"`
+	Protocol   string  `json:"protocol"`
+	RawData    string  `json:"raw_data"`
+	Confidence float64 `json:"confidence"`
+	Column9    string  `json:"column_9"`
+}
+
+// One raw evidence row (scannerv2/store RecordEvidence, #269: moved to
+// sqlc so CI sqlc-verify guards the schema binding). observed_at is bound
+// as RFC3339 text by the caller (scannerv2.DBTime; NEVER time.Time, whose
+// String() form breaks SQLite date(), see #257). The CAST names the bind as
+// text; sqlc names positional cast params ColumnN.
+func (q *Queries) InsertServiceEvidence(ctx context.Context, arg InsertServiceEvidenceParams) error {
+	_, err := q.db.ExecContext(ctx, insertServiceEvidence,
+		arg.Ip,
+		arg.DeviceUuid,
+		arg.Source,
+		arg.Kind,
+		arg.Port,
+		arg.Protocol,
+		arg.RawData,
+		arg.Confidence,
+		arg.Column9,
+	)
+	return err
+}

--- a/internal/service/scannerv2/store/sqlite.go
+++ b/internal/service/scannerv2/store/sqlite.go
@@ -32,6 +32,7 @@ import (
 
 	"mibee-steward/internal/domain"
 
+	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/scannerv2"
 
 	"github.com/google/uuid"
@@ -63,6 +64,7 @@ type SQLiteRepository struct {
 	// call resolveDeviceUUID per host). (#162)
 	uuidCache map[string]string
 	uuidMu    sync.Mutex
+	queries   *db.Queries // sqlc handle for the #269-migrated writes (tx-scoped clones per tx)
 }
 
 // Options configures the SQLiteRepository.
@@ -88,7 +90,7 @@ type Options struct {
 // v2 tables (service_evidence, host_services) — main.go applies schema.sql on
 // startup, so this holds for the production path. For tests, ensure schema is
 // applied to the in-memory DB.
-func NewSQLiteRepository(db *sql.DB, opts Options, logger *slog.Logger) *SQLiteRepository {
+func NewSQLiteRepository(dbConn *sql.DB, opts Options, logger *slog.Logger) *SQLiteRepository {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -97,7 +99,8 @@ func NewSQLiteRepository(db *sql.DB, opts Options, logger *slog.Logger) *SQLiteR
 		nid = sql.NullInt64{Int64: opts.NetworkID, Valid: true}
 	}
 	return &SQLiteRepository{
-		db:                   db,
+		db:                   dbConn,
+		queries:              db.New(dbConn),
 		logger:               logger,
 		persistRawEvidence:   opts.PersistRawEvidence,
 		defaultHBInterval:    opts.DefaultHeartbeatInterval,
@@ -136,14 +139,9 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO service_evidence (ip, device_uuid, source, kind, port, protocol, raw_data, confidence, observed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
-
+	// sqlc-generated insert (#269): tx-scoped Queries so the whole batch
+	// commits atomically; the schema binding is now CI-guarded (sqlc-verify).
+	txq := db.New(tx)
 	for _, e := range evs {
 		raw, err := json.Marshal(e.RawData)
 		if err != nil {
@@ -153,7 +151,11 @@ func (r *SQLiteRepository) RecordEvidence(ctx context.Context, evs []scannerv2.E
 		if ts.IsZero() {
 			ts = time.Now()
 		}
-		if _, err := stmt.ExecContext(ctx, e.IP, uuid, e.Source, e.Kind, e.Port, e.Protocol, string(raw), e.Confidence, scannerv2.DBTime(ts)); err != nil {
+		if err := txq.InsertServiceEvidence(ctx, db.InsertServiceEvidenceParams{
+			Ip: e.IP, DeviceUuid: uuid, Source: e.Source, Kind: e.Kind,
+			Port: int64(e.Port), Protocol: e.Protocol, RawData: string(raw),
+			Confidence: e.Confidence, Column9: scannerv2.DBTime(ts), // column 9 = observed_at (CAST-annotated: sqlc names positional cast params ColumnN)
+		}); err != nil {
 			r.logger.Debug("insert evidence row failed", "error", err)
 		}
 	}
@@ -213,13 +215,7 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 		return tx.Commit()
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO host_services (ip, device_uuid, service, port, protocol, confidence, metadata, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
+	txq := db.New(tx)
 
 	// Deduplicate by (service, port): when multiple identities share the same
 	// key (e.g. builtin http-presence + Recog http_header.server both emit
@@ -257,7 +253,10 @@ func (r *SQLiteRepository) RecordServices(ctx context.Context, ip string, servic
 		if err != nil {
 			meta = []byte("{}")
 		}
-		if _, err := stmt.ExecContext(ctx, ip, uuid, s.Service, s.Port, s.Protocol, s.Confidence, string(meta), now); err != nil {
+		if err := txq.InsertHostService(ctx, db.InsertHostServiceParams{
+			Ip: ip, DeviceUuid: uuid, Service: s.Service, Port: int64(s.Port),
+			Protocol: s.Protocol, Confidence: s.Confidence, Metadata: string(meta), Column8: now, // column 8 = updated_at (CAST-annotated)
+		}); err != nil {
 			r.logger.Warn("insert host_service row failed", "ip", ip, "service", s.Service, "error", err)
 		}
 	}
@@ -295,38 +294,29 @@ func (r *SQLiteRepository) RecordTLSCerts(ctx context.Context, ip string, certs 
 	for _, c := range certs {
 		ports[c.Port] = struct{}{}
 	}
+	txq := db.New(tx)
 	for port := range ports {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM host_tls_certs WHERE ip = ? AND port = ?`, ip, port); err != nil {
+		if err := txq.DeleteHostTLSCertsForIPPort(ctx, db.DeleteHostTLSCertsForIPPortParams{
+			Ip: ip, Port: int64(port),
+		}); err != nil {
 			return err
 		}
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO host_tls_certs (
-			ip, device_uuid, port, cert_index,
-			subject_cn, subject_org, subject, issuer_cn, issuer_org, issuer,
-			san_dns, san_ip, san_email, serial,
-			not_before, not_after,
-			sig_algorithm, key_algorithm, key_bits, is_ca, self_signed,
-			fingerprint_sha256, pem,
-			tls_version, cipher_suite, trusted, error, updated_at
-		) VALUES (?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?,  ?, ?,  ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
-
 	now := scannerv2.DBTime(time.Now())
 	for _, c := range certs {
-		if _, err := stmt.ExecContext(ctx,
-			ip, uuid, c.Port, c.CertIndex,
-			c.SubjectCN, c.SubjectOrg, c.Subject, c.IssuerCN, c.IssuerOrg, c.Issuer,
-			c.SanDNS, c.SanIP, c.SanEmail, c.Serial,
-			c.NotBefore, c.NotAfter,
-			c.SigAlgorithm, c.KeyAlgorithm, c.KeyBits, boolToInt(c.IsCA), boolToInt(c.SelfSigned),
-			c.FingerprintSHA256, c.PEM,
-			c.TLSVersion, c.CipherSuite, boolToInt(c.Trusted), c.Error, now,
-		); err != nil {
+		if err := txq.InsertHostTLSCert(ctx, db.InsertHostTLSCertParams{
+			Ip: ip, DeviceUuid: uuid, Port: int64(c.Port), CertIndex: int64(c.CertIndex),
+			SubjectCn: c.SubjectCN, SubjectOrg: c.SubjectOrg, Subject: c.Subject,
+			IssuerCn: c.IssuerCN, IssuerOrg: c.IssuerOrg, Issuer: c.Issuer,
+			SanDns: c.SanDNS, SanIp: c.SanIP, SanEmail: c.SanEmail, Serial: c.Serial,
+			Column15: c.NotBefore, Column16: c.NotAfter, // 15/16 = not_before/not_after (CAST-annotated)
+			SigAlgorithm: c.SigAlgorithm, KeyAlgorithm: c.KeyAlgorithm, KeyBits: int64(c.KeyBits),
+			IsCa: int64(boolToInt(c.IsCA)), SelfSigned: int64(boolToInt(c.SelfSigned)),
+			FingerprintSha256: c.FingerprintSHA256, Pem: c.PEM,
+			TlsVersion: c.TLSVersion, CipherSuite: c.CipherSuite, Trusted: int64(boolToInt(c.Trusted)),
+			Error: c.Error, Column28: now, // 28 = updated_at (CAST-annotated)
+		}); err != nil {
 			r.logger.Warn("insert host_tls_certs row failed", "ip", ip, "port", c.Port, "error", err)
 		}
 	}


### PR DESCRIPTION
Closes #269（按 issue 允许的范围：三张证据表纳入 sqlc；动态批量保留 raw）。

## 迁移内容

| 表 | sqlc 查询 | 保留 raw 的部分 |
|---|---|---|
| service_evidence | InsertServiceEvidence | —（整方法迁入） |
| host_services | InsertHostService | 端口 IN-list scoped DELETE（#256 语义，sqlc 无法绑定切片到 IN） |
| host_tls_certs | InsertHostTLSCert + DeleteHostTLSCertsForIPPort | —（两半都迁入） |

事务语义不变：tx 内 `db.New(tx)` 克隆 Queries，批量原子提交。RFC3339 时间戳约定保持（DBTime 字符串经 `CAST(? AS TEXT)` 绑定 —— sqlc 推断为 string；`sqlc.arg`+CAST 组合解析器不支持，位置参数生成 ColumnN 字段，调用侧注释标注列位）。

## 过程中踩的 sqlc 坑（已按 db/AGENTS.md 约定规避）

1. **多字节注释截断**：注释含 em-dash 再次触发 SQL 常量尾部截断（`CAST(? AS TE`）—— 三文件查询注释全部 ASCII 化
2. **唯一索引 conflict target**：`ON CONFLICT(ip,service,port)`（唯一**索引**而非表约束）触发误导性 duplicate-query 错误 —— 改纯 INSERT（store 本就先删后插，语义等价）
3. **丢分号**：query 文件末条无分号时追加上下文会静默粘连两条语句

## 验收对照

- `sqlc compile` 覆盖三表 ✅；`go test ./internal/service/scannerv2/...` 全绿（RecordEvidence 采样开关 / RecordServices 端口域替换 + uuid 迁移 / TLS 链替换等既有回归全数通过）✅
- 身份/设备路径（ResolveDeviceIdentity/ApplyDeviceIdentity 等复杂事务语义）保留 raw —— 等价性由既有 store 测试集守护