### PR TITLE
feat(deploy/openwrt): doctor ICMP 检查 + GL 固件排障文档（#288 问题2 落地）

### DIFF
--- a/cmd/server/doctor.go
+++ b/cmd/server/doctor.go
@@ -247,6 +247,30 @@ func doctor(args []string) int {
 		checks = append(checks, doctorCheck{name: "center reachable", status: "skip", detail: "not an agent config (center.url unset)"})
 	}
 
+	// ICMP capability (#288): the scanner and heartbeat use unprivileged
+	// ICMP (pro-bing SetPrivileged(false)) — datagram ping sockets require
+	// the group to be inside /proc/sys/net/ipv4/ping_group_range. The OpenWrt
+	// default "1 0" (disabled) leaves every probe "permission denied".
+	if raw, err := os.ReadFile("/proc/sys/net/ipv4/ping_group_range"); err == nil {
+		var lo, hi int
+		if n, _ := fmt.Sscanf(strings.TrimSpace(string(raw)), "%d %d", &lo, &hi); n == 2 {
+			gid := os.Getgid()
+			switch {
+			case lo > hi:
+				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "fail",
+					detail:  fmt.Sprintf("disabled (%s) — unprivileged ICMP probes will fail", strings.TrimSpace(string(raw))),
+					fixHint: `echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range (or add to sysctl.d; required for ICMP without root)`})
+			case gid >= lo && gid <= hi:
+				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "ok",
+					detail: fmt.Sprintf("gid %d within [%d %d]", gid, lo, hi)})
+			default:
+				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "warn",
+					detail:  fmt.Sprintf("service gid %d outside [%d %d]", gid, lo, hi),
+					fixHint: "widen ping_group_range or run the service under a covered group"})
+			}
+		}
+	}
+
 	printReport(checks)
 	for _, c := range checks {
 		if c.status == "fail" {

--- a/deploy/openwrt/README.md
+++ b/deploy/openwrt/README.md
@@ -106,6 +106,31 @@ All four are **shared across forms B and C** (and form A — center on a generic
 **Operator setup for `dns_log`:** enable dnsmasq query logging —
 `uci set dhcp.@dnsmasq[0].logqueries=1 && uci commit && /etc/init.d/dnsmasq restart`. Point `scanner.discovery.dns_log.path` at the resulting log (or leave empty to probe the conventional paths).
 
+## Operator prerequisites (GL.iNet / vendor SDK firmware)
+
+Two firmware-level settings materially affect MiBee on router deployments. `mibee-steward doctor` checks both.
+
+### ICMP without root: `ping_group_range`
+
+MiBee's ICMP probes use **unprivileged datagram ping sockets** (no CAP_NET_RAW needed). The kernel only allows these for groups inside `/proc/sys/net/ipv4/ping_group_range`, and OpenWrt's default (`1 0`) disables them entirely — every probe fails with `permission denied`. Fix once:
+
+```sh
+echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range
+# persist: echo 'net.ipv4.ping_group_range = 0 2147483647' > /etc/sysctl.d/99-mibee.conf
+```
+
+### fw3 `syn_flood` chain throttles LAN-side TCP (GL.iNet SDK firmwares)
+
+GL firmwares ship fw3 with SYN-flood protection enabled: every TCP SYN (loopback included) passes a **global 25/s, burst-50 token bucket** before the accept rules. MiBee's heartbeat port checks + probe fan-out + local API traffic can exhaust the bucket; once it empties, **new TCP connections to ANY local port are silently dropped** — the symptom looks exactly like a broken listener (SYN arrives, no SYN-ACK). If you see intermittent connection timeouts to the router's own services, disable SYN-flood protection in LuCI (Network → Firewall → Traffic Rules → SYN-flood protection), or:
+
+```sh
+uci set firewall.@defaults[0].synflood_protect=0 && uci commit firewall && /etc/init.d/firewall restart
+```
+
+### Known limitation on GL.iNet MT2500 (mt7981, kernel 5.4.211 SDK): v4 TCP listeners
+
+Field diagnosis (see issue #288) on the stock firmware shows **newly-created IPv4 TCP listeners never complete handshakes** — SYNs reach the stack, but no SYN-ACK leaves (loopback captures show the SYN-ACK leaving with an **unfilled `0.0.0.0` address**, which the peer then RSTs). This affects ANY new listener (Go and C alike — the router's own LuCI is affected from off-box too), while IPv6 listeners work perfectly and pre-existing services keep working. Ruled out: iptables filter/nat/raw/mangle, policy routing (zerotier's `iif lo` rule), loopback offloads, conntrack saturation, and `mtkhnat` (rmmod doesn't restore v4). Until the vendor kernel bug is understood, **form C on this specific firmware is not viable on v4** — bind v6 (`server.host: "::"`) or run the center elsewhere and use form B (agent on the router).
+
 ## Troubleshooting
 
 | Symptom | Cause / fix |
@@ -115,6 +140,8 @@ All four are **shared across forms B and C** (and form A — center on a generic
 | `mmap: access denied` at startup | Kernel disallows the mmap SQLite wants — run as root (the procd script does) or check the router's seccomp/apparmor. |
 | Discovery sources all no-op | Expected on a non-router host. On a router, check each source's prereq (dnsmasq running, `nf_conntrack` loaded, hostapd ctrl_interface enabled). |
 | `unsupported GOARCH mips` at build | MIPS isn't supported (modernc/libc limitation). Use an ARM/ARM64 router. |
+| ICMP probes all `permission denied` | `ping_group_range` disabled — see the operator prerequisites above. |
+| Intermittent silent connection drops to the router's own ports | fw3 `syn_flood` token bucket exhausted — see the operator prerequisites above. |
 
 ## What's NOT covered here
 


### PR DESCRIPTION
#288 的问题 2（ICMP ping_group_range）落地为自动检查 + 文档；问题 1（v4 监听器）完成一轮深度真机诊断（见 issue 评论），当前结论与绕行方案写入文档。

## doctor：icmp ping_group_range

- 禁用（`1 0`）→ **fail** + 修复命令提示（echo/sysctl.d）
- 服务 gid 越界 → warn
- 覆盖 → ok
- **真机验证**：MT2500 固件上输出 `✅ icmp ping_group_range gid 0 within [0 65535]`

## openwrt README：Operator prerequisites 节

1. ping_group_range 永久化（ICMP 探测是扫描+心跳主力，OpenWrt 默认全禁）
2. **fw3 syn_flood 令牌桶**（GL 固件默认开）：全局 25/s burst-50，超限后本机任意端口新 TCP 连接静默丢弃 —— 心跳/拨测高频 TCP 场景的实际风险 + 关闭指引
3. MT2500 v4 监听器缺陷实证记录：新监听（Go 与 C 一致）握手不完整 —— SYN 到达但 SYN-ACK 不出（lo 上抓到**未填地址的 0.0.0.0 SYN-ACK** 被对端 RST）；已排除 iptables 全表/策略路由/lo offload/conntrack 满/mtkhnat（rmmod 对照）；v6 全正常；**form C 在该固件上绕行 = v6 绑定或 form B**