### PR TITLE
feat(documents): Markdown 上传与渲染 + 文档功能 P0 修复四项

### DIFF
--- a/cmd/server/migrations.go
+++ b/cmd/server/migrations.go
@@ -157,6 +157,10 @@ func runMigrations(db *sql.DB, dbPath string) error {
 		// backup probe (#137). NULL = not config-backed-up. SET NULL on credential
 		// delete so the device row survives (backup just pauses for it).
 		"ALTER TABLE devices ADD COLUMN ssh_credential_id INTEGER REFERENCES ssh_credentials(id) ON DELETE SET NULL",
+		// documents.deleted_at: soft-delete tombstone backing the UI's
+		// delete-undo (POST /documents/{id}/restore). Reads filter on it; the
+		// uploaded file stays on disk so restore is lossless.
+		"ALTER TABLE documents ADD COLUMN deleted_at TIMESTAMP",
 		// Dual JSON layer (scan_attributes + user_attributes). Generated columns
 		// (scan_vendor/scan_mac/scan_os/scan_hostname) can't be added via ALTER
 		// on existing DBs — those are only present on fresh installs. For

--- a/db/queries/device_documents.sql
+++ b/db/queries/device_documents.sql
@@ -16,13 +16,14 @@ DELETE FROM device_documents
 WHERE device_id = ? AND document_id = ?;
 
 -- name: GetDeviceDocuments :many
-SELECT d.id, d.title, d.type, d.url, d.file_path, d.file_size, d.mime_type, d.description, d.created_at, d.updated_at
+SELECT d.id, d.title, d.type, d.url, d.file_path, d.file_size, d.mime_type, d.description, d.deleted_at, d.created_at, d.updated_at
 FROM documents d
 JOIN device_documents dd ON d.id = dd.document_id
-WHERE dd.device_id = ?;
+WHERE dd.device_id = ? AND d.deleted_at IS NULL;
 
 -- name: GetDocumentDevices :many
 SELECT dv.id, dv.name, dv.type, dv.brand, dv.model, dv.location, dv.purpose, dv.description, dv.status, dv.ip_address, dv.mac_address, dv.serial_number, dv.purchase_date, dv.warranty_expiry, dv.tags, dv.created_at, dv.updated_at
 FROM devices dv
 JOIN device_documents dd ON dv.id = dd.device_id
-WHERE dd.document_id = ?;
+JOIN documents d ON d.id = dd.document_id
+WHERE dd.document_id = ? AND d.deleted_at IS NULL;

--- a/db/queries/documents.sql
+++ b/db/queries/documents.sql
@@ -10,33 +10,42 @@
 -- name: CreateDocument :one
 INSERT INTO documents (title, type, url, file_path, file_size, mime_type, description)
 VALUES (?, ?, ?, ?, ?, ?, ?)
-RETURNING id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at;
+RETURNING id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at;
 
 -- name: GetDocument :one
-SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+SELECT id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 FROM documents
-WHERE id = ?;
+WHERE id = ? AND deleted_at IS NULL;
 
 -- name: ListDocuments :many
 -- Search is a substring match across title/description/type (case-insensitive).
 -- INSTR pattern (see ListUsers for rationale).
-SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+SELECT id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 FROM documents
-WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
+WHERE deleted_at IS NULL AND (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?;
 
 -- name: CountDocuments :one
 -- Mirrors ListDocuments WHERE so the page total reflects the active search.
 SELECT COUNT(*) FROM documents
-WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0);
+WHERE deleted_at IS NULL AND (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0);
 
 -- name: UpdateDocument :one
 UPDATE documents
 SET title = ?, type = ?, url = ?, file_path = ?, file_size = ?, mime_type = ?, description = ?, updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
-RETURNING id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at;
+WHERE id = ? AND deleted_at IS NULL
+RETURNING id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at;
 
 -- name: DeleteDocument :execrows
-DELETE FROM documents
-WHERE id = ?;
+-- Soft delete: stamp the tombstone, keep the row (and its file on disk) so
+-- POST /documents/{id}/restore can undo. Physical purge is a later concern.
+UPDATE documents
+SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+WHERE id = ? AND deleted_at IS NULL;
+
+-- name: RestoreDocument :execrows
+-- Undo a soft delete (the UI's delete-undo toast). Only clears the tombstone.
+UPDATE documents
+SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP
+WHERE id = ? AND deleted_at IS NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -122,6 +122,9 @@ CREATE TABLE IF NOT EXISTS devices (
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 -- Documents table
+-- deleted_at: soft-delete tombstone. DELETE /documents/{id} only stamps it
+-- (so the UI's undo/restore can bring the row + its file back); all read
+-- queries filter on it. Physical purge is a later retention concern.
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
@@ -131,6 +134,7 @@ CREATE TABLE IF NOT EXISTS documents (
     file_size INTEGER NOT NULL DEFAULT 0,
     mime_type TEXT NOT NULL DEFAULT '',
     description TEXT NOT NULL DEFAULT '',
+    deleted_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/internal/api/handler/document.go
+++ b/internal/api/handler/document.go
@@ -48,6 +48,10 @@ func (h *DocumentHandler) CreateURL(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.svc.CreateURL(r.Context(), req)
 	if err != nil {
+		if errors.Is(err, service.ErrTitleRequired) || errors.Is(err, service.ErrURLRequired) {
+			Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		Error(w, http.StatusInternalServerError, "failed to create document")
 		return
 	}
@@ -77,7 +81,18 @@ func (h *DocumentHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.svc.UploadFile(r.Context(), file, header, title, description)
 	if err != nil {
 		slog.Error("failed to upload file", "error", err)
-		Error(w, http.StatusInternalServerError, "failed to upload file")
+		// Client-fixable rejections surface as their real reason + status —
+		// a blanket 500 hid WHY the file was refused.
+		switch {
+		case errors.Is(err, service.ErrFileTooLarge):
+			Error(w, http.StatusRequestEntityTooLarge, err.Error())
+		case errors.Is(err, service.ErrFileTypeNotAllowed):
+			Error(w, http.StatusUnsupportedMediaType, err.Error())
+		case errors.Is(err, service.ErrFileMismatch), errors.Is(err, service.ErrTitleRequired):
+			Error(w, http.StatusBadRequest, err.Error())
+		default:
+			Error(w, http.StatusInternalServerError, "failed to upload file")
+		}
 		return
 	}
 
@@ -141,7 +156,7 @@ func (h *DocumentHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filePath, err := h.svc.GetFilePath(r.Context(), id)
+	filePath, mimeType, err := h.svc.GetFile(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, service.ErrDocumentNotFound) {
 			Error(w, http.StatusNotFound, "document not found")
@@ -186,8 +201,59 @@ func (h *DocumentHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filePath)))
+	// Pin Content-Type to the upload-validated MIME type. Letting
+	// http.ServeFile sniff would serve an HTML-flavored .md as text/html —
+	// XSS-same-origin on inline preview. Combined with the global nosniff
+	// header, the stored type is authoritative.
+	if mimeType != "" {
+		w.Header().Set("Content-Type", mimeType)
+	}
+
+	// ?inline=1 switches the disposition for embedded previews (PDF iframe,
+	// img): browsers refuse to RENDER an attachment inside a navigation
+	// context and silently fall back to download. Plain downloads keep
+	// attachment (the default), which also stays the safe choice for types
+	// a browser might execute if sniffed wrong.
+	disposition := "attachment"
+	if r.URL.Query().Get("inline") == "1" {
+		disposition = "inline"
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename=%s", disposition, filepath.Base(filePath)))
 	http.ServeFile(w, r, filePath)
+}
+
+// Restore handles POST /api/v1/documents/{id}/restore — undo a soft delete
+// (the UI's delete-undo toast). Only clears the tombstone; the row and its
+// uploaded file were kept.
+func (h *DocumentHandler) Restore(w http.ResponseWriter, r *http.Request) {
+	id, err := h.parseID(w, r)
+	if err != nil {
+		return
+	}
+
+	resp, err := h.svc.Restore(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrDocumentNotFound) {
+			Error(w, http.StatusNotFound, "document not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to restore document")
+		return
+	}
+
+	userID, _, ok := middleware.GetUserFromContext(r)
+	if ok {
+		h.auditRepo.Log(r.Context(), service.AuditLog{
+			UserID:       &userID,
+			Action:       "file.restore",
+			ResourceType: "document",
+			ResourceID:   strconv.FormatInt(id, 10),
+			IPAddress:    r.RemoteAddr,
+			UserAgent:    r.UserAgent(),
+		})
+	}
+
+	Success(w, resp)
 }
 
 // Update handles PUT /api/v1/documents/{id} — update document.

--- a/internal/api/handler/handler_extended_test.go
+++ b/internal/api/handler/handler_extended_test.go
@@ -1,11 +1,15 @@
 package handler_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +43,7 @@ func setupExtendedTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 	docSvc := service.NewDocumentService(db, uploadSvc)
 	auditRepo := service.NewAuditRepository(db)
 	docHandler := handler.NewDocumentHandler(docSvc, uploadPath, auditRepo)
+	linkHandler := handler.NewLinkHandler(db, auditRepo)
 
 	// HeartbeatService needs its dedicated store; use a temp file.
 	hbStore, err := service.OpenHeartbeatStore(filepath.Join(t.TempDir(), "hb.db"))
@@ -100,9 +105,18 @@ func setupExtendedTestServer(t *testing.T) (*httptest.Server, *sql.DB) {
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireAdmin)
 			r.Post("/", docHandler.CreateURL)
+			r.Post("/upload", docHandler.UploadFile)
 			r.Put("/{id}", docHandler.Update)
 			r.Delete("/{id}", docHandler.Delete)
+			r.Post("/{id}/restore", docHandler.Restore)
 		})
+	})
+
+	r.Route("/api/v1/devices/{id}/documents", func(r chi.Router) {
+		r.Use(middleware.RequireAuth)
+		r.Get("/", linkHandler.GetDeviceDocuments)
+		r.Post("/", linkHandler.LinkDocument)
+		r.Delete("/{docId}", linkHandler.UnlinkDocument)
 	})
 
 	r.Route("/api/v1/devices/{id}/heartbeat-configs", func(r chi.Router) {
@@ -305,4 +319,113 @@ func toInt(v interface{}) int {
 		return int(f)
 	}
 	return 0
+}
+
+func TestExtended_DocumentSoftDeleteRestore(t *testing.T) {
+	server, db := setupExtendedTestServer(t)
+	insertTestAdmin(t, db)
+	token := loginAsAdmin(t, server)
+
+	resp := authPost(t, server.URL+"/api/v1/documents", token,
+		`{"title":"Doomed Doc","type":"url","url":"https://example.com","description":"will be deleted"}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var created map[string]interface{}
+	decodeJSON(t, resp, &created)
+	docID := idToString(created["id"])
+
+	// Delete → soft: gone from reads but restore brings it back intact.
+	req := authDelete(t, server.URL+"/api/v1/documents/"+docID, token)
+	require.Equal(t, http.StatusOK, req.StatusCode)
+	readBody(t, req)
+
+	resp = authGet(t, server.URL+"/api/v1/documents/"+docID, token)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	readBody(t, resp)
+
+	// Restoring a live (never-deleted) document is a 404, not an error 500.
+	resp = authPost(t, server.URL+"/api/v1/documents/"+docID+"/restore", token, `{}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var restored map[string]interface{}
+	decodeJSON(t, resp, &restored)
+	require.Equal(t, "Doomed Doc", restored["title"])
+
+	resp = authGet(t, server.URL+"/api/v1/documents/"+docID, token)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	readBody(t, resp)
+
+	// Second restore of an already-live doc → 404 (nothing to restore).
+	resp = authPost(t, server.URL+"/api/v1/documents/"+docID+"/restore", token, `{}`)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	readBody(t, resp)
+}
+
+func TestExtended_DeviceDocumentsContract(t *testing.T) {
+	server, db := setupExtendedTestServer(t)
+	insertTestAdmin(t, db)
+	token := loginAsAdmin(t, server)
+
+	// A device to link against (minimal required fields).
+	_, err := db.Exec(`INSERT INTO devices (name, ip_address, status) VALUES ('contract-dev', '192.0.2.1', 'online')`)
+	require.NoError(t, err)
+	var deviceID int64
+	require.NoError(t, db.QueryRow(`SELECT id FROM devices WHERE name = 'contract-dev'`).Scan(&deviceID))
+
+	resp := authPost(t, server.URL+"/api/v1/documents", token,
+		`{"title":"Contract Doc","type":"url","url":"https://example.com","description":"d"}`)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var created map[string]interface{}
+	decodeJSON(t, resp, &created)
+	docID := idToString(created["id"])
+
+	// Link, then read back through the device endpoint.
+	resp = authPost(t, server.URL+"/api/v1/devices/"+strconv.FormatInt(deviceID, 10)+"/documents", token,
+		`{"document_id":`+docID+`}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	readBody(t, resp)
+
+	resp = authGet(t, server.URL+"/api/v1/devices/"+strconv.FormatInt(deviceID, 10)+"/documents", token)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var payload map[string]interface{}
+	decodeJSON(t, resp, &payload)
+	// The frontend reads res.documents — the endpoint MUST return the wrapper
+	// object, not a bare array (the bug this test pins).
+	docs, ok := payload["documents"].([]interface{})
+	require.True(t, ok, "response must be {documents: [...]}")
+	require.Len(t, docs, 1)
+	require.Equal(t, "Contract Doc", docs[0].(map[string]interface{})["title"])
+}
+
+func TestExtended_UploadErrorCodes(t *testing.T) {
+	server, db := setupExtendedTestServer(t)
+	insertTestAdmin(t, db)
+	token := loginAsAdmin(t, server)
+
+	newReq := func(filename, content string) *http.Request {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		part, err := writer.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = part.Write([]byte(content))
+		require.NoError(t, err)
+		require.NoError(t, writer.WriteField("title", "t"))
+		require.NoError(t, writer.Close())
+		req, err := http.NewRequest("POST", server.URL+"/api/v1/documents/upload", &buf)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req
+	}
+
+	// Plain text (.txt) → 415 with the real reason, not a blanket 500.
+	resp, err := http.DefaultClient.Do(newReq("notes.txt", strings.Repeat("plain text ", 80)))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+	body := readBody(t, resp)
+	require.Contains(t, body, "file type not allowed")
+
+	// Shell script content named .png → 400 content/extension mismatch.
+	resp, err = http.DefaultClient.Do(newReq("evil.png", strings.Repeat("#!/bin/sh\n", 80)))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, readBody(t, resp), "does not match")
 }

--- a/internal/api/handler/link.go
+++ b/internal/api/handler/link.go
@@ -132,7 +132,10 @@ func (h *LinkHandler) GetDeviceDocuments(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	Success(w, docs)
+	// Wrapped as {documents: [...]} — the frontend reads res.documents (same
+	// shape as GET /documents); the bare array it used to return parsed to
+	// undefined and rendered "no documents linked" forever.
+	Success(w, map[string]any{"documents": docs})
 }
 
 // GetDocumentDevices handles GET /api/v1/documents/{id}/devices

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -867,6 +867,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			r.Post("/upload", docHandler.UploadFile)
 			r.Put("/{id}", docHandler.Update)
 			r.Delete("/{id}", docHandler.Delete)
+			// Undo for the delete-undo toast: restore is a write on the doc.
+			r.Post("/{id}/restore", docHandler.Restore)
 		})
 	})
 

--- a/internal/db/device_documents.sql.go
+++ b/internal/db/device_documents.sql.go
@@ -11,10 +11,10 @@ import (
 )
 
 const getDeviceDocuments = `-- name: GetDeviceDocuments :many
-SELECT d.id, d.title, d.type, d.url, d.file_path, d.file_size, d.mime_type, d.description, d.created_at, d.updated_at
+SELECT d.id, d.title, d.type, d.url, d.file_path, d.file_size, d.mime_type, d.description, d.deleted_at, d.created_at, d.updated_at
 FROM documents d
 JOIN device_documents dd ON d.id = dd.document_id
-WHERE dd.device_id = ?
+WHERE dd.device_id = ? AND d.deleted_at IS NULL
 `
 
 func (q *Queries) GetDeviceDocuments(ctx context.Context, deviceID int64) ([]Document, error) {
@@ -35,6 +35,7 @@ func (q *Queries) GetDeviceDocuments(ctx context.Context, deviceID int64) ([]Doc
 			&i.FileSize,
 			&i.MimeType,
 			&i.Description,
+			&i.DeletedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -55,7 +56,8 @@ const getDocumentDevices = `-- name: GetDocumentDevices :many
 SELECT dv.id, dv.name, dv.type, dv.brand, dv.model, dv.location, dv.purpose, dv.description, dv.status, dv.ip_address, dv.mac_address, dv.serial_number, dv.purchase_date, dv.warranty_expiry, dv.tags, dv.created_at, dv.updated_at
 FROM devices dv
 JOIN device_documents dd ON dv.id = dd.device_id
-WHERE dd.document_id = ?
+JOIN documents d ON d.id = dd.document_id
+WHERE dd.document_id = ? AND d.deleted_at IS NULL
 `
 
 type GetDocumentDevicesRow struct {

--- a/internal/db/documents.sql.go
+++ b/internal/db/documents.sql.go
@@ -11,7 +11,7 @@ import (
 
 const countDocuments = `-- name: CountDocuments :one
 SELECT COUNT(*) FROM documents
-WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
+WHERE deleted_at IS NULL AND (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
 `
 
 type CountDocumentsParams struct {
@@ -38,7 +38,7 @@ const createDocument = `-- name: CreateDocument :one
 
 INSERT INTO documents (title, type, url, file_path, file_size, mime_type, description)
 VALUES (?, ?, ?, ?, ?, ?, ?)
-RETURNING id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+RETURNING id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 `
 
 type CreateDocumentParams struct {
@@ -79,6 +79,7 @@ func (q *Queries) CreateDocument(ctx context.Context, arg CreateDocumentParams) 
 		&i.FileSize,
 		&i.MimeType,
 		&i.Description,
+		&i.DeletedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -86,10 +87,13 @@ func (q *Queries) CreateDocument(ctx context.Context, arg CreateDocumentParams) 
 }
 
 const deleteDocument = `-- name: DeleteDocument :execrows
-DELETE FROM documents
-WHERE id = ?
+UPDATE documents
+SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+WHERE id = ? AND deleted_at IS NULL
 `
 
+// Soft delete: stamp the tombstone, keep the row (and its file on disk) so
+// POST /documents/{id}/restore can undo. Physical purge is a later concern.
 func (q *Queries) DeleteDocument(ctx context.Context, id int64) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteDocument, id)
 	if err != nil {
@@ -99,9 +103,9 @@ func (q *Queries) DeleteDocument(ctx context.Context, id int64) (int64, error) {
 }
 
 const getDocument = `-- name: GetDocument :one
-SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+SELECT id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 FROM documents
-WHERE id = ?
+WHERE id = ? AND deleted_at IS NULL
 `
 
 func (q *Queries) GetDocument(ctx context.Context, id int64) (Document, error) {
@@ -116,6 +120,7 @@ func (q *Queries) GetDocument(ctx context.Context, id int64) (Document, error) {
 		&i.FileSize,
 		&i.MimeType,
 		&i.Description,
+		&i.DeletedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -123,9 +128,9 @@ func (q *Queries) GetDocument(ctx context.Context, id int64) (Document, error) {
 }
 
 const listDocuments = `-- name: ListDocuments :many
-SELECT id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+SELECT id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 FROM documents
-WHERE (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
+WHERE deleted_at IS NULL AND (? = '' OR INSTR(lower(title), lower(?)) > 0 OR INSTR(lower(description), lower(?)) > 0 OR INSTR(lower(type), lower(?)) > 0)
 ORDER BY id
 LIMIT ? OFFSET ?
 `
@@ -166,6 +171,7 @@ func (q *Queries) ListDocuments(ctx context.Context, arg ListDocumentsParams) ([
 			&i.FileSize,
 			&i.MimeType,
 			&i.Description,
+			&i.DeletedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -182,11 +188,26 @@ func (q *Queries) ListDocuments(ctx context.Context, arg ListDocumentsParams) ([
 	return items, nil
 }
 
+const restoreDocument = `-- name: RestoreDocument :execrows
+UPDATE documents
+SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP
+WHERE id = ? AND deleted_at IS NOT NULL
+`
+
+// Undo a soft delete (the UI's delete-undo toast). Only clears the tombstone.
+func (q *Queries) RestoreDocument(ctx context.Context, id int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, restoreDocument, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateDocument = `-- name: UpdateDocument :one
 UPDATE documents
 SET title = ?, type = ?, url = ?, file_path = ?, file_size = ?, mime_type = ?, description = ?, updated_at = CURRENT_TIMESTAMP
-WHERE id = ?
-RETURNING id, title, type, url, file_path, file_size, mime_type, description, created_at, updated_at
+WHERE id = ? AND deleted_at IS NULL
+RETURNING id, title, type, url, file_path, file_size, mime_type, description, deleted_at, created_at, updated_at
 `
 
 type UpdateDocumentParams struct {
@@ -221,6 +242,7 @@ func (q *Queries) UpdateDocument(ctx context.Context, arg UpdateDocumentParams) 
 		&i.FileSize,
 		&i.MimeType,
 		&i.Description,
+		&i.DeletedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -170,16 +170,17 @@ type DeviceSystem struct {
 }
 
 type Document struct {
-	ID          int64     `json:"id"`
-	Title       string    `json:"title"`
-	Type        string    `json:"type"`
-	Url         string    `json:"url"`
-	FilePath    string    `json:"file_path"`
-	FileSize    int64     `json:"file_size"`
-	MimeType    string    `json:"mime_type"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          int64      `json:"id"`
+	Title       string     `json:"title"`
+	Type        string     `json:"type"`
+	Url         string     `json:"url"`
+	FilePath    string     `json:"file_path"`
+	FileSize    int64      `json:"file_size"`
+	MimeType    string     `json:"mime_type"`
+	Description string     `json:"description"`
+	DeletedAt   *time.Time `json:"deleted_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 type HeartbeatConfig struct {

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -24,6 +24,8 @@ import (
 var (
 	ErrDocumentNotFound = errors.New("document not found")
 	ErrNotFileDocument  = errors.New("document is not a file type")
+	ErrTitleRequired    = errors.New("title is required")
+	ErrURLRequired      = errors.New("url is required")
 )
 
 // DocumentService handles document management business logic.
@@ -43,7 +45,10 @@ func NewDocumentService(dbConn db.DBTX, uploadSvc *UploadService) *DocumentServi
 // CreateURL creates a document with type="url".
 func (s *DocumentService) CreateURL(ctx context.Context, req domain.CreateDocumentRequest) (*domain.DocumentResponse, error) {
 	if req.Title == "" {
-		return nil, fmt.Errorf("title is required")
+		return nil, ErrTitleRequired
+	}
+	if req.URL == "" {
+		return nil, ErrURLRequired
 	}
 
 	doc, err := s.queries.CreateDocument(ctx, db.CreateDocumentParams{
@@ -63,12 +68,12 @@ func (s *DocumentService) CreateURL(ctx context.Context, req domain.CreateDocume
 // UploadFile saves a file and creates a document with type="file".
 func (s *DocumentService) UploadFile(ctx context.Context, file multipart.File, header *multipart.FileHeader, title string, description string) (*domain.DocumentResponse, error) {
 	if title == "" {
-		return nil, fmt.Errorf("title is required")
+		return nil, ErrTitleRequired
 	}
 
 	filePath, _, fileSize, mimeType, err := s.upload.SaveFile(file, header.Filename, header.Size)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save file: %w", err)
+		return nil, err
 	}
 
 	doc, err := s.queries.CreateDocument(ctx, db.CreateDocumentParams{
@@ -185,16 +190,10 @@ func (s *DocumentService) Update(ctx context.Context, id int64, req domain.Updat
 	return &resp, nil
 }
 
-// Delete removes a document by ID, also removing the file from disk if type="file".
+// Delete soft-deletes a document by ID (stamps deleted_at). The row and its
+// uploaded file stay on disk so Restore can undo; list/get queries filter the
+// tombstone away.
 func (s *DocumentService) Delete(ctx context.Context, id int64) error {
-	doc, err := s.queries.GetDocument(ctx, id)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrDocumentNotFound
-		}
-		return fmt.Errorf("failed to get document: %w", err)
-	}
-
 	affected, err := s.queries.DeleteDocument(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete document: %w", err)
@@ -202,30 +201,41 @@ func (s *DocumentService) Delete(ctx context.Context, id int64) error {
 	if affected == 0 {
 		return ErrDocumentNotFound
 	}
-
-	// Remove file from disk if it's a file-type document
-	if doc.Type == string(domain.DocTypeFile) && doc.FilePath != "" {
-		os.Remove(doc.FilePath)
-	}
-
 	return nil
 }
 
-// GetFilePath returns the file path for a file-type document (for download).
-func (s *DocumentService) GetFilePath(ctx context.Context, id int64) (string, error) {
+// Restore undoes a soft delete (the UI's delete-undo toast). Only clears the
+// tombstone — the row and its file were never physically removed.
+func (s *DocumentService) Restore(ctx context.Context, id int64) (*domain.DocumentResponse, error) {
+	affected, err := s.queries.RestoreDocument(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to restore document: %w", err)
+	}
+	if affected == 0 {
+		return nil, ErrDocumentNotFound
+	}
+	return s.Get(ctx, id)
+}
+
+// GetFile returns the file path and stored MIME type for a file-type document
+// (for download/preview). The MIME type is what the upload whitelist validated
+// — serving it verbatim (instead of letting http.ServeFile sniff) pins the
+// Content-Type and stops an HTML-flavored .md from being sniffed as text/html
+// on inline preview.
+func (s *DocumentService) GetFile(ctx context.Context, id int64) (path string, mimeType string, err error) {
 	doc, err := s.queries.GetDocument(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", ErrDocumentNotFound
+			return "", "", ErrDocumentNotFound
 		}
-		return "", fmt.Errorf("failed to get document: %w", err)
+		return "", "", fmt.Errorf("failed to get document: %w", err)
 	}
 
 	if doc.Type != string(domain.DocTypeFile) {
-		return "", ErrNotFileDocument
+		return "", "", ErrNotFileDocument
 	}
 
-	return doc.FilePath, nil
+	return doc.FilePath, doc.MimeType, nil
 }
 
 // toDocumentResponse converts a db.Document to domain.DocumentResponse.

--- a/internal/service/upload.go
+++ b/internal/service/upload.go
@@ -10,6 +10,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,9 +18,77 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 )
+
+// Typed upload rejection reasons — the HTTP handler maps each to a distinct
+// status code (413/415/400) so the client sees WHY the file was refused,
+// instead of a blanket 500.
+var (
+	ErrFileTooLarge       = errors.New("file exceeds the maximum allowed size")
+	ErrFileTypeNotAllowed = errors.New("file type not allowed")
+	ErrFileMismatch       = errors.New("file content does not match its extension")
+)
+
+// allowedMIMETypes is the upload whitelist. Comparisons happen on NORMALIZED
+// media types (parameters like "; charset=utf-8" stripped first) because
+// http.DetectContentType appends parameters to text types but not binary ones.
+var allowedMIMETypes = map[string]bool{
+	"image/jpeg":         true,
+	"image/png":          true,
+	"image/gif":          true,
+	"application/pdf":    true,
+	"application/msword": true,
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document":   true,
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         true,
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": true,
+	"text/markdown": true,
+}
+
+// extMimeOverrides hard-codes extension→MIME for text types whose mapping is
+// missing from minimal hosts (distroless/alpine without shared-mime-info):
+// mime.TypeByExtension(".md") returns "" there, which would make the
+// extension fallback in SaveFile fail portably.
+var extMimeOverrides = map[string]string{
+	".md":       "text/markdown",
+	".markdown": "text/markdown",
+}
+
+// normalizeMime strips media-type parameters ("; charset=utf-8") and lowers
+// the case, so whitelist comparisons don't depend on detector-specific
+// parameter suffixes.
+func normalizeMime(v string) string {
+	if mt, _, err := mime.ParseMediaType(v); err == nil {
+		return strings.ToLower(mt)
+	}
+	return strings.ToLower(v)
+}
+
+// isTextMime reports whether v is any text/* type.
+func isTextMime(v string) bool {
+	return strings.HasPrefix(v, "text/")
+}
+
+// compatibleMime reports whether sniffed content (detected) may carry a
+// filename extension claiming ext:
+//   - Generic detections the sniffer cannot distinguish (all Office formats
+//     sniff as application/zip) are accepted — but NOT for a text/* target:
+//     binary content named .md is a mismatch, a .md must actually be text.
+//   - The text/* family is one sniffing group (plain text, markdown and HTML
+//     all detect as text/plain or text/html), so any text/* content validates
+//     any text/* extension. The security boundary for text is elsewhere:
+//     render-side sanitization + forced-attachment downloads with nosniff.
+func compatibleMime(detected, ext string) bool {
+	if detected == "application/zip" || detected == "application/octet-stream" {
+		return !isTextMime(ext)
+	}
+	if isTextMime(detected) && isTextMime(ext) {
+		return true
+	}
+	return detected == ext
+}
 
 // UploadService handles file upload operations.
 type UploadService struct {
@@ -40,7 +109,7 @@ func NewUploadService(uploadDir string, maxFileSize int64) *UploadService {
 func (s *UploadService) SaveFile(file io.Reader, header string, size int64) (filePath string, fileName string, fileSize int64, mimeType string, err error) {
 	if size > s.maxFileSize {
 		slog.Warn("file upload rejected", "filename", header, "size", size, "reason", "exceeds max file size")
-		return "", "", 0, "", fmt.Errorf("file size %d exceeds maximum allowed size %d", size, s.maxFileSize)
+		return "", "", 0, "", fmt.Errorf("%w (%d > %d bytes)", ErrFileTooLarge, size, s.maxFileSize)
 	}
 
 	// Ensure upload directory exists
@@ -56,46 +125,43 @@ func (s *UploadService) SaveFile(file io.Reader, header string, size int64) (fil
 	// Detect MIME type from file content
 	detectedMime := DetectMimeType(buf)
 
-	// Get MIME type from file extension
-	extMime := mime.TypeByExtension(filepath.Ext(header))
-
-	// Allowed MIME types whitelist
-	var allowedMIMETypes = map[string]bool{
-		"image/jpeg":         true,
-		"image/png":          true,
-		"image/gif":          true,
-		"application/pdf":    true,
-		"application/msword": true,
-		"application/vnd.openxmlformats-officedocument.wordprocessingml.document":   true,
-		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         true,
-		"application/vnd.openxmlformats-officedocument.presentationml.presentation": true,
+	// Get MIME type from file extension, with hard-coded overrides for text
+	// types (see extMimeOverrides for why TypeByExtension alone is not portable).
+	ext := filepath.Ext(header)
+	extMime := extMimeOverrides[ext]
+	if extMime == "" {
+		extMime = mime.TypeByExtension(ext)
 	}
+
+	// All comparisons on normalized (parameter-stripped) media types: sniffed
+	// text types carry "; charset=utf-8", which would never equal a bare
+	// whitelist key like "text/markdown".
+	detectedNorm := normalizeMime(detectedMime)
+	extNorm := normalizeMime(extMime)
 
 	// Determine effective MIME: prefer content-detected type when specific,
 	// fall back to extension-based type for Office formats that http.DetectContentType
-	// cannot distinguish (all detect as application/zip)
-	mimeType = detectedMime
-	if !allowedMIMETypes[mimeType] && allowedMIMETypes[extMime] {
-		mimeType = extMime
+	// cannot distinguish (all detect as application/zip) and for markdown
+	// (sniffs as text/plain).
+	mimeType = detectedNorm
+	if !allowedMIMETypes[mimeType] && allowedMIMETypes[extNorm] {
+		mimeType = extNorm
 	}
 
-	// Check detected MIME against whitelist
+	// Check effective MIME against whitelist
 	if !allowedMIMETypes[mimeType] {
 		slog.Warn("file upload rejected", "filename", header, "reason", fmt.Sprintf("mime type not allowed: %s", detectedMime))
-		return "", "", 0, "", fmt.Errorf("file type not allowed: %s", detectedMime)
+		return "", "", 0, "", fmt.Errorf("%w: %s", ErrFileTypeNotAllowed, detectedMime)
 	}
 
-	// Verify content MIME matches extension (when content detection is specific)
-	if extMime != "" && detectedMime != extMime {
-		// Skip mismatch check for generic types that http.DetectContentType can't distinguish
-		if detectedMime != "application/zip" && detectedMime != "application/octet-stream" {
-			slog.Warn("file upload rejected", "filename", header, "reason", "content does not match extension")
-			return "", "", 0, "", fmt.Errorf("file content does not match extension")
-		}
+	// Verify content MIME is compatible with the extension (when both are
+	// specific). See compatibleMime for the text/* and generic-container rules.
+	if extNorm != "" && !compatibleMime(detectedNorm, extNorm) {
+		slog.Warn("file upload rejected", "filename", header, "reason", "content does not match extension")
+		return "", "", 0, "", ErrFileMismatch
 	}
 
-	// Generate UUID filename
-	ext := filepath.Ext(header)
+	// Generate UUID filename (extension already resolved above)
 	uuidName := uuid.New().String() + ext
 	destPath := filepath.Join(s.uploadDir, uuidName)
 

--- a/internal/service/upload_test.go
+++ b/internal/service/upload_test.go
@@ -137,3 +137,106 @@ func TestSaveFile_ExceedsMaxSize(t *testing.T) {
 		t.Fatal("expected error for oversized file, got nil")
 	}
 }
+
+func TestSaveFile_AllowedMarkdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := NewUploadService(tmpDir, 10<<20)
+
+	mdData := []byte("# 运维手册\n\n- ICMP 探测\n- SNMP OID 表\n\n```bash\nnmap -sP 192.0.2.0/24\n```\n")
+	mdData = append(mdData, bytes.Repeat([]byte(" "), 512-len(mdData))...)
+	reader := bytes.NewReader(mdData)
+
+	_, _, _, mimeType, err := svc.SaveFile(reader, "runbook.md", int64(len(mdData)))
+	if err != nil {
+		t.Fatalf("expected no error for allowed markdown, got: %v", err)
+	}
+	if mimeType != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", mimeType)
+	}
+}
+
+func TestSaveFile_MarkdownLeadingHTMLBlock(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := NewUploadService(tmpDir, 10<<20)
+
+	// A .md starting with an HTML block sniffs as text/html; that is still
+	// text/* content and must be accepted as markdown (sniffing cannot tell
+	// the text family apart — sanitize happens at render time).
+	mdData := []byte("<div class=\"note\">alert</div>\n\n# heading\n")
+	mdData = append(mdData, bytes.Repeat([]byte(" "), 512-len(mdData))...)
+	reader := bytes.NewReader(mdData)
+
+	_, _, _, mimeType, err := svc.SaveFile(reader, "note.md", int64(len(mdData)))
+	if err != nil {
+		t.Fatalf("expected no error for markdown with leading HTML block, got: %v", err)
+	}
+	if mimeType != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", mimeType)
+	}
+}
+
+func TestSaveFile_BlockedBinaryNamedMarkdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := NewUploadService(tmpDir, 10<<20)
+
+	// Binary content named .md — the generic-detection exemption must NOT
+	// apply to a text target; a .md has to actually be text.
+	data := make([]byte, 512)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	reader := bytes.NewReader(data)
+
+	_, _, _, _, err := svc.SaveFile(reader, "malware.md", int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error for binary content named .md, got nil")
+	}
+}
+
+func TestSaveFile_BlockedPlainText(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := NewUploadService(tmpDir, 10<<20)
+
+	// Plain .txt stays outside the whitelist (only markdown is supported).
+	txtData := []byte("plain text meeting notes")
+	txtData = append(txtData, bytes.Repeat([]byte(" "), 512-len(txtData))...)
+	reader := bytes.NewReader(txtData)
+
+	_, _, _, _, err := svc.SaveFile(reader, "notes.txt", int64(len(txtData)))
+	if err == nil {
+		t.Fatal("expected error for .txt upload, got nil")
+	}
+}
+
+func TestNormalizeMime(t *testing.T) {
+	cases := map[string]string{
+		"text/plain; charset=utf-8": "text/plain",
+		"text/markdown":             "text/markdown",
+		"IMAGE/PNG":                 "image/png",
+		"garbage":                   "garbage",
+	}
+	for in, want := range cases {
+		if got := normalizeMime(in); got != want {
+			t.Errorf("normalizeMime(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCompatibleMime(t *testing.T) {
+	cases := []struct {
+		detected, ext string
+		want          bool
+	}{
+		{"text/plain; charset=utf-8", "text/markdown", true},                                                 // text family
+		{"text/html; charset=utf-8", "text/markdown", true},                                                  // text family
+		{"image/jpeg", "image/jpeg", true},                                                                   // exact
+		{"image/jpeg", "image/png", false},                                                                   // mismatch
+		{"application/zip", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", true}, // Office container
+		{"application/octet-stream", "text/markdown", false},                                                 // binary under text ext
+	}
+	for _, c := range cases {
+		if got := compatibleMime(normalizeMime(c.detected), normalizeMime(c.ext)); got != c.want {
+			t.Errorf("compatibleMime(%q, %q) = %v, want %v", c.detected, c.ext, got, c.want)
+		}
+	}
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -231,6 +231,7 @@
 		"Preview": "Preview",
 		"Preview File": "Preview File",
 		"Preview Not Available": "Preview not available for this file type",
+		"Rendering Preview": "Rendering preview…",
 		"Restore Failed": "Restore failed",
 		"URL Placeholder": "https://...",
 		"Page Title": "Documents"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -231,6 +231,7 @@
 		"Preview": "预览",
 		"Preview File": "预览文件",
 		"Preview Not Available": "此文件类型不支持预览",
+		"Rendering Preview": "正在渲染预览…",
 		"Restore Failed": "恢复失败",
 		"URL Placeholder": "https://...",
 		"Page Title": "文档"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,9 @@
         "@inlang/paraglide-js": "^2.20.2",
         "@inlang/paraglide-sveltekit": "^0.16.1",
         "@lucide/svelte": "^1.23.0",
+        "dompurify": "^3.4.14",
         "echarts": "^6.1.0",
+        "marked": "^18.0.10",
         "qrcode": "^1.5.4",
         "zod": "^4.4.3"
       },
@@ -3525,6 +3527,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4533,6 +4544,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.10.tgz",
+      "integrity": "sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,9 @@
     "@inlang/paraglide-js": "^2.20.2",
     "@inlang/paraglide-sveltekit": "^0.16.1",
     "@lucide/svelte": "^1.23.0",
+    "dompurify": "^3.4.14",
     "echarts": "^6.1.0",
+    "marked": "^18.0.10",
     "qrcode": "^1.5.4",
     "zod": "^4.4.3"
   }

--- a/web/src/__tests__/markdown.test.ts
+++ b/web/src/__tests__/markdown.test.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+ *
+ * This file is part of MiBee Steward, distributed under the GNU Affero General
+ * Public License v3.0 or later. A commercial license is available for
+ * use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from '$lib/utils/markdown';
+
+describe('renderMarkdown', () => {
+	it('renders GFM structure (headings, lists, code, tables)', () => {
+		const out = renderMarkdown('# Title\n\n- item\n\n```bash\nls -la\n```\n\n| a | b |\n| - | - |\n| 1 | 2 |');
+		expect(out).toContain('<h1>Title</h1>');
+		expect(out).toContain('<li>item</li>');
+		expect(out).toContain('<pre><code class="language-bash">ls -la');
+		expect(out).toContain('<table>');
+		expect(out).toContain('<td>2</td>');
+	});
+
+	it('strips script tags, event handlers and javascript: URLs', () => {
+		const out = renderMarkdown(
+			'# ok\n\n<script>alert(1)</' + 'script>\n\n<img src=x onerror="alert(1)">\n\n[a](javascript:alert(1))'
+		);
+		expect(out).toContain('<h1>ok</h1>');
+		expect(out).not.toContain('alert(1)');
+		expect(out).not.toContain('<script');
+		expect(out).not.toContain('onerror');
+		expect(out).not.toContain('javascript:');
+	});
+
+	it('opens links in a new tab with rel=noopener', () => {
+		const out = renderMarkdown('[docs](https://example.com/x)');
+		expect(out).toContain('href="https://example.com/x"');
+		expect(out).toContain('target="_blank"');
+		expect(out).toContain('rel="noopener noreferrer"');
+	});
+
+	it('renders task-list checkboxes (GFM)', () => {
+		const out = renderMarkdown('- [x] done\n- [ ] todo');
+		expect(out).toContain('type="checkbox"');
+		expect(out).toContain('checked');
+	});
+
+	it('renders inline HTML fragments that survive sanitization', () => {
+		const out = renderMarkdown('<div class="note">plain div is fine</div>');
+		expect(out).toContain('plain div is fine');
+	});
+
+	it('handles empty and null-ish input', () => {
+		expect(renderMarkdown('')).toBe('');
+		expect(renderMarkdown(undefined as unknown as string)).toBe('');
+	});
+});

--- a/web/src/lib/styles/themes.css
+++ b/web/src/lib/styles/themes.css
@@ -424,6 +424,95 @@ body {
 	border: 1px solid var(--color-primary);
 }
 
+/* ── Markdown rendering (document preview) ──
+ * Typography for sanitized markdown bodies (documents/{id} preview modal).
+ * Token-driven so it follows the dark/light theme automatically; sizes are
+ * scoped under .markdown-body and use !important where needed to beat
+ * Tailwind preflight resets on element selectors. */
+.markdown-body {
+	font-size: 0.9375rem;
+	line-height: 1.7;
+	color: var(--color-text);
+	word-wrap: break-word;
+}
+.markdown-body > *:first-child { margin-top: 0 !important; }
+.markdown-body > *:last-child { margin-bottom: 0 !important; }
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+	margin: 1.4em 0 0.6em;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--color-text);
+}
+.markdown-body h1 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid var(--color-border); }
+.markdown-body h2 { font-size: 1.3em; padding-bottom: 0.25em; border-bottom: 1px solid var(--color-border); }
+.markdown-body h3 { font-size: 1.15em; }
+.markdown-body h4 { font-size: 1em; }
+.markdown-body p { margin: 0.75em 0; }
+.markdown-body a { color: var(--color-primary); text-decoration: underline; text-underline-offset: 3px; }
+.markdown-body a:hover { color: var(--color-primary-hover); }
+.markdown-body ul,
+.markdown-body ol { margin: 0.75em 0; padding-left: 1.6em; }
+.markdown-body ul { list-style: disc; }
+.markdown-body ol { list-style: decimal; }
+.markdown-body li { margin: 0.3em 0; }
+.markdown-body li > ul,
+.markdown-body li > ol { margin: 0.2em 0; }
+.markdown-body blockquote {
+	margin: 1em 0;
+	padding: 0.4em 1em;
+	color: var(--color-text-muted);
+	border-left: 3px solid var(--color-border-strong);
+	background: var(--color-surface-2);
+	border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.markdown-body code {
+	font-family: var(--font-mono);
+	font-size: 0.875em;
+	padding: 0.15em 0.4em;
+	border-radius: var(--radius-sm);
+	background: var(--color-surface-2);
+	border: 1px solid var(--color-border);
+}
+.markdown-body pre {
+	margin: 1em 0;
+	padding: 0.9em 1.1em;
+	overflow-x: auto;
+	border-radius: var(--radius-md);
+	background: var(--color-bg);
+	border: 1px solid var(--color-border);
+}
+.markdown-body pre code {
+	padding: 0;
+	background: none;
+	border: none;
+	font-size: 0.85em;
+	line-height: 1.6;
+}
+.markdown-body table {
+	margin: 1em 0;
+	border-collapse: collapse;
+	font-size: 0.9em;
+}
+.markdown-body th,
+.markdown-body td {
+	padding: 0.45em 0.9em;
+	border: 1px solid var(--color-border);
+	text-align: left;
+}
+.markdown-body th {
+	background: var(--color-surface-2);
+	font-weight: 600;
+}
+.markdown-body tr:nth-child(2n) td { background: color-mix(in srgb, var(--color-surface-2) 45%, transparent); }
+.markdown-body img { max-width: 100%; border-radius: var(--radius-sm); }
+.markdown-body hr { margin: 1.5em 0; border: none; border-top: 1px solid var(--color-border); }
+.markdown-body input[type='checkbox'] { margin-right: 0.4em; }
+
 /* Online/offline status indicator pulses */
 @keyframes pulse-green {
 	0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 70%, transparent); }

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+ *
+ * This file is part of MiBee Steward, distributed under the GNU Affero General
+ * Public License v3.0 or later. A commercial license is available for
+ * use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+ */
+
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import type { HtmlString } from './html.js';
+
+// GFM covers tables/strikethrough/task lists (the docs-site flavor); `breaks`
+// renders single newlines as <br> — matches how people actually write ops
+// notes in plain editors.
+marked.setOptions({ gfm: true, breaks: true });
+
+// External links open in a new tab — markdown bodies routinely reference
+// vendor docs, and navigating the SPA away would lose app state.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+	if (node.tagName === 'A' && node.getAttribute('href')) {
+		node.setAttribute('target', '_blank');
+		node.setAttribute('rel', 'noopener noreferrer');
+	}
+});
+
+/**
+ * renderMarkdown converts markdown source to sanitized HTML for a `{@html}`
+ * sink (document preview). The returned HtmlString is safe by construction:
+ * DOMPurify strips scripts, event handlers and javascript:/data: URLs, and
+ * the surviving inline HTML is intentional — README-style documents mix
+ * markdown with HTML fragments. Uploaded content is untrusted; sanitize here
+ * is the ONLY rendering path for it (never `{@html}` raw file text).
+ */
+export function renderMarkdown(src: string): HtmlString {
+	const raw = marked.parse(src ?? '', { async: false });
+	return DOMPurify.sanitize(raw, {
+		// DOMPurify's default profile already excludes scripts/iframes/forms.
+		// input stays allowed — GFM task lists render as checkbox inputs
+		// (event handlers are stripped regardless); everything else here is
+		// belt-and-braces stating the intent for document previews.
+		FORBID_TAGS: ['style', 'form', 'button', 'textarea', 'select', 'iframe', 'object', 'embed'],
+		FORBID_ATTR: ['style']
+	});
+}

--- a/web/src/routes/documents/+page.svelte
+++ b/web/src/routes/documents/+page.svelte
@@ -12,6 +12,8 @@
 	import { api } from '$lib/api/client';
 	import { m } from '$lib/i18n-paraglide';
 	import { html, sanitizeUrl } from '$lib/utils';
+	import { renderMarkdown } from '$lib/utils/markdown';
+	import type { HtmlString } from '$lib/utils/html';
 	import { getErrorMessage } from '$lib/utils/error';
 	import { addToast } from '$lib/stores/toast';
 	import Modal from '$lib/components/Modal.svelte';
@@ -82,6 +84,10 @@
 	// File preview modal
 	let previewOpen = $state(false);
 	let previewDoc = $state<Document | null>(null);
+	// Markdown preview: fetched + rendered (sanitized) on open.
+	let previewHtml = $state<HtmlString>('');
+	let previewLoading = $state(false);
+	let previewError = $state('');
 
 	onMount(() => {
 		hydrateFromUrl();
@@ -269,12 +275,34 @@
 	}
 
 	// --- File Preview ---
-	function openPreview(doc: Document) {
+	async function openPreview(doc: Document) {
 		previewDoc = doc;
+		previewError = '';
+		previewHtml = '';
 		previewOpen = true;
+		if (isMarkdown(doc)) {
+			// Markdown renders client-side: fetch the raw text through the API
+			// client (auth/CSRF parity with every other request), then sanitize.
+			previewLoading = true;
+			try {
+				const blob = await api.download(`/documents/${doc.id}/download`);
+				previewHtml = renderMarkdown(await blob.text());
+			} catch (err: unknown) {
+				previewError = getErrorMessage(err);
+			} finally {
+				previewLoading = false;
+			}
+		}
+	}
+
+	function isMarkdown(doc: Document): boolean {
+		const mime = doc.mime_type?.toLowerCase() || '';
+		const ext = doc.file_path?.split('.').pop()?.toLowerCase() || '';
+		return mime === 'text/markdown' || ['md', 'markdown'].includes(ext);
 	}
 
 	function isPreviewable(doc: Document): boolean {
+		if (isMarkdown(doc)) return true;
 		const mime = doc.mime_type?.toLowerCase() || '';
 		const ext = doc.file_path?.split('.').pop()?.toLowerCase() || '';
 		return mime.startsWith('image/') || mime === 'application/pdf'
@@ -596,17 +624,40 @@
 <Modal bind:open={previewOpen} title={m["documents.Preview File"]()} maxWidth="48rem" onClose={() => { previewOpen = false; }}>
 	{#if previewDoc}
 		<div class="text-sm text-text-muted mb-3">{previewDoc.title}</div>
-		{#if isImage(previewDoc)}
+		{#if isMarkdown(previewDoc)}
+			{#if previewLoading}
+				<div class="flex items-center justify-center gap-2 py-16 text-text-muted">
+					<LoaderCircle class="w-5 h-5 animate-spin" aria-hidden="true" />
+					<span>{m["documents.Rendering Preview"]()}</span>
+				</div>
+			{:else if previewError}
+				<div class="text-center py-8 text-text-muted">
+					<p class="mb-3 text-error">{previewError}</p>
+					{#if previewDoc.file_path}
+						<button
+							onclick={() => downloadDocument(previewDoc!)}
+							class="px-3 py-1.5 text-xs rounded text-primary hover:bg-primary/10 transition-colors border border-primary/30"
+						>
+							{m["documents.Download"]()}
+						</button>
+					{/if}
+				</div>
+			{:else}
+				<!-- previewHtml is sanitized in renderMarkdown (DOMPurify) — the only
+				     path through which uploaded file text may reach {@html}. -->
+				<div class="markdown-body max-h-[70vh] overflow-y-auto">{@html previewHtml}</div>
+			{/if}
+		{:else if isImage(previewDoc)}
 			<div class="flex justify-center">
 				<img
-					src="/api/v1/documents/{previewDoc.id}/download"
+					src="/api/v1/documents/{previewDoc.id}/download?inline=1"
 					alt={previewDoc.title}
 					class="max-w-full max-h-[70vh] rounded-lg border border-border"
 				/>
 			</div>
 		{:else if isPdf(previewDoc)}
 			<iframe
-				src="/api/v1/documents/{previewDoc.id}/download"
+				src="/api/v1/documents/{previewDoc.id}/download?inline=1"
 				class="w-full h-[70vh] rounded-lg border border-border"
 				title={previewDoc.title}
 			></iframe>


### PR DESCRIPTION
## Markdown 支持

- **上传**：白名单新增 `text/markdown`。MIME 比较全部参数归一化（剥 ` ; charset=utf-8`）；`.md`/`.markdown` 扩展名硬编码映射（精简容器无 mime.tables 也可移植）；text/* 家族嗅探互认（嗅探无法区分 plain/markdown/html，安全边界移至渲染端 DOMPurify 消毒 + 下载端 attachment+nosniff）；二进制内容命名 `.md` 明确拒绝（收紧了旧的 octet-stream 豁免）
- **预览**：marked(GFM) + DOMPurify 渲染——剥 `<script>`、事件处理器、`javascript:` 链接，外链强制 `_blank + noopener`；`.markdown-body` 排版样式全部用现有设计 token，暗/亮主题自动跟随
- 新增前端单测（渲染结构 + 三类 XSS 剥离）、后端上传单测

## P0 修复（功能评审中发现的 4 个 bug）

| # | 问题 | 修复 |
|---|------|------|
| 1 | 删除后的"撤销"toast 调用不存在的 `POST /documents/{id}/restore`，必然 404；后端为硬删除 | `documents.deleted_at` 软删除墓碑（读查询全部过滤，文件保留）；新增 restore 路由（CapDocumentWrite + `file.restore` 审计） |
| 2 | `GET /devices/{id}/documents` 返回裸数组，前端按 `{documents:[…]}` 解析 → "已关联文档"永远显示空 | 后端包装为 `{documents:[…]}`，与其他列表接口一致；前端零改动 |
| 3 | PDF 预览 iframe 复用 attachment 下载接口，Chrome 对 attachment 走下载通道 → 预览空白 | 下载接口支持 `?inline=1`；预览 img/iframe 带 inline 参数；Content-Type 固定为落库白名单值（防 ServeFile 嗅探把 HTML 味 .md 当 text/html 内嵌的同源 XSS） |
| 4 | 上传被拒（类型/超限/内容不符）一律 500 + "failed to upload file"，真实原因只在服务端日志 | 类型化错误映射 413/415/400，真实原因透出给客户端 |

## 验证

- `go test ./...` 全量通过（新增：软删-恢复周期 / 关联契约 / 上传错误码集成测试）
- `npm test` 203/203（新增 markdown 渲染+消毒 6 条）
- golangci-lint v2.12.2 = 0 issues；gofmt/goimports 干净；sqlc v1.31.1 重新生成（与 CI 同版本）
- 浏览器端到端（临时实例）：撤销链路 fetch 实录 restore 请求发出+列表恢复；关联弹窗正确显示并过滤已关联项；inline 响应头实测 `Content-Disposition: inline`；上传 .txt 表单显示 `file type not allowed: text/plain; charset=utf-8`

## 后续（不在本 PR）

- 软删除文档的物理清理可挂到 cleanupSvc retention 扫描
- 原始文件名落库 + RFC 5987 下载文件名（P1）