### PR TITLE
fix(discovery): multicast 组加入按平台拆分 — Windows 构建/测试恢复可用（#321）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,32 @@ jobs:
           name: go-coverage
           path: cover.out
 
+  # Cross-compile the whole tree for Windows from the Linux runner (build-only,
+  # no tests — Windows is a dev platform for this repo, deployments are Linux).
+  # Guards against bare-syscall regressions like #321, where
+  # discovery/multicast.go used int-fd setsockopt calls with no build tag and
+  # silently broke `go build ./...` for every Windows contributor. go vet is
+  # included because it type-checks for the target platform too.
+  windows-build:
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: '0'
+      GOOS: windows
+      GOARCH: amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: web/dist
+      - run: go vet ./...
+      - run: go build ./...
+
   frontend-test:
     needs: build-frontend
     runs-on: ubuntu-latest

--- a/internal/service/scannerv2/discovery/multicast.go
+++ b/internal/service/scannerv2/discovery/multicast.go
@@ -19,61 +19,15 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 )
 
-// reuseJoinControl is a ListenConfig.Control that sets SO_REUSEADDR AND joins
-// the multicast group via IP_ADD_MEMBERSHIP. SO_REUSEADDR lets the listener bind
-// alongside a system resolver (avahi, systemd-resolved) that already holds
-// :5353 / :1900; it deliberately does NOT set SO_REUSEPORT (that would split
-// incoming datagrams between us and the resolver, halving both our coverage).
-//
-// The IP_ADD_MEMBERSHIP is the critical part that was missing before: binding to
-// a multicast address (or to 0.0.0.0:port) does NOT by itself cause the kernel
-// to deliver multicast packets to the socket. The kernel only forwards packets
-// sent to a group to sockets that have explicitly joined that group. Without the
-// join, the listener opens successfully and the read loop runs forever — but
-// receives nothing, because the kernel never hands it any multicast traffic.
-// This was the root cause of the multicast source emitting zero events despite
-// devices broadcasting on the link.
-//
-// ifaceName selects the interface to join on (empty = the first up,
-// multicast-capable, non-loopback interface, which is the common single-NIC
-// case). Joining on a specific interface is required for IP_ADD_MEMBERSHIP to
-// receive link-local multicast (224.0.0.251) — the kernel needs to know which
-// L2 segment to listen on.
-func reuseJoinControl(group, ifaceName string) func(network, address string, c syscall.RawConn) error {
-	ifi, ifiErr := multicastInterface(ifaceName)
-	return func(_, _ string, c syscall.RawConn) error {
-		var sockErr error
-		err := c.Control(func(fd uintptr) {
-			sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
-			if sockErr != nil {
-				return
-			}
-			if ifiErr != nil {
-				sockErr = ifiErr
-				return
-			}
-			mreq := syscall.IPMreq{}
-			copy(mreq.Multiaddr[:], net.ParseIP(group).To4())
-			// Bind membership to the interface's IPv4 address (INADDR_ANY +
-			// imr_interface = kernel picks the default-route iface, but pinning
-			// it makes the choice deterministic and works when there is no
-			// default route, e.g. on a host with only a link-local config).
-			if ifi != nil && len(ifi.Addr) >= 4 {
-				copy(mreq.Interface[:], ifi.Addr[:4])
-			}
-			sockErr = syscall.SetsockoptIPMreq(int(fd), syscall.IPPROTO_IP,
-				syscall.IP_ADD_MEMBERSHIP, &mreq)
-		})
-		if err != nil {
-			return err
-		}
-		return sockErr
-	}
-}
+// The socket-level group join (SO_REUSEADDR + IP_ADD_MEMBERSHIP) is
+// platform-specific: syscall.SetsockoptInt/SetsockoptIPMreq take an int fd on
+// Unix but a syscall.Handle on Windows. It lives in multicast_control_unix.go /
+// multicast_control_windows.go behind build constraints; everything else in
+// this file is portable net code. reuseJoinControl(group, ifaceName) is the
+// seam the listeners below call into.
 
 // multicastInterface resolves the interface to join multicast groups on. When
 // name is non-empty it must name an up, multicast-capable interface; otherwise

--- a/internal/service/scannerv2/discovery/multicast_control_unix.go
+++ b/internal/service/scannerv2/discovery/multicast_control_unix.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+//go:build !windows
+
+package discovery
+
+import (
+	"net"
+	"syscall"
+)
+
+// reuseJoinControl is a ListenConfig.Control that sets SO_REUSEADDR AND joins
+// the multicast group via IP_ADD_MEMBERSHIP. SO_REUSEADDR lets the listener bind
+// alongside a system resolver (avahi, systemd-resolved) that already holds
+// :5353 / :1900; it deliberately does NOT set SO_REUSEPORT (that would split
+// incoming datagrams between us and the resolver, halving both our coverage).
+//
+// The IP_ADD_MEMBERSHIP is the critical part that was missing before: binding to
+// a multicast address (or to 0.0.0.0:port) does NOT by itself cause the kernel
+// to deliver multicast packets to the socket. The kernel only forwards packets
+// sent to a group to sockets that have explicitly joined that group. Without the
+// join, the listener opens successfully and the read loop runs forever — but
+// receives nothing, because the kernel never hands it any multicast traffic.
+// This was the root cause of the multicast source emitting zero events despite
+// devices broadcasting on the link.
+//
+// ifaceName selects the interface to join on (empty = the first up,
+// multicast-capable, non-loopback interface, which is the common single-NIC
+// case). Joining on a specific interface is required for IP_ADD_MEMBERSHIP to
+// receive link-local multicast (224.0.0.251) — the kernel needs to know which
+// L2 segment to listen on.
+//
+// Unix-only (see multicast_control_windows.go): the socket-descriptor
+// arguments of syscall.SetsockoptInt/SetsockoptIPMreq take an int here but a
+// syscall.Handle (uintptr) on Windows, so this file carries the `!windows`
+// build constraint the tagless multicast.go used to lack (#321).
+func reuseJoinControl(group, ifaceName string) func(network, address string, c syscall.RawConn) error {
+	ifi, ifiErr := multicastInterface(ifaceName)
+	return func(_, _ string, c syscall.RawConn) error {
+		var sockErr error
+		err := c.Control(func(fd uintptr) {
+			sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+			if sockErr != nil {
+				return
+			}
+			if ifiErr != nil {
+				sockErr = ifiErr
+				return
+			}
+			mreq := syscall.IPMreq{}
+			copy(mreq.Multiaddr[:], net.ParseIP(group).To4())
+			// Bind membership to the interface's IPv4 address (INADDR_ANY +
+			// imr_interface = kernel picks the default-route iface, but pinning
+			// it makes the choice deterministic and works when there is no
+			// default route, e.g. on a host with only a link-local config).
+			if ifi != nil && len(ifi.Addr) >= 4 {
+				copy(mreq.Interface[:], ifi.Addr[:4])
+			}
+			sockErr = syscall.SetsockoptIPMreq(int(fd), syscall.IPPROTO_IP,
+				syscall.IP_ADD_MEMBERSHIP, &mreq)
+		})
+		if err != nil {
+			return err
+		}
+		return sockErr
+	}
+}

--- a/internal/service/scannerv2/discovery/multicast_control_windows.go
+++ b/internal/service/scannerv2/discovery/multicast_control_windows.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+//go:build windows
+
+package discovery
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// reuseJoinControl is the Windows counterpart of the Unix socket-control
+// implementation (multicast_control_unix.go). Joining an IPv4 multicast group
+// needs IP_ADD_MEMBERSHIP on a syscall.Handle-typed descriptor; instead of
+// carrying a Windows socket path this project cannot exercise in CI, Windows
+// builds decline the join: ListenPacket fails with this error and
+// MulticastSource.run skips the mDNS/SSDP listeners with a warning. The
+// multicast source is supplemental — every other discovery source and the
+// whole engine keep working, and `go build`/`go test ./...` stay green on
+// Windows dev machines, which is the point of the split (#321). Deployments
+// are Linux; the CI windows-build job keeps this file honest.
+func reuseJoinControl(_, _ string) func(network, address string, c syscall.RawConn) error {
+	return func(_, _ string, _ syscall.RawConn) error {
+		return fmt.Errorf("multicast group join (IP_ADD_MEMBERSHIP) not implemented on windows builds")
+	}
+}


### PR DESCRIPTION
## 问题(#321)

`multicast.go` 的 `reuseJoinControl` 直接调用 `syscall.SetsockoptInt`/`SetsockoptIPMreq`(int fd 签名,仅 Unix 成立)且**无任何 build tag**,Windows 上 `go build ./...`/`go test ./...` 直接编译失败,连带 cmd/server、cmd/agent、internal/api/handler、internal/api/routes 等所有传递依赖 discovery 的包本地不可构建/测试。

## 修复

- socket 组加入(SO_REUSEADDR + IP_ADD_MEMBERSHIP)按目录既有 real/stub 模式拆分:
  - `multicast_control_unix.go`(`//go:build !windows`)— 原实现原样迁移,linux/darwin 开发机行为不变
  - `multicast_control_windows.go`(`//go:build windows`)— 返回明确错误的 stub;ListenPacket 失败后 `MulticastSource.run` 按既有降级路径对该协议跳过并告警("multicast source disabled"),其余发现源与整个引擎不受影响。不引入未经验证的 Windows socket 路径——Windows 是开发平台,部署目标是 Linux
- `multicast.go` 保留全部可移植逻辑,顶部注明平台接缝
- CI 新增 **windows-build** job:linux runner 交叉编译(`CGO_ENABLED=0 GOOS=windows GOARCH=amd64`)`go vet` + `go build ./...`(仅构建不跑测试,消费共享 frontend-dist artifact),防再次悄悄破坏——issue 的"最低限度"建议一并落地

## 验证

- linux: `go build ./...` + `go test ./internal/service/scannerv2/discovery/` 全绿
- windows 交叉: `GOOS=windows go vet ./...` + `go build ./...` 通过(修复前复现 #321 的两处编译错误)
- darwin 交叉: `GOOS=darwin go build ./internal/... ./cmd/...` 通过(unix 实现双平台确认)
- gofmt/goimports 干净

Closes #321