### PR TITLE
docs: 治理批 — MD040 进 CI + api.md 中间件链 mermaid + changelog 镜像脚本化（#319 #322 #323）

### DIFF
--- a/.github/DCO.md
+++ b/.github/DCO.md
@@ -21,7 +21,7 @@ git commit -s -m "feat(scanner): add new probe"
 
 This produces a trailer in the commit message:
 
-```
+```text
 Signed-off-by: Jane Doe <jane@example.com>
 ```
 
@@ -46,7 +46,7 @@ git config commit.gpgsign false   # DCO uses trailers, not GPG — but this is u
 
 ## The DCO text
 
-```
+```text
 Developer Certificate of Origin
 Version 1.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,23 @@ jobs:
           echo "health check timed out" >&2
           docker logs mibee-ci
           exit 1
+
+  # Docs governance (#319 / #322): fence-language lint (MD040) so the website's
+  # highlight.js rendering never regresses into mixed highlighted/monochrome
+  # code blocks, plus a drift guard that regenerates the docs changelog
+  # mirrors and fails when CHANGELOG.md changed without running
+  # `make docs-changelog-sync`. markdownlint-cli2 is pinned like every other
+  # CI tool in this repo (sqlc v1.31.1, golangci-lint v2.12.2).
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: markdownlint (MD040 fenced-code-language)
+        run: npx -y markdownlint-cli2@0.23.2 "**/*.md"
+      - name: Changelog mirror drift check
+        run: |
+          ./scripts/gen_changelog_mirror.sh
+          git diff --exit-code -- docs/zh/changelog.md docs/en/changelog.md

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,32 @@
+// markdownlint-cli2 configuration — see https://github.com/DavidAnson/markdownlint-cli2
+//
+// Purpose (#319): lock in fence-language annotations (MD040) so the website's
+// highlight.js rendering never regresses into a mix of highlighted and
+// monochrome code blocks (the one-off audit in #297/PR #300 fixed every
+// existing file; this config + the CI `docs` job keep it that way).
+//
+// Only MD040 is enabled ("default": false turns off everything else) — this is
+// a targeted guard, not a general style guide. Pure-output fences (shells
+// transcripts, logs) should be annotated `text`.
+{
+  "config": {
+    "default": false,
+    "MD040": true
+  },
+  "ignores": [
+    // Tool-generated third-party content (#297 explicitly left these alone)
+    "web/src/paraglide/**",
+    "web/project.inlang/**",
+    // Dependencies exist only in local checkouts (CI docs job never installs
+    // them), but a local `npx markdownlint-cli2 "**/*.md"` run would hit them
+    "node_modules/**",
+    "web/node_modules/**",
+    // Local-only strategy notes; gitignored, listed in case of a stray copy
+    "docs/private/**",
+    // Local-only files (gitignored, never in CI; ignored so a local run
+    // matches CI): workspace agent instructions + agent session artifacts
+    "AGENTS.md",
+    ".zcode/**",
+    ".omo/**"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-s -w -X mibee-steward/internal/version.Version=$(VERSION)
 BUILD_DIR=bin
 
-.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan build-linux-amd64 build-linux-arm64 build-linux-arm clean test dev migrate-up sync-fingerprints sync-device-types sync-oui-curated fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
+.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan build-linux-amd64 build-linux-arm64 build-linux-arm clean test dev migrate-up sync-fingerprints sync-device-types sync-oui-curated docs-changelog-sync fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
 
 all: build
 
@@ -92,6 +92,12 @@ sync-fingerprints:
 sync-device-types:
 	@cp -v configs/fingerprints/device-types/device_types.yaml internal/service/scannerv2/runner/device_types.yaml
 	@echo "device_types.yaml synced to runner embed dir"
+
+# docs-changelog-sync regenerates the docs/{zh,en}/changelog.md mirrors from
+# the root CHANGELOG.md (#322). Run whenever CHANGELOG.md changes; the CI
+# `docs` job runs the same script and fails on drift.
+docs-changelog-sync:
+	@./scripts/gen_changelog_mirror.sh
 
 # sync-oui-curated copies the hand-maintained CC-BY-SA OUI table from configs/
 # into the vendor package dir so //go:embed picks it up (Go embed cannot reach

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,10 @@ Documentation is maintained bilingually: `zh/` (中文) and `en/` (English) are 
 
 ## Conventions
 
-- **Website sync**: the MiBee Studio website (www.mlsbs.top) mirrors this manual from `docs/{zh,en}/` into `public/docs/mibeesteward/{zh-CN,en-US}/` via its `sync-docs.ps1` script (slug = filename, 1:1). Keep filenames stable — renaming a page breaks the site's `manifest.json`.
-- **Changelog mirror**: `en/changelog.md` is a verbatim copy of the root [CHANGELOG.md](../CHANGELOG.md); `zh/changelog.md` is the same content behind a Chinese note. Refresh both when `CHANGELOG.md` changes.
+- **Single source of truth**: this directory IS the manual. The MiBee Studio website docs center (www.mlsbs.top/#/docs/mibeesteward/) syncs from `docs/{zh,en}/` automatically — the website mirrors the repo, never the other way around.
+- **Website sync mechanics**: the site pulls `docs/{zh,en}/` into `public/docs/mibeesteward/{zh-CN,en-US}/` via its `sync-docs.ps1` script (slug = filename, 1:1). Keep filenames stable; **renaming/moving/deleting a page requires an issue** so the website's `ArticleMap` and `manifest.json` can be updated in lockstep — a silent rename becomes a 404 on the site. In-manual cross-links use bare `slug.md`; targets outside the collection use absolute links.
+- **Changelog mirror**: `en/changelog.md` is a verbatim copy of the root [CHANGELOG.md](../CHANGELOG.md); `zh/changelog.md` is the same content behind a Chinese note. Both are **generated** — run `make docs-changelog-sync` after editing `CHANGELOG.md`; the CI `docs` job fails on drift.
+- **Fence languages**: every code fence carries a language annotation (`go`, `bash`, `yaml`, `mermaid`, …; plain output as `text`) — enforced by markdownlint MD040 in the CI `docs` job, because the website's highlight.js rendering degrades to monochrome without it.
 - **Diagrams**: use Mermaid fenced blocks; do not use ASCII-art diagrams.
 - **Screenshots**: WebP, 1440×900 viewport, light theme, stored under `{zh,en}/images/` and referenced with relative paths (`images/foo.webp`) — the website sync script downloads relative image srcs into the site automatically. Every screenshot must be **sanitized**: demo-safe IPs (`192.168.1.x` / `192.168.2.x`), generic device names, no real MACs/hostnames/credentials. Capture via `scripts/docs_sanitize_proxy.py` (reverse proxy that rewrites API responses) and audit before publishing.
 - **Public docs only**: content here is published — never include private infrastructure details, credentials, or unreleased strategy.

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -42,8 +42,11 @@ Complete REST API documentation for the MiBee Steward device management and moni
 
 Every request passes through the following middleware in source registration order:
 
-```text
-RequestID → RealIP → Logging → Metrics → Recoverer → CORS → SecurityHeaders → CSRF → Global Rate Limit → Auth/RBAC (+ Network Scope / Agent Token)
+```mermaid
+flowchart LR
+    A[RequestID] --> B[RealIP] --> C[Logging] --> D[Metrics] --> E[Recoverer]
+    E --> F[CORS] --> G[SecurityHeaders] --> H[CSRF]
+    H --> I[Global Rate Limit] --> J["Auth/RBAC<br/>(+ Network Scope / Agent Token)"]
 ```
 
 - `RealIP` only trusts `X-Forwarded-For` when the TCP peer is in `server.trusted_proxies` (default empty = trust no proxy); when directly exposed the TCP peer is used. Reverse proxy deployments must declare the proxy source range in configuration.

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -42,8 +42,11 @@ MiBee Steward 设备管理与监控系统（含设备系统、网络扫描、多
 
 每个请求依次经过以下中间件（与源码注册顺序一致）：
 
-```text
-RequestID → RealIP → Logging → Metrics → Recoverer → CORS → SecurityHeaders → CSRF → 全局限流 → 认证/RBAC（+ 网络范围 / 代理令牌）
+```mermaid
+flowchart LR
+    A[RequestID] --> B[RealIP] --> C[Logging] --> D[Metrics] --> E[Recoverer]
+    E --> F[CORS] --> G[SecurityHeaders] --> H[CSRF]
+    H --> I["全局限流"] --> J["认证/RBAC<br/>（+ 网络范围 / 代理令牌）"]
 ```
 
 - `RealIP` 仅在 TCP 对端位于 `server.trusted_proxies`（默认空 = 不信任任何代理）时采信 `X-Forwarded-For`；直接暴露时以 TCP 对端为准。反向代理部署需在配置中声明代理来源段。

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -1,4 +1,4 @@
-> 本页是仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 的镜像副本（保留英文原文，便于与仓库逐字对照）。上游 CHANGELOG 更新后需同步刷新本文件。
+> 本页由 `make docs-changelog-sync` 从仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 自动生成（保留英文原文，便于与仓库逐字对照），请勿手改。
 
 
 # Changelog

--- a/scripts/gen_changelog_mirror.sh
+++ b/scripts/gen_changelog_mirror.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Regenerate the docs/{zh,en}/changelog.md mirrors from the root CHANGELOG.md
+# (#322). Run via `make docs-changelog-sync` whenever CHANGELOG.md changes; the
+# CI `docs` job runs this same script and fails on drift, so a release that
+# forgets to refresh the mirrors is caught before merge.
+#
+# - en/changelog.md: verbatim copy of CHANGELOG.md
+# - zh/changelog.md: one-line Chinese provenance note + the verbatim content
+#
+# Do not hand-edit the mirrors — edit CHANGELOG.md and re-run this script.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "error: CHANGELOG.md not found at repo root" >&2
+  exit 1
+fi
+
+cp CHANGELOG.md docs/en/changelog.md
+
+{
+  echo "> 本页由 \`make docs-changelog-sync\` 从仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 自动生成（保留英文原文，便于与仓库逐字对照），请勿手改。"
+  echo
+  echo
+  cat CHANGELOG.md
+} > docs/zh/changelog.md
+
+echo "docs/{zh,en}/changelog.md regenerated from CHANGELOG.md"


### PR DESCRIPTION
## 内容

三个 docs 治理 issue 一批落地:

### MD040 固化进 CI（#319）
- 新增 `.markdownlint-cli2.jsonc`:`"default": false` 仅启用 MD040(fenced-code-language),最高严格度、无豁免清单;忽略 `web/src/paraglide`、`web/project.inlang`(#297 明确不动的工具生成物)、node_modules、以及 gitignored 的本地目录(`docs/private`、`AGENTS.md`、`.zcode`、`.omo`——CI 天然不见,列出让本地运行与 CI 一致)
- ci.yml 新增 **docs** job:`npx -y markdownlint-cli2@0.23.2 "**/*.md"`(版本钉死,对齐 sqlc v1.31.1 / golangci v2.12.2 惯例)
- 存量清零:`.github/DCO.md` 仅存的两处无语言围栏补 `text`——当前 main 检出 0 违规(本地已跑通,58 文件 0 issues)

### api.md 中间件链 mermaid 化（#323）
- `docs/{zh,en}/api.md` 的单行 ASCII 箭头替换为 mermaid flowchart(采用 issue 给出的图形),与 distributed.md 拓扑风格统一;官网已原生渲染 mermaid,合并重新同步即生效

### docs 升级为 single source of truth 的仓库侧收尾（#322）
- **changelog 镜像脚本化**:`scripts/gen_changelog_mirror.sh` + `make docs-changelog-sync` 从根 CHANGELOG.md 重新生成 en(逐字)/zh(中文说明头+逐字)两镜像;docs job 内置 drift check——改了 CHANGELOG 忘刷镜像 → CI 失败(替代 issue 建议的手工同步)
- **docs/README.md Conventions 固化**:single-source-of-truth 正式声明(标注官网文档中心 URL `www.mlsbs.top/#/docs/mibeesteward/`)、手册改名/移动/删除需开 issue 知会官网侧(ArticleMap/manifest 同步)、集合内互链裸 `slug.md`、fence 一律带语言标注、changelog 镜像标记为生成物请勿手改

## 验证
- 本地 `npx markdownlint-cli2@0.23.2 "**/*.md"` → 58 文件 0 issues
- `make docs-changelog-sync` 幂等,生成物与 CHANGELOG.md 逐字一致(diff 校验)
- zh 镜像正文与根 CHANGELOG.md `diff` 为空(仅说明行更新为指向生成命令)

Closes #319
Closes #322
Closes #323