### PR TITLE
fix(config): env 覆盖精确映射 — 下划线段键可被 MIBEE_* 覆盖（#331）

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,8 +386,16 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
-	// Load env vars with MIBEE_ prefix
+	// Load env vars with MIBEE_ prefix. The transform resolves against the
+	// exact env-name → key table derived from the Config struct first, so
+	// keys with underscores in a segment (auth.initial_admin_password ←
+	// MIBEE_AUTH_INITIAL_ADMIN_PASSWORD) land correctly (#331); vars matching
+	// no known key keep the legacy blind underscore→dot split.
+	exactKeys := envKeyMap("MIBEE_")
 	if err := k.Load(env.Provider("MIBEE_", ".", func(s string) string {
+		if key, ok := exactKeys[s]; ok {
+			return key
+		}
 		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "MIBEE_")), "_", ".")
 	}), nil); err != nil {
 		return nil, err

--- a/internal/config/env_override_test.go
+++ b/internal/config/env_override_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// writeConfigYAML writes a minimal valid YAML (jwt_secret +
+// initial_admin_password are required by validation) and returns its path.
+func writeConfigYAML(t *testing.T) string {
+	t.Helper()
+	tmp, err := os.CreateTemp(t.TempDir(), "cfg-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmp.WriteString(`server: {port: 8080, host: "0.0.0.0"}
+auth:
+  jwt_secret: "this-is-definitely-32-chars-long!!"
+  initial_admin_password: "from-yaml"
+`); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	return tmp.Name()
+}
+
+// TestEnvOverride_KeyCategories guards the three env-override shapes (#331):
+// word-only keys, dot-separated keys, and keys with underscores INSIDE a
+// segment — the last kind silently failed before the exact-map fix because
+// the transform split every underscore into a dot.
+func TestEnvOverride_KeyCategories(t *testing.T) {
+	yamlPath := writeConfigYAML(t)
+
+	cases := []struct {
+		name  string
+		env   string
+		value string
+		check func(cfg *Config) bool
+	}{
+		{
+			name:  "word-only key: server.port",
+			env:   "MIBEE_SERVER_PORT",
+			value: "9090",
+			check: func(cfg *Config) bool { return cfg.Server.Port == 9090 },
+		},
+		{
+			name:  "dot-only key: security.master_key",
+			env:   "MIBEE_SECURITY_MASTER_KEY",
+			value: "hexbytes",
+			check: func(cfg *Config) bool { return cfg.Security.MasterKey == "hexbytes" },
+		},
+		{
+			name:  "underscore segment: auth.initial_admin_password",
+			env:   "MIBEE_AUTH_INITIAL_ADMIN_PASSWORD",
+			value: "from-env",
+			check: func(cfg *Config) bool { return cfg.Auth.InitialAdminPassword == "from-env" },
+		},
+		{
+			name:  "underscore segment: auth.jwt_secret",
+			env:   "MIBEE_AUTH_JWT_SECRET",
+			value: "this-is-definitely-32-chars-long!!",
+			check: func(cfg *Config) bool { return cfg.Auth.JWTSecret == "this-is-definitely-32-chars-long!!" },
+		},
+		{
+			name:  "deep underscore key: database.sqlite.path",
+			env:   "MIBEE_DATABASE_SQLITE_PATH",
+			value: "/tmp/env.db",
+			check: func(cfg *Config) bool { return cfg.Database.SQLite.Path == "/tmp/env.db" },
+		},
+		{
+			name:  "three-level underscore key: retention.sweep_interval_hours",
+			env:   "MIBEE_RETENTION_SWEEP_INTERVAL_HOURS",
+			value: "12",
+			check: func(cfg *Config) bool { return cfg.Retention.SweepIntervalHours == 12 },
+		},
+		{
+			name:  "scanner underscore key: scanner.allow_reserved_targets",
+			env:   "MIBEE_SCANNER_ALLOW_RESERVED_TARGETS",
+			value: "true",
+			check: func(cfg *Config) bool { return cfg.Scanner.AllowReservedTargets },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.env, tc.value)
+			cfg, err := Load(yamlPath)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if !tc.check(cfg) {
+				t.Errorf("%s=%s did not take effect", tc.env, tc.value)
+			}
+		})
+	}
+}
+
+// TestEnvOverride_BeatsYAML is the exact repro from #331: the YAML sets
+// initial_admin_password and the env var must win, not be silently ignored.
+func TestEnvOverride_BeatsYAML(t *testing.T) {
+	yamlPath := writeConfigYAML(t)
+	t.Setenv("MIBEE_AUTH_INITIAL_ADMIN_PASSWORD", "from-env")
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Auth.InitialAdminPassword != "from-env" {
+		t.Errorf("env override lost: got %q, want %q", cfg.Auth.InitialAdminPassword, "from-env")
+	}
+}
+
+// TestEnvKeyMap_CoversDocumentedKeys sanity-checks the reflected map itself:
+// spot keys from each category are present and map to the right koanf path.
+func TestEnvKeyMap_CoversDocumentedKeys(t *testing.T) {
+	m := envKeyMap("MIBEE_")
+	for _, env := range []string{
+		"MIBEE_SERVER_PORT",
+		"MIBEE_SECURITY_MASTER_KEY",
+		"MIBEE_AUTH_INITIAL_ADMIN_PASSWORD",
+		"MIBEE_AUTH_JWT_SECRET",
+		"MIBEE_DATABASE_SQLITE_PATH",
+		"MIBEE_RETENTION_SWEEP_INTERVAL_HOURS",
+		"MIBEE_SCANNER_ALLOW_RESERVED_TARGETS",
+	} {
+		if _, ok := m[env]; !ok {
+			t.Errorf("envKeyMap missing %s", env)
+		}
+	}
+	if m["MIBEE_AUTH_INITIAL_ADMIN_PASSWORD"] != "auth.initial_admin_password" {
+		t.Errorf("wrong mapping: %q", m["MIBEE_AUTH_INITIAL_ADMIN_PASSWORD"])
+	}
+	if len(m) < 100 {
+		t.Errorf("envKeyMap suspiciously small: %d keys", len(m))
+	}
+}
+
+// TestEnvOverride_YAMLStillWorksWhenNoEnv: without env vars the YAML value
+// survives (the map must not interfere with the plain YAML path).
+func TestEnvOverride_YAMLStillWorksWhenNoEnv(t *testing.T) {
+	yamlPath := writeConfigYAML(t)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Auth.InitialAdminPassword != "from-yaml" {
+		t.Errorf("yaml value lost: got %q", cfg.Auth.InitialAdminPassword)
+	}
+}

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package config
+
+import (
+	"reflect"
+	"strings"
+)
+
+// envKeyMap builds the exact environment-variable-name → koanf-key mapping
+// for every leaf key in the Config struct (#331).
+//
+// Why exact mapping: the legacy transform replaced EVERY underscore in an env
+// var with a dot, so any key whose segment contains an underscore was
+// unreachable from the environment — MIBEE_AUTH_INITIAL_ADMIN_PASSWORD became
+// auth.initial.admin.password instead of auth.initial_admin_password and was
+// silently dropped on unmarshal. Word-only keys (server.port) and dot-only
+// keys (security.master_key) worked by coincidence. The documented contract
+// ("every config key + MIBEE_* env override", docs/en/configuration.md)
+// demands the underscore form work for all keys.
+//
+// The map is derived by reflecting over the Config struct's `koanf` tags —
+// the same tags Unmarshal consumes — so it can never drift from the real key
+// universe. Dots in a key path and underscores inside a segment both become
+// underscores in the env name (auth.initial_admin_password →
+// MIBEE_AUTH_INITIAL_ADMIN_PASSWORD), exactly as users type them.
+func envKeyMap(prefix string) map[string]string {
+	m := map[string]string{}
+	var walk func(t reflect.Type, path string)
+	walk = func(t reflect.Type, path string) {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			name := f.Tag.Get("koanf")
+			if name == "" || name == "-" {
+				continue
+			}
+			if i := strings.IndexByte(name, ','); i >= 0 {
+				name = name[:i]
+			}
+			key := name
+			if path != "" {
+				key = path + "." + name
+			}
+			ft := f.Type
+			if ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+			switch ft.Kind() {
+			case reflect.Struct:
+				// Structs that carry their own scalar encoding (time.Time has
+				// no koanf tags below it) yield no leaves — harmless.
+				walk(ft, key)
+			default:
+				m[prefix+strings.ToUpper(strings.ReplaceAll(key, ".", "_"))] = key
+			}
+		}
+	}
+	walk(reflect.TypeOf(Config{}), "")
+	return m
+}

--- a/internal/config/envkeys.go
+++ b/internal/config/envkeys.go
@@ -49,7 +49,7 @@ func envKeyMap(prefix string) map[string]string {
 				key = path + "." + name
 			}
 			ft := f.Type
-			if ft.Kind() == reflect.Ptr {
+			if ft.Kind() == reflect.Pointer {
 				ft = ft.Elem()
 			}
 			switch ft.Kind() {


### PR DESCRIPTION
## 问题(#331)

env 变换 `strings.ReplaceAll(lower(trimPrefix(s)), "_", ".")` 把**所有**下划线拆成点 → koanf tag 含下划线的键全部无法被 env 覆盖:`MIBEE_AUTH_INITIAL_ADMIN_PASSWORD` → `auth.initial.admin.password`(不存在的键),静默丢弃。单词键(`server.port`)与纯点键(`security.master_key`)纯属巧合地正常。`docs/en/configuration.md` 明确承诺 every config key + MIBEE_* env,此前并未兑现。

## 修复

新增 `internal/config/envkeys.go`:`envKeyMap(prefix)` 反射遍历 **Config 结构体的 koanf tag**(unmarshal 消费的同一批 tag → 不可能漂移)构建精确 env 名→键映射;env transform 先查表命中即用,**未命中保持旧的盲拆分回退**(兼容未知变量)。键宇宙由此完整覆盖——与 YAML 内容无关,部分配置/空配置同样生效。

## 验证(回归护栏,按 issue 要求)

- **三类键各至少一个**:单词(`server.port`)、两段点键(`security.master_key`)、下划线段键 ×5(`auth.initial_admin_password`、`auth.jwt_secret`、`database.sqlite.path`、`retention.sweep_interval_hours`、`scanner.allow_reserved_targets`)
- **issue 原样复现**:YAML `initial_admin_password: from-yaml` + env `MIBEE_AUTH_INITIAL_ADMIN_PASSWORD=from-env` → env 胜出(修复前 from-yaml)
- 映射表 sanity:抽查键存在、映射正确、总量 ≥100
- 无 env 时 YAML 值不受影响
- `go build ./...` + config/cmd/api 全部测试绿;gofmt/goimports 干净

Closes #331