### PR TITLE
fix(metrics): 设备 gauge 周期刷新 — 增删后不再漂移到重启（#333）

### DIFF
--- a/internal/api/handler/metrics.go
+++ b/internal/api/handler/metrics.go
@@ -12,6 +12,7 @@ package handler
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -27,6 +28,26 @@ import (
 // MetricsHandler returns an http.Handler that serves Prometheus metrics.
 func MetricsHandler() http.Handler {
 	return promhttp.Handler()
+}
+
+// StartDeviceMetricsRefresher seeds the device gauges once immediately, then
+// recomputes them on a fixed ticker until ctx is cancelled (#333). The gauges
+// are Reset+Set snapshots of DB state — without periodic refresh they froze at
+// the process-start snapshot and drifted from reality in BOTH directions
+// (SQL-side cleanups left counts inflated; devices discovered after startup
+// were never counted) until restart. Two aggregate COUNTs per tick; cheap.
+func StartDeviceMetricsRefresher(ctx context.Context, dbtx db.DBTX, interval time.Duration) {
+	UpdateDeviceMetrics(ctx, dbtx)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			UpdateDeviceMetrics(ctx, dbtx)
+		}
+	}
 }
 
 // UpdateDeviceMetrics queries the database and updates the MibeeDevicesTotal gauge.

--- a/internal/api/handler/metrics_test.go
+++ b/internal/api/handler/metrics_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. You may use, modify, and redistribute it under
+// those terms; see LICENSE for the full text. A commercial license is available
+// for use cases the AGPL does not accommodate; see LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/metrics"
+	"mibee-steward/internal/testutil"
+)
+
+// TestUpdateDeviceMetrics_TracksDBChanges pins the refresh semantics the 60s
+// refresher loop relies on (#333): a second call after devices are removed /
+// added must move the gauges to the new DB state — including label
+// combinations dropping to zero (a status with no devices left disappears
+// entirely via the Reset, not a stale nonzero reading).
+func TestUpdateDeviceMetrics_TracksDBChanges(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	ctx := context.Background()
+
+	seed := func(n int, status string) {
+		for i := 0; i < n; i++ {
+			_, err := conn.ExecContext(ctx,
+				`INSERT INTO devices (device_uuid, name, ip_address, mac_address, type, status) VALUES (?, ?, ?, '', 'other', ?)`,
+				fmt.Sprintf("uuid-%s-%d", status, i), fmt.Sprintf("dev-%s-%d", status, i),
+				fmt.Sprintf("10.0.%d.%d", i, int(status[0])), status)
+			require.NoError(t, err)
+		}
+	}
+
+	seed(5, "online")
+	seed(3, "offline")
+	UpdateDeviceMetrics(ctx, conn)
+	require.Equal(t, 5.0, promtestutil.ToFloat64(metrics.MibeeDevicesTotal.WithLabelValues("online", "")))
+	require.Equal(t, 3.0, promtestutil.ToFloat64(metrics.MibeeDevicesTotal.WithLabelValues("offline", "")))
+
+	// The #333 shape: a bulk SQL cleanup (1023 phantom rows) between refreshes.
+	_, err = conn.ExecContext(ctx, `DELETE FROM devices WHERE status = 'online'`)
+	require.NoError(t, err)
+
+	UpdateDeviceMetrics(ctx, conn)
+	require.Equal(t, 0.0, promtestutil.ToFloat64(metrics.MibeeDevicesTotal.WithLabelValues("online", "")))
+	require.Equal(t, 3.0, promtestutil.ToFloat64(metrics.MibeeDevicesTotal.WithLabelValues("offline", "")))
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -1030,13 +1030,21 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	sdHandler := handler.NewSDHandler(dbConn, deviceSystemRepo)
 	r.Get("/sd", sdHandler.ServeHTTP)
 
-	// Seed initial device metrics
-	go handler.UpdateDeviceMetrics(context.Background(), dbConn)
+	// Device gauges refresh on a 60s ticker (#333): they are Reset+Set
+	// snapshots of DB state and a one-shot seed froze them at the
+	// process-start snapshot — SQL-side cleanups and post-start discoveries
+	// both drifted the counts until restart. Cancelled in the cleanup
+	// closure below (before db.Close()).
+	deviceMetricsCtx, deviceMetricsCancel := context.WithCancel(context.Background())
+	go handler.StartDeviceMetricsRefresher(deviceMetricsCtx, dbConn, 60*time.Second)
 	// SPA handler — serves embedded frontend
 	spaHandler := handler.NewSPAHandler()
 	r.Mount("/", spaHandler)
 
 	return r, heartbeatSvc, func() {
+		// Stop the device-metrics refresher BEFORE the DB close — its tick
+		// runs aggregate COUNTs against dbConn (#333).
+		deviceMetricsCancel()
 		if demoActivity != nil {
 			demoActivity.Stop()
 		}


### PR DESCRIPTION
## 问题(#333)

`UpdateDeviceMetrics`(Reset+Set 快照,语义本身正确)只在 routes.go 启动时执行一次 → `mibee_devices_total` / `mibee_fingerprint_identified` 停在进程启动快照:SQL 清理/脚本直改后计数虚高、启动后新发现设备不计入,双向漂移直到重启。实测:清理 1023 台幻影后 online 1059(实际 37)。

## 修复

- `handler.StartDeviceMetricsRefresher(ctx, dbtx, interval)`:立即种子一次 + ticker 周期重算,ctx 取消退出
- routes.go:`context.WithCancel` 接线 60s 刷新,并挂进 shutdown cleanup(**db.Close() 前取消**,与既有一致)
- 每 tick 两条聚合 COUNT + 一条 json_extract 汇总,成本可忽略

## 顺带审计(issue 建议)

`internal/metrics` 其余 gauge 逐一核对:`mibee_agent_last_report_timestamp` 事件驱动、`mibee_db_size_bytes`/`mibee_db_table_rows` 走 #280 维护 job、`mibee_scanner_tasks_total` 有 RefreshScannerTaskGauges 事件刷新——**均无同类一次性接线问题**。

## 测试

`TestUpdateDeviceMetrics_TracksDBChanges`:seed online×5/offline×3 → 断言 → `DELETE` online 全部 → 再刷 → online 归零/offline 保持(即 #333 的形状,锁定周期刷新所依赖的语义)。

Closes #333