### PR TITLE
feat(scanner): scan_tasks 原生支持 agent 网络 — 调度器自动下发 agent 扫描命令

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -152,7 +152,7 @@ func main() {
 	// mini-DB (seeded manually or via the task API on the center in a later
 	// phase). For now an operator adds rows to scan_tasks directly.
 	scanScheduler, schedErr := scannerv2scheduler.New(queries, dbConn,
-		func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64) {
+		func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64, _ *int64) {
 			defer func() {
 				if r := recover(); r != nil {
 					slog.Error("scan_func_panic", "task_id", taskID, "panic", r)

--- a/internal/api/routes/agent_dispatch_test.go
+++ b/internal/api/routes/agent_dispatch_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service"
+	"mibee-steward/internal/testutil"
+)
+
+// TestAgentForNetwork covers the dispatch decision helper: nil network,
+// network without agent, agent-bound network, and a missing network row all
+// resolve deterministically (missing → local scan, never a panic).
+func TestAgentForNetwork(t *testing.T) {
+	conn, err0 := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err0)
+	t.Cleanup(func() { conn.Close() })
+	_, err := conn.Exec(`INSERT INTO networks (id, name, cidr, agent_id) VALUES
+		(1, 'lan-63', '192.168.63.0/24', NULL),
+		(3, 'lan-62', '192.168.62.0/24', 'agent-62')`)
+	require.NoError(t, err)
+
+	require.Equal(t, "", agentForNetwork(conn, nil), "nil network must run locally")
+	id1 := int64(1)
+	require.Equal(t, "", agentForNetwork(conn, &id1), "agent-less network must run locally")
+	id3 := int64(3)
+	require.Equal(t, "agent-62", agentForNetwork(conn, &id3), "agent-bound network must dispatch")
+	id9 := int64(999)
+	require.Equal(t, "", agentForNetwork(conn, &id9), "missing network must fall back to local")
+}
+
+// TestDispatchAgentScan_SuccessAndFailure pins the agent-task dispatch
+// behavior: a successful enqueue records a completed run row; a rejected
+// enqueue (targets outside the agent network's CIDR) records a FAILED run
+// with the reason — the failure must be visible in run history, not just logs.
+func TestDispatchAgentScan_SuccessAndFailure(t *testing.T) {
+	conn, err0 := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err0)
+	t.Cleanup(func() { conn.Close() })
+	_, err := conn.Exec(`INSERT INTO networks (id, name, cidr, agent_id) VALUES
+		(3, 'lan-62', '192.168.62.0/24', 'agent-62')`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`INSERT INTO scan_tasks (id, name, targets, cron_expr, timeout, concurrent_hosts, enabled)
+		VALUES (7, 'lan-62-agent', '192.168.62.0/24', '*/10 * * * *', 300, 8, 1)`)
+	require.NoError(t, err)
+
+	queries := db.New(conn)
+	svc := service.NewAgentCommandService(queries, false, false)
+	ctx := context.Background()
+
+	// Success path: in-CIDR targets → command enqueued + completed run.
+	dispatchAgentScan(ctx, queries, svc, 7, "192.168.62.0/24", 300*1e9, "agent-62")
+	var cmdCount int
+	require.NoError(t, conn.QueryRow(`SELECT COUNT(*) FROM agent_commands WHERE agent_id='agent-62' AND command='scan'`).Scan(&cmdCount))
+	require.Equal(t, 1, cmdCount, "scan command must be enqueued for the agent")
+	run, err := queries.GetLatestRun(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, "completed", run.Status)
+	require.Equal(t, "", run.ErrorMessage)
+
+	// Failure path: out-of-CIDR targets → no command + failed run with reason.
+	dispatchAgentScan(ctx, queries, svc, 7, "10.99.0.0/24", 300*1e9, "agent-62")
+	var cmdCount2 int
+	require.NoError(t, conn.QueryRow(`SELECT COUNT(*) FROM agent_commands`).Scan(&cmdCount2))
+	require.Equal(t, 1, cmdCount2, "rejected dispatch must not enqueue a second command")
+	run2, err := queries.GetLatestRun(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, "failed", run2.Status)
+	require.NotEmpty(t, run2.ErrorMessage, "failure reason must surface in the run row")
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -531,14 +532,27 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 			"trigger_identify", cfg.Scanner.Discovery.TriggerIdentify)
 	}
 
-	// Scheduler: cron-driven scan tasks. The ScanFunc delegates to the runner.
+	// Agent command service: constructed BEFORE the scheduler so the ScanFunc
+	// binding below can close over it (agent-network tasks dispatch through it
+	// instead of running a local scan).
+	agentCmdSvc := service.NewAgentCommandService(scanQueries, cfg.AgentFleet.RemoteOpsEnabled, cfg.Scanner.AllowReservedTargets)
+
+	// Scheduler: cron-driven scan tasks. The ScanFunc binding is the
+	// local-vs-agent dispatcher: a task whose resolved network is
+	// agent-managed (networks.agent_id set) has no local scanner path — the
+	// agent IS the scanner there — so the tick enqueues a scan command for
+	// that agent; everything else runs the local pipeline via the runner.
 	scanScheduler, schedErr := scannerv2scheduler.New(scanQueries, dbConn,
-		func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64) {
+		func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64, networkID *int64) {
 			defer func() {
 				if r := recover(); r != nil {
 					slog.Error("scan_func_panic", "task_id", taskID, "panic", r)
 				}
 			}()
+			if agentID := agentForNetwork(dbConn, networkID); agentID != "" {
+				dispatchAgentScan(ctx, scanQueries, agentCmdSvc, taskID, targets, timeout, agentID)
+				return
+			}
 			scanRunner.Run(ctx, taskID, targets, timeout, concurrentHosts, cfg.Scanner.PersistRawEvidence, credentialID)
 		}, slog.Default())
 	if schedErr != nil {
@@ -684,8 +698,8 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// binds the request to an agent_id + network_id, and every reported device is
 	// tagged with that network so multi-LAN data coexists without collision.
 	// Routed on the top-level mux (separate from /agents/tokens) so the two auth
-	// regimes don't interfere.
-	agentCmdSvc := service.NewAgentCommandService(scanQueries, cfg.AgentFleet.RemoteOpsEnabled, cfg.Scanner.AllowReservedTargets)
+	// regimes don't interfere. agentCmdSvc is constructed above (before the
+	// scheduler) so the ScanFunc dispatcher can share the same instance.
 	agentReportHandler := handler.NewAgentReportHandler(scanRunner, scanQueries, dbConn, agentCmdSvc)
 	agentCommandHandler := handler.NewAgentCommandHandler(scanQueries, agentCmdSvc, auditRepo)
 	r.Route("/api/v1/agents", func(r chi.Router) {
@@ -1230,4 +1244,67 @@ func resolveNetworkID(dbConn *sql.DB, cfg *config.Config) int64 {
 
 	slog.Info("network identity resolved", "id", id, "name", name, "cidr", cfg.Network.CIDR)
 	return id
+}
+
+// agentForNetwork returns the agent_id bound to the given network ("" when
+// networkID is nil, the network has no agent, or the lookup fails — all of
+// which mean "run locally"). Used by the scheduler's ScanFunc dispatcher to
+// route agent-managed networks to their scanner.
+func agentForNetwork(dbConn *sql.DB, networkID *int64) string {
+	if networkID == nil {
+		return ""
+	}
+	var agentID sql.NullString
+	if err := dbConn.QueryRow(`SELECT agent_id FROM networks WHERE id = ?`, *networkID).Scan(&agentID); err != nil {
+		// Missing row / transient error: fall back to the local scan path.
+		slog.Warn("agent dispatch: network lookup failed; running local scan", "network_id", *networkID, "error", err)
+		return ""
+	}
+	return strings.TrimSpace(agentID.String)
+}
+
+// dispatchAgentScan enqueues a scan command for an agent-managed network task
+// and records a scan_task_runs row so the task's run history reflects the
+// dispatch (completed = command accepted by the command channel; the scan
+// itself executes on the agent and reports back via /agents/report). A failed
+// enqueue (e.g. targets outside the agent network's CIDR, reserved range with
+// the escape hatch off) is recorded as a FAILED run with the reason — the
+// failure must be visible in the UI, not just the journal.
+func dispatchAgentScan(ctx context.Context, queries *db.Queries, agentCmdSvc *service.AgentCommandService, taskID int64, targets string, timeout time.Duration, agentID string) {
+	start := time.Now()
+	now := time.Now()
+	run, runErr := queries.CreateScanTaskRun(ctx, db.CreateScanTaskRunParams{TaskID: taskID, StartedAt: &now})
+	if runErr != nil {
+		// No run row → still dispatch; the command channel is the primary
+		// effect and the agent view shows it.
+		slog.Warn("agent dispatch: run row create failed", "task_id", taskID, "error", runErr)
+	}
+	runCreated := runErr == nil && run.ID != 0
+	finishRun := func(status, errMsg string) {
+		if !runCreated {
+			return
+		}
+		fin := time.Now()
+		if uerr := queries.UpdateScanTaskRun(ctx, db.UpdateScanTaskRunParams{
+			Status:       status,
+			DurationMs:   fin.Sub(start).Milliseconds(),
+			ErrorMessage: errMsg,
+			FinishedAt:   &fin,
+			ID:           run.ID,
+		}); uerr != nil {
+			slog.Warn("agent dispatch: run row update failed", "task_id", taskID, "run_id", run.ID, "error", uerr)
+		}
+	}
+
+	cmd, err := agentCmdSvc.Enqueue(ctx, agentID, "scan", map[string]interface{}{
+		"targets": targets,
+		"timeout": int(timeout.Seconds()),
+	})
+	if err != nil {
+		slog.Error("agent dispatch: enqueue failed", "task_id", taskID, "agent_id", agentID, "targets", targets, "error", err)
+		finishRun("failed", err.Error())
+		return
+	}
+	slog.Info("scan task dispatched to agent", "task_id", taskID, "agent_id", agentID, "command_id", cmd.ID, "targets", targets)
+	finishRun("completed", "")
 }

--- a/internal/service/scannerv2/scheduler/scheduler.go
+++ b/internal/service/scannerv2/scheduler/scheduler.go
@@ -38,11 +38,15 @@ import (
 )
 
 // ScanFunc executes one scan task. It is invoked by the scheduler on each cron
-// tick; implementations (runner.Runner.Run) handle run/result persistence and
-// the device bridge. timeout/concurrentHosts carry the task's tuning.
-// credentialID optionally binds the scan to an SNMP credential (issue #135);
-// 0 = use the engine's global default community.
-type ScanFunc func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64)
+// tick; implementations handle run/result persistence and the device bridge.
+// timeout/concurrentHosts carry the task's tuning. credentialID optionally
+// binds a scan to an SNMP credential (issue #135); 0 = use the engine's global
+// default community. networkID is the task's resolved network (nil = task not
+// scoped to any network): the routes-layer binding uses it to decide whether
+// the task belongs to an agent-managed network and should be dispatched as an
+// agent command instead of a local scan (agent networks have no local scanner
+// path — the agent IS the scanner there).
+type ScanFunc func(ctx context.Context, taskID int64, targets string, timeout time.Duration, concurrentHosts int, credentialID int64, networkID *int64)
 
 // Scheduler manages cron-driven scan tasks.
 type Scheduler struct {
@@ -69,7 +73,7 @@ func New(queries *db.Queries, dbConn *sql.DB, scanFn ScanFunc, logger *slog.Logg
 		logger = slog.Default()
 	}
 	if scanFn == nil {
-		scanFn = func(context.Context, int64, string, time.Duration, int, int64) {} // no-op safe default
+		scanFn = func(context.Context, int64, string, time.Duration, int, int64, *int64) {} // no-op safe default
 	}
 	return &Scheduler{
 		scheduler:          s,
@@ -282,7 +286,7 @@ func (s *Scheduler) executeScan(taskID int64, targets string) {
 
 	start := time.Now()
 	s.logger.Info("scan job started", "task_id", taskID, "targets", targets)
-	s.scanFunc(ctx, taskID, targets, timeout, concurrent, credentialID)
+	s.scanFunc(ctx, taskID, targets, timeout, concurrent, credentialID, task.NetworkID)
 	s.logger.Info("scan job completed", "task_id", taskID, "duration", time.Since(start))
 }
 

--- a/internal/service/scannerv2/scheduler/scheduler_test.go
+++ b/internal/service/scannerv2/scheduler/scheduler_test.go
@@ -110,7 +110,7 @@ func TestTriggerNow_InvokesScanFunc(t *testing.T) {
 	const targets = "192.168.0.0/24"
 	// Build (not started), seed the task row, THEN start so Start's job
 	// re-hydration picks up task 7 and TriggerNow can find it.
-	s, _, conn := newTestScheduler(t, func(_ context.Context, id int64, tgt string, _ time.Duration, _ int, _ int64) {
+	s, _, conn := newTestScheduler(t, func(_ context.Context, id int64, tgt string, _ time.Duration, _ int, _ int64, _ *int64) {
 		select {
 		case got <- call{id, tgt}:
 		default:
@@ -140,7 +140,7 @@ func TestCancelTask_CancelsInFlightScan(t *testing.T) {
 	cancelled := make(chan struct{})
 	// Build, seed, THEN start so the seeded task is re-hydrated into the
 	// scheduler's jobMap and TriggerNow can fire it.
-	s, _, conn := newTestScheduler(t, func(ctx context.Context, _ int64, _ string, _ time.Duration, _ int, _ int64) {
+	s, _, conn := newTestScheduler(t, func(ctx context.Context, _ int64, _ string, _ time.Duration, _ int, _ int64, _ *int64) {
 		<-ctx.Done() // block until cancelled
 		close(cancelled)
 	})
@@ -182,7 +182,7 @@ func TestConcurrentAddRemove_JobCountConsistent(t *testing.T) {
 	const taskID = int64(42)
 	// Start first (empty DB → no jobs re-hydrated, harmless), then seed + rely on
 	// AddJob (which works regardless of started state) to exercise the mutex.
-	s, _, conn := startTestScheduler(t, func(context.Context, int64, string, time.Duration, int, int64) {})
+	s, _, conn := startTestScheduler(t, func(context.Context, int64, string, time.Duration, int, int64, *int64) {})
 	seedScanTask(t, conn, taskID, "10.0.0.0/24")
 	require.NoError(t, s.AddJob(taskID, "*/10 * * * *", "10.0.0.0/24"))
 
@@ -255,4 +255,39 @@ func TestCleanupStaleRuns_MarksOldRunningAsFailed(t *testing.T) {
 	).Scan(&freshStatus)
 	require.NoError(t, err)
 	require.Equal(t, "running", freshStatus, "recent run (<1h) must be left running")
+}
+
+// TestTriggerNow_PassesNetworkID pins the ScanFunc contract for agent-network
+// dispatch: the scheduler must hand the task's resolved network_id (nil when
+// unscoped) to the bound function so the routes-layer dispatcher can route
+// agent-managed networks to their agent instead of a local scan.
+func TestTriggerNow_PassesNetworkID(t *testing.T) {
+	const taskID = int64(42)
+	const targets = "192.168.62.0/24"
+	gotNet := make(chan *int64, 1)
+	s, _, conn := newTestScheduler(t, func(_ context.Context, _ int64, _ string, _ time.Duration, _ int, _ int64, networkID *int64) {
+		select {
+		case gotNet <- networkID:
+		default:
+		}
+	})
+	seedScanTask(t, conn, taskID, targets)
+	// Stamp the task with a network (the production path is
+	// taskservice.stampTaskNetwork; the test writes it directly).
+	_, err := conn.Exec(`INSERT INTO networks (id, name, cidr) VALUES (3, 'lan-62', '192.168.62.0/24')
+		ON CONFLICT(id) DO NOTHING`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`UPDATE scan_tasks SET network_id = 3 WHERE id = ?`, taskID)
+	require.NoError(t, err)
+	s.Start(context.Background())
+	t.Cleanup(func() { s.Stop() })
+	require.NoError(t, s.TriggerNow(taskID))
+
+	select {
+	case n := <-gotNet:
+		require.NotNil(t, n, "networkID must be passed through for a stamped task")
+		require.EqualValues(t, 3, *n)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ScanFunc was not invoked")
+	}
 }

--- a/internal/service/scannerv2/taskservice/scheduler_test.go
+++ b/internal/service/scannerv2/taskservice/scheduler_test.go
@@ -36,7 +36,7 @@ func setupSvcWithScheduler(t *testing.T) (*Service, *db.Queries) {
 	t.Cleanup(func() { conn.Close() })
 	queries := db.New(conn)
 	sched, err := scheduler.New(queries, conn,
-		func(context.Context, int64, string, time.Duration, int, int64) {}, // no-op scan
+		func(context.Context, int64, string, time.Duration, int, int64, *int64) {}, // no-op scan
 		nil)
 	require.NoError(t, err)
 	sched.Start(context.Background())


### PR DESCRIPTION
## 动机

agent 管理的网络没有原生定时扫描:调度器只会本地扫描,agent 命令只能手动 API 触发。测试环境靠 systemd timer + 硬编码密码的 shell 脚本凑了两个月——昨天密码一改,脚本静默失败的同时还把 admin 的失败登录计数每 10 分钟烧一次、持续续锁,用户被锁数小时(详见 .102 排障)。**内部能力不该依赖外部胶水脚本**,这是治本。

## 实现

- `ScanFunc` 签名追加 `networkID *int64`(调度器从任务行透传,未盖章任务为 nil)
- routes 的 ScanFunc 绑定改为**分发器**:任务网络 `networks.agent_id` 非空 → `AgentCommandService.Enqueue` 下发 scan 命令(targets + timeout);否则原样走本地 runner。agent 网络"本地无扫描路径——agent 就是扫描器"的路由语义落在绑定层,scheduler/runner 保持不感知
- 下发复用既有校验(CIDR 边界 + 保留段 + escape hatch),**下发失败写 failed run 行带原因**(UI 可见,不再静默);成功记 completed run;扫描结果照旧经 /agents/report 回流
- cmd/agent 的本地调度绑定适配新签名

## 测试

- scheduler:networkID 透传(盖章任务传值、TriggerNow 路径)
- routes:agentForNetwork 四种情形(nil/无 agent/有 agent/缺行)+ dispatchAgentScan 成功/越界拒绝的 run 断言;期间修掉一个真 bug:finishRun 闭包复用被 enqueue 改写的 err,失败 run 永远不落库
- 本地全量:仅剩 dbopen/probe 两个 main 上既有的 Windows 平台预存失败(CI Linux 正常)

## 部署后(待本 PR 合并)

.102 退役 `mibee-agent-scan-trigger.timer`,改为普通 scan_task(目标 192.168.62.0/24,自动盖章到 lan-62 → agent-62)。