### PR TITLE
fix(agent): mini-DB 启动幂等迁移 — agentSchema 补齐缺失列,旧库 ALTER 升级

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -387,7 +387,48 @@ func openAgentDB(dbPath string) (*sql.DB, error) {
 		conn.Close()
 		return nil, fmt.Errorf("apply agent schema: %w", err)
 	}
+	if err := applyAgentMigrations(conn); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("apply agent migrations: %w", err)
+	}
 	return conn, nil
+}
+
+// agentMigrations brings pre-existing mini-DBs up to the current
+// agentSchema shape (#337): CREATE TABLE IF NOT EXISTS never touches an
+// existing table, so columns added after an agent was first provisioned
+// must be ALTERed in idempotently — the same pattern as the center's
+// cmd/server/migrations.go. Without this, every device-identity query
+// referencing a new column (offline_since was the one seen in the wild)
+// fails and the roam/replace bridge silently degrades.
+var agentMigrations = []struct {
+	table   string // target table (for detection + error context)
+	stmt    string // full ALTER TABLE ... ADD COLUMN
+	colName string // column to detect via pragma_table_info
+}{
+	{"devices", "ALTER TABLE devices ADD COLUMN offline_since TIMESTAMP", "offline_since"},
+	{"devices", "ALTER TABLE devices ADD COLUMN device_uuid TEXT NOT NULL DEFAULT ''", "device_uuid"},
+	{"devices", "ALTER TABLE devices ADD COLUMN ssh_credential_id INTEGER", "ssh_credential_id"},
+	// scan_tasks columns the scheduler's ListEnabledScanTasks touches
+	// (observed in the wild as a startup ERROR on .174).
+	{"scan_tasks", "ALTER TABLE scan_tasks ADD COLUMN credential_id INTEGER", "credential_id"},
+	{"scan_tasks", "ALTER TABLE scan_tasks ADD COLUMN network_id INTEGER", "network_id"},
+}
+
+func applyAgentMigrations(conn *sql.DB) error {
+	for _, m := range agentMigrations {
+		var present int
+		if err := conn.QueryRow(`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, m.table, m.colName).Scan(&present); err != nil {
+			return fmt.Errorf("inspect %s.%s: %w", m.table, m.colName, err)
+		}
+		if present > 0 {
+			continue
+		}
+		if _, err := conn.Exec(m.stmt); err != nil {
+			return fmt.Errorf("add %s.%s: %w", m.table, m.colName, err)
+		}
+	}
+	return nil
 }
 
 // agentSchema is the minimal table set the runner + scheduler touch. Shapes
@@ -409,7 +450,9 @@ CREATE TABLE IF NOT EXISTS scan_tasks (
 	id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, targets TEXT NOT NULL,
 	cron_expr TEXT NOT NULL DEFAULT '0 */6 * * *', pipeline_config TEXT NOT NULL DEFAULT '{}',
 	global_labels TEXT NOT NULL DEFAULT '{}', timeout INTEGER NOT NULL DEFAULT 300,
-	concurrent_hosts INTEGER NOT NULL DEFAULT 50, enabled INTEGER NOT NULL DEFAULT 1,
+	concurrent_hosts INTEGER NOT NULL DEFAULT 50,
+	credential_id INTEGER, network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL,
+	enabled INTEGER NOT NULL DEFAULT 1,
 	last_run_at TIMESTAMP, next_run_at TIMESTAMP, last_run_status TEXT,
 	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -462,7 +505,9 @@ CREATE TABLE IF NOT EXISTS devices (
 	user_attributes TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(user_attributes)),
 	network_id INTEGER REFERENCES networks(id) ON DELETE SET NULL,
 	first_seen TIMESTAMP, last_seen TIMESTAMP,
-	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	device_uuid TEXT NOT NULL DEFAULT '', offline_since TIMESTAMP,
+	ssh_credential_id INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_devices_status ON devices(status);
 CREATE INDEX IF NOT EXISTS idx_devices_type ON devices(type);

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package main
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// TestOpenAgentDB_MigratesLegacyDB pins #337: a mini-DB created by an older
+// agent (devices table without offline_since / device_uuid /
+// ssh_credential_id) must be brought up to shape on startup — CREATE TABLE IF
+// NOT EXISTS alone leaves legacy tables untouched and every identity query
+// touching the new columns fails (observed in the wild as constant
+// "no such column: offline_since" WARNs with degraded roam/replace).
+func TestOpenAgentDB_MigratesLegacyDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/legacy.db"
+
+	// Provision a legacy DB: old devices shape + one row.
+	legacy, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = legacy.Exec(`CREATE TABLE devices (
+		id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
+		type TEXT NOT NULL DEFAULT 'other', brand TEXT NOT NULL DEFAULT '', model TEXT NOT NULL DEFAULT '',
+		location TEXT NOT NULL DEFAULT '', purpose TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'unknown', ip_address TEXT NOT NULL DEFAULT '', mac_address TEXT NOT NULL DEFAULT '',
+		serial_number TEXT NOT NULL DEFAULT '', purchase_date TEXT NOT NULL DEFAULT '', warranty_expiry TEXT NOT NULL DEFAULT '',
+		tags TEXT NOT NULL DEFAULT '{}', scan_source TEXT NOT NULL DEFAULT 'manual', prometheus_labels TEXT NOT NULL DEFAULT '{}',
+		last_scanned_at TIMESTAMP, last_scan_task_id INTEGER, open_ports TEXT NOT NULL DEFAULT '[]',
+		detected_services TEXT NOT NULL DEFAULT '[]', prometheus_url TEXT NOT NULL DEFAULT '', node_exporter_url TEXT NOT NULL DEFAULT '',
+		last_scan_rtt_ms INTEGER NOT NULL DEFAULT 0,
+		scan_attributes TEXT NOT NULL DEFAULT '{}', user_attributes TEXT NOT NULL DEFAULT '{}',
+		network_id INTEGER, first_seen TIMESTAMP, last_seen TIMESTAMP,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`)
+	require.NoError(t, err)
+	_, err = legacy.Exec(`INSERT INTO devices (name, ip_address) VALUES ('legacy-host', '192.168.62.10')`)
+	require.NoError(t, err)
+	require.NoError(t, legacy.Close())
+
+	// openAgentDB must migrate it in place and keep the data readable.
+	conn, err := openAgentDB(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	for _, col := range []string{"offline_since", "device_uuid", "ssh_credential_id"} {
+		var n int
+		require.NoError(t, conn.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('devices') WHERE name = ?`, col).Scan(&n), col)
+		require.Equal(t, 1, n, "column %s must exist after migration", col)
+	}
+	var name, uuid string
+	require.NoError(t, conn.QueryRow(`SELECT name, device_uuid FROM devices WHERE ip_address='192.168.62.10'`).Scan(&name, &uuid))
+	require.Equal(t, "legacy-host", name)
+	require.Equal(t, "", uuid, "backfill default for device_uuid")
+
+	// Idempotence: a second open must succeed unchanged.
+	require.NoError(t, conn.Close())
+	conn2, err := openAgentDB(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn2.Close() })
+	for _, col := range []string{"credential_id", "network_id"} {
+		var n int
+		require.NoError(t, conn2.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('scan_tasks') WHERE name = ?`, col).Scan(&n), col)
+		require.Equal(t, 1, n, "scan_tasks.%s must exist after migration", col)
+	}
+	var cols int
+	require.NoError(t, conn2.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('devices')`).Scan(&cols))
+}


### PR DESCRIPTION
## 动机(#337,.174 实测)

agent 本地 mini-DB 的 devices 表缺 `offline_since`/`device_uuid`/`ssh_credential_id`。**根因比 issue 里写的更糟:不止旧库落后——`agentSchema` 的 CREATE TABLE 本身就没这几列,新装 agent 同样中招**。共享的 device-identity SQL 一碰新列就报错,漫游/资产更换合并静默降级(一轮扫描 12 次 'no such column: offline_since')。

## 修复

- `agentSchema` devices 建表补三列(新库直接正确)
- `applyAgentMigrations`:`pragma_table_info` 探测 + 幂等 `ALTER TABLE ADD COLUMN`,与中心 migrations.go 同模式;`openAgentDB` 在建表后执行,旧库就地升级
- 回归测试:legacy 形态库(含数据)→ 迁移后三列在位、数据完好、重开幂等

Closes #337