### PR TITLE
feat(probe): 拨测多视角执行通道 — agent 本地执行 + 计划下发 + 批量回流(#277 步骤 2)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -295,6 +295,14 @@ func main() {
 			"trigger_identify", cfg.Scanner.Discovery.TriggerIdentify)
 	}
 
+	// Vantage prober (#277): executes the center-assigned probe plan locally
+	// and ships results in batches. Started before the poller so a "probe"
+	// command arriving in the first poll has a receiver.
+	probePoster := agent.NewHTTPResultPoster(cfg.Center.URL, cfg.Center.AuthToken, slog.Default())
+	prober := agent.NewProber(probePoster, slog.Default())
+	prober.Start(ctxBg)
+	defer prober.Stop()
+
 	// Command poller: fetches ad-hoc scan commands from the center (Phase 5c).
 	// The runScan callback wraps the runner so this package doesn't import runner
 	// directly (avoids an import cycle). Commands are best-effort — the agent's
@@ -319,6 +327,7 @@ func main() {
 			scanRunner.Run(ctx, run.ID, targets, to, cfg.Scanner.MaxConcurrentHosts, cfg.Scanner.PersistRawEvidence, 0)
 			return fmt.Sprintf(`{"run_id":%d,"targets":"%s"}`, run.ID, targets), nil
 		}, slog.Default())
+	cmdPoller.SetProber(prober)
 	if cfg.Center.RemoteOpsEnabled {
 		// Remote-ops opt-in (#278): restart/config-reload re-exec the process
 		// (config is consumed at construction; re-exec is the only faithful

--- a/internal/agent/command_poller.go
+++ b/internal/agent/command_poller.go
@@ -40,6 +40,11 @@ type CommandPoller struct {
 	pollEvery time.Duration
 	logger    *slog.Logger
 
+	// prober, when set, receives "probe" plan commands (#277). nil (tests,
+	// older wiring) makes a probe command fail with a clear message instead
+	// of being silently dropped.
+	prober *Prober
+
 	// networkCIDR is this agent's own configured network (cfg.Network.CIDR), used
 	// for the agent-side boundary check (issue #19 Layer 2-agent). When non-nil,
 	// a scan command whose targets fall outside it is rejected before execution
@@ -76,6 +81,12 @@ type CommandPoller struct {
 // (the agent wires its scanRunner.Run into this). pollEvery ≤0 → 60s.
 // networkCIDR is this agent's own network (cfg.Network.CIDR); empty/invalid
 // disables the agent-side boundary check (degrade-open).
+// SetProber injects the vantage prober (set after construction, mirroring
+// the center's SetTOTPService pattern, so the constructor stays stable).
+func (p *CommandPoller) SetProber(pr *Prober) {
+	p.prober = pr
+}
+
 func NewCommandPoller(centerURL, authToken string, pollEvery time.Duration, networkCIDR string, runScan func(context.Context, string, int) (string, error), logger *slog.Logger) *CommandPoller {
 	if logger == nil {
 		logger = slog.Default()
@@ -278,6 +289,20 @@ func (p *CommandPoller) execute(ctx context.Context, cmd pendingCommand) {
 		} else {
 			result = summary
 		}
+	case "probe":
+		var pc ProbePlanCommand
+		if err := json.Unmarshal([]byte(cmd.Payload), &pc); err != nil {
+			result = fmt.Sprintf(`{"error":"bad payload: %s"}`, err.Error())
+			status = "failed"
+			break
+		}
+		if p.prober == nil {
+			result = `{"error":"probe plan received but this agent has no prober"}`
+			status = "failed"
+			break
+		}
+		p.prober.ApplyConfig(pc)
+		result = fmt.Sprintf(`{"applied":%q,"targets":%d}`, pc.Fingerprint, len(pc.Targets))
 	case "restart", "config-reload", "logs-tail":
 		if !p.remoteOpsEnabled {
 			result = `{"error":"remote ops commands are disabled on this agent (center.remote_ops_enabled)"}`

--- a/internal/agent/prober.go
+++ b/internal/agent/prober.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/service/probetarget"
+)
+
+// ProbePlanCommand is the payload of the center's "probe" command (#277):
+// the full, sorted set of targets this agent should probe locally, plus the
+// plan fingerprint (the agent logs it; re-application is idempotent because
+// ApplyConfig replaces the whole plan).
+type ProbePlanCommand struct {
+	Targets     []probetarget.Spec `json:"targets"`
+	Fingerprint string             `json:"fingerprint"`
+}
+
+// ResultPoster ships finished probe results to the center. One method, called
+// from the prober's own goroutine; the production implementation batches +
+// retries lightly, tests stub it.
+type ResultPoster interface {
+	Post(ctx context.Context, results []probetarget.AgentResultReport)
+}
+
+// HTTPResultPoster posts result batches to the center's
+// POST /api/v1/agents/probe-report with the agent bearer token. A failed post
+// is logged and the batch DROPPED — probe results are observations, not
+// ledger entries; a lost sample is preferable to unbounded buffering on a
+// tiny router. (The scan reporter keeps its buffer because scan reports ARE
+// the asset ledger; probes are not.)
+type HTTPResultPoster struct {
+	CenterURL string
+	Token     string
+	Client    *http.Client
+	Logger    *slog.Logger
+}
+
+// NewHTTPResultPoster builds the production poster: the shared HTTP client
+// defaults (no timeout — per-probe deadlines already bounded execution).
+func NewHTTPResultPoster(centerURL, token string, logger *slog.Logger) *HTTPResultPoster {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HTTPResultPoster{
+		CenterURL: centerURL,
+		Token:     token,
+		Client:    &http.Client{},
+		Logger:    logger,
+	}
+}
+
+type probeReportPayload struct {
+	Results []probetarget.AgentResultReport `json:"results"`
+}
+
+func (p *HTTPResultPoster) Post(ctx context.Context, results []probetarget.AgentResultReport) {
+	if len(results) == 0 {
+		return
+	}
+	body, err := json.Marshal(probeReportPayload{Results: results})
+	if err != nil {
+		p.Logger.Warn("probe poster: marshal failed", "error", err)
+		return
+	}
+	url := p.CenterURL + "/api/v1/agents/probe-report"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		p.Logger.Warn("probe poster: build request failed", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.Token)
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		p.Logger.Warn("probe poster: post failed; batch dropped", "count", len(results), "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		p.Logger.Warn("probe poster: center rejected batch; dropped", "status", resp.StatusCode, "count", len(results))
+	}
+}
+
+// Prober executes the center-assigned vantage probe plan on the agent (#277
+// step 2). The center sends the WHOLE plan whenever it changes (fingerprint
+// gating — steady state is no traffic); the agent runs each target on its own
+// interval entirely locally, so probing survives center downtime and never
+// adds per-probe command-channel load.
+type Prober struct {
+	poster ResultPoster
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	targets []probetarget.Spec
+	applied string // last applied plan fingerprint
+
+	cancel context.CancelFunc
+	done   chan struct{}
+	// reportBatch aggregates finished results; flushed every flushInterval or
+	// when full — one HTTP post per batch instead of per probe.
+	reportBatch chan probetarget.AgentResultReport
+}
+
+// NewProber starts the local probe loop. tickInterval must be ≤ the smallest
+// supported interval (the center UI floor is 10s) so intervals schedule
+// faithfully; it re-reads the plan each tick, making ApplyConfig effective
+// within one tick.
+func NewProber(poster ResultPoster, logger *slog.Logger) *Prober {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Prober{
+		poster:      poster,
+		logger:      logger,
+		done:        make(chan struct{}),
+		reportBatch: make(chan probetarget.AgentResultReport, 1024),
+	}
+}
+
+// Start launches the scheduling + reporting loops. Call once after
+// construction; Stop cancels both.
+func (p *Prober) Start(ctx context.Context) {
+	ctx, p.cancel = context.WithCancel(ctx)
+	go p.scheduleLoop(ctx)
+	go p.reportLoop(ctx)
+}
+
+// Stop cancels the loops and waits for both to wind down.
+func (p *Prober) Stop() {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	<-p.done
+}
+
+// ApplyConfig replaces the whole probe plan (called by the command poller on
+// a "probe" command). An empty target list clears the plan — the center
+// dispatches one final empty plan when a target set empties out.
+func (p *Prober) ApplyConfig(cmd ProbePlanCommand) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.targets = append([]probetarget.Spec(nil), cmd.Targets...)
+	p.applied = cmd.Fingerprint
+	p.logger.Info("probe plan applied", "targets", len(p.targets), "fingerprint", shortFP(cmd.Fingerprint))
+}
+
+// PlanFingerprint returns the fingerprint of the currently applied plan
+// ("" when none was ever applied) — command-completion payloads echo it so
+// the center can correlate acks with plans.
+func (p *Prober) PlanFingerprint() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.applied
+}
+
+func (p *Prober) scheduleLoop(ctx context.Context) {
+	defer close(p.done)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	nextDue := make(map[int64]time.Time)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		p.mu.Lock()
+		targets := append([]probetarget.Spec(nil), p.targets...)
+		p.mu.Unlock()
+
+		now := time.Now()
+		live := make(map[int64]bool, len(targets))
+		for _, t := range targets {
+			live[t.ID] = true
+			due, ok := nextDue[t.ID]
+			if !ok {
+				// First sight of this target: due immediately (a fresh plan
+				// should produce a first sample fast, not after an interval).
+				due = now
+			}
+			if now.Before(due) {
+				continue
+			}
+			nextDue[t.ID] = now.Add(time.Duration(t.IntervalSeconds) * time.Second)
+			go p.probeOne(ctx, t)
+		}
+		for id := range nextDue {
+			if !live[id] {
+				delete(nextDue, id)
+			}
+		}
+	}
+}
+
+// probeOne runs a single target through the shared execution core and queues
+// the result for batch reporting. Panics in a module prober are contained:
+// one bad target must never wedge the loop.
+func (p *Prober) probeOne(ctx context.Context, spec probetarget.Spec) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("prober: target panic recovered", "target_id", spec.ID, "panic", r)
+		}
+	}()
+	t := db.ProbeTarget{
+		ID:             spec.ID,
+		Name:           spec.Name,
+		Module:         spec.Module,
+		Target:         spec.Target,
+		TimeoutSeconds: int64(spec.TimeoutSeconds),
+	}
+	out := probetarget.RunTarget(ctx, t)
+
+	report := probetarget.AgentResultReport{
+		TargetID:     spec.ID,
+		Vantage:      spec.Vantage,
+		Status:       out.Status,
+		LatencyMs:    float64(out.Latency.Microseconds()) / 1000.0,
+		StatusCode:   out.StatusCode,
+		ErrorMessage: out.ErrMsg,
+		TLSVersion:   out.TLSVersion,
+		CertNotAfter: out.CertNotAfter,
+		CertTrusted:  out.CertTrusted,
+		CheckedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	select {
+	case p.reportBatch <- report:
+	default:
+		p.logger.Warn("prober: report buffer full; result dropped", "target_id", spec.ID)
+	}
+}
+
+// reportLoop drains the result batch channel: 10s flush cadence or a
+// 32-result full batch, whichever comes first.
+func (p *Prober) reportLoop(ctx context.Context) {
+	const (
+		flushEvery = 10 * time.Second
+		batchMax   = 32
+	)
+	ticker := time.NewTicker(flushEvery)
+	defer ticker.Stop()
+	buf := make([]probetarget.AgentResultReport, 0, batchMax)
+
+	flush := func() {
+		if len(buf) == 0 {
+			return
+		}
+		p.poster.Post(ctx, buf)
+		buf = buf[:0]
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return
+		case r := <-p.reportBatch:
+			buf = append(buf, r)
+			if len(buf) >= batchMax {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func shortFP(fp string) string {
+	if len(fp) > 12 {
+		return fp[:12]
+	}
+	return fp
+}
+
+// Ensure the fmt import stays referenced if log sites change.
+var _ = fmt.Sprintf

--- a/internal/agent/prober_test.go
+++ b/internal/agent/prober_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/service/probetarget"
+)
+
+// TestProber_ApplyConfig pins the plan lifecycle: apply stores the plan and
+// its fingerprint, re-apply replaces wholesale (no merge residue from a
+// previous plan), and the empty plan clears targets.
+func TestProber_ApplyConfig(t *testing.T) {
+	p := NewProber(nil, nil) // poster nil: loops never started, poster unused
+
+	specs := []probetarget.Spec{
+		{ID: 1, Name: "a", Module: "http", Target: "http://a/", IntervalSeconds: 60, TimeoutSeconds: 10, Vantage: "agent:x"},
+		{ID: 2, Name: "b", Module: "tcp", Target: "b:443", IntervalSeconds: 120, TimeoutSeconds: 10, Vantage: "agent:x"},
+	}
+	p.ApplyConfig(ProbePlanCommand{Fingerprint: "fp1", Targets: specs})
+	require.Equal(t, "fp1", p.PlanFingerprint())
+
+	p.ApplyConfig(ProbePlanCommand{Fingerprint: "fp2", Targets: specs[:1]})
+	require.Equal(t, "fp2", p.PlanFingerprint())
+
+	// Empty plan clears.
+	p.ApplyConfig(ProbePlanCommand{Fingerprint: "fp3"})
+	require.Equal(t, "fp3", p.PlanFingerprint())
+}

--- a/internal/api/handler/agent_probe_report.go
+++ b/internal/api/handler/agent_probe_report.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"mibee-steward/internal/api/middleware"
+	"mibee-steward/internal/service/probetarget"
+)
+
+// AgentProbeReportHandler handles POST /api/v1/agents/probe-report (#277):
+// the agent-side vantage prober's result batches. Agent-token authenticated
+// (same regime as /agents/report); the reporting agent's identity overrides
+// any vantage the payload claims — an agent can only write its own track.
+type AgentProbeReportHandler struct {
+	svc *probetarget.Service
+}
+
+func NewAgentProbeReportHandler(svc *probetarget.Service) *AgentProbeReportHandler {
+	return &AgentProbeReportHandler{svc: svc}
+}
+
+// Report accepts a batch of probe results. Rows for targets deleted between
+// plan and report are skipped silently (normal race); malformed batches are
+// a 400.
+func (h *AgentProbeReportHandler) Report(w http.ResponseWriter, r *http.Request) {
+	agentID, _, ok := middleware.GetAgentFromContext(r)
+	if !ok || agentID == "" {
+		Error(w, http.StatusUnauthorized, "agent identity missing")
+		return
+	}
+	var payload struct {
+		Results []probetarget.AgentResultReport `json:"results"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(payload.Results) == 0 {
+		Success(w, map[string]interface{}{"accepted": 0})
+		return
+	}
+	accepted, err := h.svc.IngestAgentResults(r.Context(), agentID, payload.Results)
+	if err != nil {
+		slog.Error("agent probe report: ingest failed", "agent_id", agentID, "accepted", accepted, "error", err)
+		Error(w, http.StatusInternalServerError, "failed to ingest probe results")
+		return
+	}
+	Success(w, map[string]interface{}{"accepted": accepted})
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -632,6 +632,18 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	// while probing aims at arbitrary external endpoints by design.
 	probeEngine := probetarget.NewEngine(db.New(probeDB), slog.Default(), prometheus.DefaultRegisterer)
 	probeTargetSvc := probetarget.New(db.New(probeDB), probeEngine)
+	// Vantage probe dispatcher (#277): ships agent plans over the command
+	// channel whenever a plan content changes (fingerprint-gated, steady
+	// state is zero traffic). Same 10s cadence as the engine tick.
+	probeDispatcher := probetarget.NewAgentDispatcher(db.New(probeDB), agentCmdSvc, slog.Default())
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			probeDispatcher.DispatchTick(context.Background())
+		}
+	}()
+	agentProbeReportHandler := handler.NewAgentProbeReportHandler(probeTargetSvc)
 	probeTargetHandler := handler.NewProbeTargetHandler(probeTargetSvc, scanQueries)
 	r.Route("/api/v1/probe-targets", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
@@ -706,6 +718,7 @@ func NewRouter(dbConn *sql.DB, cfg *config.Config) (http.Handler, *service.Heart
 	r.Route("/api/v1/agents", func(r chi.Router) {
 		r.Use(middleware.RequireAgentToken)
 		r.Post("/report", agentReportHandler.Report)
+		r.Post("/probe-report", agentProbeReportHandler.Report)
 		// Agent command channel (Phase 5c): the agent polls pending commands
 		// (GET /commands), acknowledges (POST /commands/{id}/ack), executes, and
 		// reports the result (POST /commands/{id}/complete). Pull model.

--- a/internal/service/agent_command_service.go
+++ b/internal/service/agent_command_service.go
@@ -68,6 +68,7 @@ var OpsCommands = map[string]bool{
 func ValidCommands() map[string]bool {
 	return map[string]bool{
 		"scan":          true,
+		"probe":         true,
 		"restart":       true,
 		"config-reload": true,
 		"logs-tail":     true,

--- a/internal/service/probetarget/dispatcher.go
+++ b/internal/service/probetarget/dispatcher.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package probetarget
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+)
+
+// CommandEnqueuer is the slice of AgentCommandService the dispatcher needs.
+// An interface keeps probetarget decoupled from the agent-command service
+// (and lets tests stub enqueueing without the command tables).
+type CommandEnqueuer interface {
+	Enqueue(ctx context.Context, agentID, command string, payload map[string]interface{}) (db.AgentCommand, error)
+}
+
+// Spec is ONE target's execution definition as shipped to an agent
+// inside the "probe" command payload. The agent runs it on its own schedule
+// and reports results tagged with the vantage it was given.
+type Spec struct {
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	Module          string `json:"module"`
+	Target          string `json:"target"`
+	IntervalSeconds int    `json:"interval_seconds"`
+	TimeoutSeconds  int    `json:"timeout_seconds"`
+	Vantage         string `json:"vantage"`
+}
+
+// AgentDispatcher ships vantage probe plans to agents over the command
+// channel (#277 step 2). It is NOT a scheduler: agents run their own
+// intervals locally. The dispatcher only (re)sends a plan when the plan's
+// content changed — a sha256 over the agent's sorted specs — so the steady
+// state is zero command traffic, and a config edit propagates within one
+// dispatch tick.
+type AgentDispatcher struct {
+	queries *db.Queries
+	enqueue CommandEnqueuer
+	logger  *slog.Logger
+
+	// lastFingerprint per agentID of the last plan successfully enqueued.
+	lastFingerprint map[string]string
+}
+
+func NewAgentDispatcher(queries *db.Queries, enqueue CommandEnqueuer, logger *slog.Logger) *AgentDispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AgentDispatcher{
+		queries:         queries,
+		enqueue:         enqueue,
+		logger:          logger,
+		lastFingerprint: make(map[string]string),
+	}
+}
+
+// DispatchTick lists enabled targets, groups the agent-vantage ones
+// ('agent:{id}' exclusively, 'all' additionally to the center track) per
+// agent, and enqueues a "probe" plan for any agent whose plan changed.
+// Called on the same 10s cadence as the engine tick by the center wiring.
+func (d *AgentDispatcher) DispatchTick(ctx context.Context) {
+	targets, err := d.queries.ListEnabledProbeTargets(ctx)
+	if err != nil {
+		d.logger.Error("probe dispatch: list targets failed", "error", err)
+		return
+	}
+	agents := d.knownAgents(ctx)
+
+	perAgent := make(map[string][]db.ProbeTarget)
+	for _, t := range targets {
+		switch {
+		case t.Vantage == domain.ProbeVantageAll:
+			// 'all' runs on every known agent in addition to the center.
+			for _, agentID := range agents {
+				perAgent[agentID] = append(perAgent[agentID], t)
+			}
+		case strings.HasPrefix(t.Vantage, domain.ProbeVantageAgentPrefix):
+			agentID := strings.TrimPrefix(t.Vantage, domain.ProbeVantageAgentPrefix)
+			if agentID == "" {
+				continue
+			}
+			perAgent[agentID] = append(perAgent[agentID], t)
+		}
+	}
+
+	for agentID, list := range perAgent {
+		if err := d.sendPlan(ctx, agentID, list); err != nil {
+			d.logger.Error("probe dispatch: enqueue plan failed", "agent_id", agentID, "error", err)
+		}
+	}
+	// An agent whose every target was deleted gets an EMPTY plan once, so its
+	// local prober stops cleanly instead of probing ghosts forever.
+	for _, agentID := range agents {
+		if _, ok := perAgent[agentID]; ok {
+			continue
+		}
+		if d.lastFingerprint[agentID] == "" {
+			continue // never had a plan — nothing to clear
+		}
+		if err := d.sendPlan(ctx, agentID, nil); err != nil {
+			d.logger.Warn("probe dispatch: clear plan failed", "agent_id", agentID, "error", err)
+		}
+	}
+}
+
+// knownAgents returns the agent IDs that currently have a network bound
+// (networks.agent_id) — the same population the scan dispatcher routes to.
+func (d *AgentDispatcher) knownAgents(ctx context.Context) []string {
+	nets, err := d.queries.ListNetworks(ctx)
+	if err != nil {
+		d.logger.Warn("probe dispatch: list networks failed", "error", err)
+		return nil
+	}
+	var ids []string
+	for _, n := range nets {
+		if n.AgentID != nil && strings.TrimSpace(*n.AgentID) != "" {
+			ids = append(ids, strings.TrimSpace(*n.AgentID))
+		}
+	}
+	return ids
+}
+
+// sendPlan enqueues a "probe" command for one agent when (and only when) the
+// plan content changed. The payload carries the plan's fingerprint so the
+// agent can log idempotent re-application.
+func (d *AgentDispatcher) sendPlan(ctx context.Context, agentID string, list []db.ProbeTarget) error {
+	specs := make([]Spec, 0, len(list))
+	for _, t := range list {
+		specs = append(specs, Spec{
+			ID: t.ID, Name: t.Name, Module: t.Module, Target: t.Target,
+			IntervalSeconds: int(t.IntervalSeconds), TimeoutSeconds: int(t.TimeoutSeconds),
+			Vantage: agentVantageFor(t.Vantage, agentID),
+		})
+	}
+	sort.Slice(specs, func(i, j int) bool { return specs[i].ID < specs[j].ID })
+
+	fp := PlanFingerprint(specs)
+	if fp == d.lastFingerprint[agentID] {
+		return nil // unchanged plan: the agent already has it
+	}
+	payload := map[string]interface{}{
+		"targets":     specs,
+		"fingerprint": fp,
+	}
+	if _, err := d.enqueue.Enqueue(ctx, agentID, "probe", payload); err != nil {
+		return fmt.Errorf("enqueue probe plan (%d targets): %w", len(specs), err)
+	}
+	d.lastFingerprint[agentID] = fp
+	if len(specs) == 0 {
+		d.logger.Info("probe dispatch: plan cleared", "agent_id", agentID)
+	} else {
+		d.logger.Info("probe dispatch: plan shipped", "agent_id", agentID, "targets", len(specs))
+	}
+	return nil
+}
+
+// agentVantageFor canonicalizes the vantage the AGENT should stamp on its
+// results: an 'all' plan becomes this agent's track ('agent:{id}'); an
+// agent-specific plan stays as-is.
+func agentVantageFor(planVantage, agentID string) string {
+	if planVantage == domain.ProbeVantageAll {
+		return domain.ProbeVantageAgentPrefix + agentID
+	}
+	return planVantage
+}
+
+// PlanFingerprint hashes a sorted spec list so the dispatcher can skip
+// enqueueing unchanged plans (steady state = zero command traffic).
+func PlanFingerprint(specs []Spec) string {
+	b, _ := json.Marshal(specs)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// AgentResultReport is ONE result row in an agent's probe-report batch.
+// TargetID + Vantage identify the track; CheckedAt is the agent's clock at
+// probe time (RFC3339), which the ingest path treats as authoritative for
+// ordering (agents may buffer during center downtime).
+type AgentResultReport struct {
+	TargetID     int64   `json:"target_id"`
+	Vantage      string  `json:"vantage"`
+	Status       string  `json:"status"`
+	LatencyMs    float64 `json:"latency_ms"`
+	StatusCode   int     `json:"status_code"`
+	ErrorMessage string  `json:"error_message"`
+	TLSVersion   string  `json:"tls_version"`
+	CertNotAfter string  `json:"cert_not_after"`
+	CertTrusted  *bool   `json:"cert_trusted"`
+	CheckedAt    string  `json:"checked_at"`
+}
+
+// IngestAgentResults persists a batch of agent-side probe results (#277).
+// The reporting agent's identity (from its token) overrides whatever vantage
+// the payload claims — an agent can only ever write its own track.
+// Rows for unknown/deleted targets are skipped, not failed: a plan removal
+// racing an in-flight report is normal operation.
+func (s *Service) IngestAgentResults(ctx context.Context, agentID string, results []AgentResultReport) (int, error) {
+	own := domain.ProbeVantageAgentPrefix + agentID
+	accepted := 0
+	for _, r := range results {
+		t, err := s.queries.GetProbeTarget(ctx, r.TargetID)
+		if err != nil {
+			continue // plan raced: target deleted/disabled mid-flight
+		}
+		// Gauge first (best-effort), then persistence.
+		s.engine.metrics.record(t.Name, t.Module, own, r.Status, r.LatencyMs/1000.0, certExpiryUnix(r.CertNotAfter))
+		if err := s.queries.CreateProbeResult(ctx, db.CreateProbeResultParams{
+			TargetID:     r.TargetID,
+			Status:       r.Status,
+			LatencyMs:    r.LatencyMs,
+			StatusCode:   int64(r.StatusCode),
+			ErrorMessage: r.ErrorMessage,
+			TlsVersion:   r.TLSVersion,
+			CertNotAfter: r.CertNotAfter,
+			CertTrusted:  certTrustedDB(r.CertTrusted),
+			CheckedAt:    r.CheckedAt,
+			Vantage:      own,
+		}); err != nil {
+			return accepted, err
+		}
+		accepted++
+	}
+	return accepted, nil
+}

--- a/internal/service/probetarget/dispatcher_test.go
+++ b/internal/service/probetarget/dispatcher_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi-Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later. See LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package probetarget
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/domain"
+	"mibee-steward/internal/testutil"
+)
+
+// fakeEnqueuer records probe plans per agent (test double for the command
+// service slice).
+type fakeEnqueuer struct {
+	plans map[string][]map[string]interface{} // agentID → enqueued payloads
+}
+
+func (f *fakeEnqueuer) Enqueue(_ context.Context, agentID, _ string, payload map[string]interface{}) (db.AgentCommand, error) {
+	if f.plans == nil {
+		f.plans = map[string][]map[string]interface{}{}
+	}
+	f.plans[agentID] = append(f.plans[agentID], payload)
+	return db.AgentCommand{ID: int64(len(f.plans[agentID]))}, nil
+}
+
+func setupDispatch(t *testing.T) (*AgentDispatcher, *fakeEnqueuer, *db.Queries, *sql.DB) {
+	t.Helper()
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	fake := &fakeEnqueuer{}
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewAgentDispatcher(queries, fake, quiet), fake, queries, conn
+}
+
+func seedVantageWorld(t *testing.T, conn *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	// One agent-bound network (agent-62) so 'all' plans have a destination.
+	_, err := conn.ExecContext(ctx, `INSERT INTO networks (id, name, cidr, agent_id) VALUES (3, 'lan-62', '192.168.62.0/24', 'agent-62')`)
+	require.NoError(t, err)
+	mk := func(name, target, vantage string) {
+		_, err := conn.ExecContext(ctx,
+			`INSERT INTO probe_targets (name, module, target, vantage, interval_seconds, timeout_seconds, enabled)
+			 VALUES (?, 'http', ?, ?, 60, 10, 1)`, name, target, vantage)
+		require.NoError(t, err)
+	}
+	mk("center-only", "http://center.example/", domain.ProbeVantageCenter)
+	mk("agent-only", "http://agent.example/", domain.ProbeVantageAgentPrefix+"agent-62")
+	mk("both", "http://both.example/", domain.ProbeVantageAll)
+}
+
+// TestAgentDispatch_GroupsAndFingerprints pins the routing table: agent-only
+// plans go to their agent, 'all' plans to every bound agent, center plans to
+// nobody; and an unchanged plan is NOT re-enqueued on the next tick.
+func TestAgentDispatch_GroupsAndFingerprints(t *testing.T) {
+	d, fake, _, conn := setupDispatch(t)
+	seedVantageWorld(t, conn)
+	ctx := context.Background()
+
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 1, "one plan on first tick")
+	plan := fake.plans["agent-62"][0]["targets"].([]Spec)
+	require.Len(t, plan, 2, "agent-only + all, not the center-only target")
+	names := map[string]bool{plan[0].Name: true, plan[1].Name: true}
+	require.True(t, names["agent-only"] && names["both"])
+	for _, spec := range plan {
+		require.Equal(t, domain.ProbeVantageAgentPrefix+"agent-62", spec.Vantage,
+			"'all' must be canonicalized to the receiving agent's track")
+	}
+
+	// Unchanged plan: second tick enqueues nothing.
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 1, "steady state must be zero command traffic")
+
+	// Plan change (interval edit) re-ships exactly once more.
+	_, err := conn.ExecContext(ctx, `UPDATE probe_targets SET interval_seconds = 120 WHERE name = 'both'`)
+	require.NoError(t, err)
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 2)
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 2)
+}
+
+// TestAgentDispatch_ClearsEmptyPlan pins the empty-plan clear: when an
+// agent's whole target set disappears it receives ONE final empty plan; an
+// agent that never had targets receives nothing.
+func TestAgentDispatch_ClearsEmptyPlan(t *testing.T) {
+	d, fake, _, conn := setupDispatch(t)
+	seedVantageWorld(t, conn)
+	ctx := context.Background()
+
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 1)
+
+	_, err := conn.ExecContext(ctx, `DELETE FROM probe_targets WHERE vantage != 'center'`)
+	require.NoError(t, err)
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 2, "exactly one clearing plan")
+	clearPlan := fake.plans["agent-62"][1]["targets"].([]Spec)
+	require.Empty(t, clearPlan)
+	d.DispatchTick(ctx)
+	require.Len(t, fake.plans["agent-62"], 2, "no repeat clears")
+}
+
+// TestIngestAgentResults_OwnsVantage pins the ownership rule: whatever
+// vantage the payload claims, rows are stored under the REPORTING agent's
+// track; rows for deleted targets are skipped, not failed.
+func TestIngestAgentResults_OwnsVantage(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	queries := db.New(conn)
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	engine := NewEngine(queries, quiet, nil)
+	svc := New(queries, engine)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, validCreate("http", "http://x.example/"))
+	require.NoError(t, err)
+
+	// Payload lies about the vantage; ingest stamps the agent's own track.
+	n, err := svc.IngestAgentResults(ctx, "agent-62", []AgentResultReport{
+		{TargetID: created.ID, Vantage: "center", Status: "success", LatencyMs: 12.5, CheckedAt: "2026-08-26T02:00:00Z"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	res, _, err := svc.Results(ctx, created.ID, "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, domain.ProbeVantageAgentPrefix+"agent-62", res[0].Vantage)
+	require.Equal(t, "success", res[0].Status)
+
+	// Unknown target id: skipped silently.
+	n, err = svc.IngestAgentResults(ctx, "agent-62", []AgentResultReport{
+		{TargetID: 9999, Status: "success", CheckedAt: "2026-08-26T02:01:00Z"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+}

--- a/internal/service/probetarget/engine.go
+++ b/internal/service/probetarget/engine.go
@@ -55,11 +55,13 @@ const (
 // nextDue map (seeded from last_run_at on first sight) prevents re-probing a
 // target the process just probed before a restart.
 type Engine struct {
-	queries     *db.Queries
-	logger      *slog.Logger
-	metrics     *metrics
-	probers     map[string]probe.Prober // http/tcp/icmp modules
-	certCollect certCollector
+	queries *db.Queries
+	logger  *slog.Logger
+	metrics *metrics
+	// exec is the stateless module dispatcher (probers + cert collector).
+	// Split out of Engine so the AGENT-side vantage prober (#277) reuses
+	// the exact execution core without dragging the center DB along.
+	exec targetExecutor
 
 	nextDue  map[int64]time.Time
 	mu       sync.Mutex // guards nextDue
@@ -81,15 +83,17 @@ func NewEngine(queries *db.Queries, logger *slog.Logger, reg prometheus.Register
 		queries: queries,
 		logger:  logger,
 		metrics: newMetrics(reg),
-		probers: map[string]probe.Prober{
-			"http": &probe.HTTPProber{},
-			"tcp":  &probe.TCPProber{},
-			"icmp": &probe.ICMPProber{},
+		exec: targetExecutor{
+			probers: map[string]probe.Prober{
+				"http": &probe.HTTPProber{},
+				"tcp":  &probe.TCPProber{},
+				"icmp": &probe.ICMPProber{},
+			},
+			certCollect: scannerv2probe.CollectCertChain,
 		},
-		certCollect: scannerv2probe.CollectCertChain,
-		nextDue:     make(map[int64]time.Time),
-		sem:         make(chan struct{}, maxConcurrency),
-		done:        make(chan struct{}),
+		nextDue: make(map[int64]time.Time),
+		sem:     make(chan struct{}, maxConcurrency),
+		done:    make(chan struct{}),
 	}
 }
 
@@ -170,7 +174,7 @@ func (e *Engine) tick(ctx context.Context) {
 		if t.Vantage != domain.ProbeVantageCenter && t.Vantage != domain.ProbeVantageAll {
 			continue
 		}
-		current[t.Name+"/"+t.Module] = true
+		current[t.Name+"/"+t.Module+"/"+domain.ProbeVantageCenter] = true
 
 		due, ok := e.nextDue[t.ID]
 		if !ok {
@@ -247,17 +251,17 @@ func (e *Engine) probeTarget(ctx context.Context, t db.ProbeTarget) (domain.Prob
 	defer e.inFlight.Delete(t.ID)
 
 	checkedAt := time.Now().UTC().Format(time.RFC3339)
-	out := e.execute(ctx, t)
+	out := e.exec.execute(ctx, t)
 
 	if err := e.queries.CreateProbeResult(ctx, db.CreateProbeResultParams{
 		TargetID:     t.ID,
-		Status:       out.status,
-		LatencyMs:    float64(out.latency.Microseconds()) / 1000.0,
-		StatusCode:   int64(out.statusCode),
-		ErrorMessage: out.errMsg,
-		TlsVersion:   out.tlsVersion,
-		CertNotAfter: out.certNotAfter,
-		CertTrusted:  certTrustedDB(out.certTrusted),
+		Status:       out.Status,
+		LatencyMs:    float64(out.Latency.Microseconds()) / 1000.0,
+		StatusCode:   int64(out.StatusCode),
+		ErrorMessage: out.ErrMsg,
+		TlsVersion:   out.TLSVersion,
+		CertNotAfter: out.CertNotAfter,
+		CertTrusted:  certTrustedDB(out.CertTrusted),
 		CheckedAt:    checkedAt,
 		Vantage:      domain.ProbeVantageCenter, // the engine IS the center executor
 	}); err != nil {
@@ -266,9 +270,9 @@ func (e *Engine) probeTarget(ctx context.Context, t db.ProbeTarget) (domain.Prob
 
 	if err := e.queries.SetProbeTargetLastResult(ctx, db.SetProbeTargetLastResultParams{
 		LastRunAt:     checkedAt,
-		LastStatus:    out.status,
-		LastLatencyMs: float64(out.latency.Microseconds()) / 1000.0,
-		LastError:     out.errMsg,
+		LastStatus:    out.Status,
+		LastLatencyMs: float64(out.Latency.Microseconds()) / 1000.0,
+		LastError:     out.ErrMsg,
 		ID:            t.ID,
 	}); err != nil {
 		e.logger.Error("probe engine: update target last-result failed", "target_id", t.ID, "error", err)
@@ -277,23 +281,23 @@ func (e *Engine) probeTarget(ctx context.Context, t db.ProbeTarget) (domain.Prob
 	// Upsert only on successful collection: a transient handshake failure must
 	// not wipe the last known-good chain (deliberately unlike host_tls_certs,
 	// whose "current state" semantics serve a different UI).
-	if len(out.certs) > 0 {
-		if err := e.upsertCerts(ctx, t.ID, out.certs); err != nil {
+	if len(out.Certs) > 0 {
+		if err := e.upsertCerts(ctx, t.ID, out.Certs); err != nil {
 			e.logger.Error("probe engine: upsert certs failed", "target_id", t.ID, "error", err)
 		}
 	}
 
-	e.metrics.record(t.Name, t.Module, out.status, out.latency.Seconds(), certExpiryUnix(out.certNotAfter))
+	e.metrics.record(t.Name, t.Module, domain.ProbeVantageCenter, out.Status, out.Latency.Seconds(), certExpiryUnix(out.CertNotAfter))
 
 	return domain.ProbeResultResponse{
 		TargetID:     t.ID,
-		Status:       out.status,
-		LatencyMs:    float64(out.latency.Microseconds()) / 1000.0,
-		StatusCode:   out.statusCode,
-		ErrorMessage: out.errMsg,
-		TLSVersion:   out.tlsVersion,
-		CertNotAfter: out.certNotAfter,
-		CertTrusted:  out.certTrusted,
+		Status:       out.Status,
+		LatencyMs:    float64(out.Latency.Microseconds()) / 1000.0,
+		StatusCode:   out.StatusCode,
+		ErrorMessage: out.ErrMsg,
+		TLSVersion:   out.TLSVersion,
+		CertNotAfter: out.CertNotAfter,
+		CertTrusted:  out.CertTrusted,
 		CheckedAt:    checkedAt,
 	}, nil
 }

--- a/internal/service/probetarget/engine_test.go
+++ b/internal/service/probetarget/engine_test.go
@@ -54,7 +54,7 @@ func (f *fakeProber) count() int {
 func newTestEngine(t *testing.T, queries *db.Queries, fp *fakeProber, cc certCollector) *Engine {
 	t.Helper()
 	e := NewEngine(queries, slog.New(slog.NewTextHandler(io.Discard, nil)), nil /* no metrics */)
-	e.probers = map[string]probe.Prober{"http": fp, "tcp": fp, "icmp": fp}
+	e.exec.probers = map[string]probe.Prober{"http": fp, "tcp": fp, "icmp": fp}
 	if cc == nil {
 		// Never touch the network from tests; modules that don't collect certs
 		// never invoke this anyway.
@@ -62,7 +62,7 @@ func newTestEngine(t *testing.T, queries *db.Queries, fp *fakeProber, cc certCol
 			return []scannerv2.TLSCertRecord{{Error: "stub: no cert collection in tests"}}
 		}
 	}
-	e.certCollect = cc
+	e.exec.certCollect = cc
 	return e
 }
 
@@ -185,7 +185,7 @@ func TestEngine_TLSCollectionFailureKeepsLastGoodChain(t *testing.T) {
 
 	// Handshake now fails (e.g. transient network) — the stored chain must
 	// survive so the UI keeps showing the last known-good certificate.
-	engine.certCollect = func(_ context.Context, _ string, _ int, _ time.Duration) []scannerv2.TLSCertRecord {
+	engine.exec.certCollect = func(_ context.Context, _ string, _ int, _ time.Duration) []scannerv2.TLSCertRecord {
 		return []scannerv2.TLSCertRecord{{IP: "example.com", Port: 443, Error: "dial tcp: i/o timeout"}}
 	}
 	resp, err := engine.TriggerNow(ctx, tgt.ID)

--- a/internal/service/probetarget/executor.go
+++ b/internal/service/probetarget/executor.go
@@ -20,6 +20,7 @@ import (
 	"mibee-steward/internal/db"
 	"mibee-steward/internal/service/probe"
 	"mibee-steward/internal/service/scannerv2"
+	scannerv2probe "mibee-steward/internal/service/scannerv2/probe"
 )
 
 // certCollector mirrors scannerv2probe.CollectCertChain's signature so tests
@@ -29,36 +30,71 @@ import (
 // auto-derived from the address).
 type certCollector func(ctx context.Context, host string, port int, timeout time.Duration) []scannerv2.TLSCertRecord
 
-// outcome is a single probe execution's result, before persistence. The cert
+// Outcome is a single probe execution's result, before persistence. The cert
 // summary fields mirror the probe_results summary columns (history without a
 // join); certs carries the full chain for the probe_tls_certs upsert.
-type outcome struct {
-	status       string // success | fail | timeout
-	latency      time.Duration
-	statusCode   int // http module only
-	errMsg       string
-	tlsVersion   string
-	certNotAfter string // leaf NotAfter, RFC3339; "" = none collected
-	certTrusted  *bool
-	certs        []scannerv2.TLSCertRecord // nil unless a chain was collected
+// Exported because the agent reuses the same executor for vantage probing
+// (#277): the agent has no center DB, so it runs RunTarget and ships the
+// outcome back over the command/report channel instead of persisting.
+type Outcome struct {
+	Status       string // success | fail | timeout
+	Latency      time.Duration
+	StatusCode   int // http module only
+	ErrMsg       string
+	TLSVersion   string
+	CertNotAfter string // leaf NotAfter, RFC3339; "" = none collected
+	CertTrusted  *bool
+	Certs        []scannerv2.TLSCertRecord // nil unless a chain was collected
+}
+
+// outcome kept as a spelling alias so the engine-side call sites read
+// naturally during the export migration.
+type outcome = Outcome
+
+// targetExecutor is the stateless module dispatcher: which probers to use and
+// how to collect certificate chains. Split from Engine so the agent-side
+// vantage prober (#277) reuses the exact execution core without the center DB.
+type targetExecutor struct {
+	probers     map[string]probe.Prober // http/tcp/icmp modules
+	certCollect certCollector
+}
+
+// defaultTargetExecutor is what RunTarget (and the agent) use: the production
+// probers + the scanner's real cert collector.
+var defaultTargetExecutor = targetExecutor{
+	probers: map[string]probe.Prober{
+		"http": &probe.HTTPProber{},
+		"tcp":  &probe.TCPProber{},
+		"icmp": &probe.ICMPProber{},
+	},
+	certCollect: scannerv2probe.CollectCertChain,
+}
+
+// RunTarget dispatches one target to its module prober — the shared
+// execution core used by BOTH the center engine and the agent-side vantage
+// prober (#277). Never panics on an unknown module (returns a fail outcome)
+// — the CHECK constraint makes that unreachable, but callers must never
+// wedge on bad data.
+func RunTarget(ctx context.Context, t db.ProbeTarget) Outcome {
+	return defaultTargetExecutor.execute(ctx, t)
 }
 
 // execute dispatches one target to its module prober. Never panics on an
 // unknown module (returns a fail outcome) — the CHECK constraint makes that
 // unreachable, but the engine must never wedge on bad data.
-func (e *Engine) execute(ctx context.Context, t db.ProbeTarget) outcome {
+func (x *targetExecutor) execute(ctx context.Context, t db.ProbeTarget) outcome {
 	timeout := time.Duration(t.TimeoutSeconds) * time.Second
 	switch t.Module {
 	case "http":
-		return e.executeHTTP(ctx, t, timeout)
+		return x.executeHTTP(ctx, t, timeout)
 	case "tls":
-		return e.executeTLS(ctx, t, timeout)
+		return x.executeTLS(ctx, t, timeout)
 	case "tcp":
-		return e.executeSimple(ctx, t, "tcp", timeout)
+		return x.executeSimple(ctx, t, "tcp", timeout)
 	case "icmp":
-		return e.executeSimple(ctx, t, "icmp", timeout)
+		return x.executeSimple(ctx, t, "icmp", timeout)
 	default:
-		return outcome{status: "fail", errMsg: "unknown module: " + t.Module}
+		return outcome{Status: "fail", ErrMsg: "unknown module: " + t.Module}
 	}
 }
 
@@ -69,11 +105,11 @@ func (e *Engine) execute(ctx context.Context, t db.ProbeTarget) outcome {
 // collector still captures the chain so the UI can show WHY it failed. A
 // collection failure never flips an otherwise-successful HTTP probe — the cert
 // fields are simply absent for that run.
-func (e *Engine) executeHTTP(ctx context.Context, t db.ProbeTarget, timeout time.Duration) outcome {
-	res, err := e.probers["http"].Probe(ctx, t.Target, timeout)
+func (x *targetExecutor) executeHTTP(ctx context.Context, t db.ProbeTarget, timeout time.Duration) outcome {
+	res, err := x.probers["http"].Probe(ctx, t.Target, timeout)
 	if err != nil {
 		// Prober-level error (not the target's fault) — counts as fail.
-		return outcome{status: classifyError(err.Error()), errMsg: err.Error()}
+		return outcome{Status: classifyError(err.Error()), ErrMsg: err.Error()}
 	}
 	out := outcomeFromResult(res)
 
@@ -85,7 +121,7 @@ func (e *Engine) executeHTTP(ctx context.Context, t db.ProbeTarget, timeout time
 				port = n
 			}
 		}
-		out.attachCerts(e.collectCerts(ctx, host, port, timeout))
+		out.attachCerts(x.collectCerts(ctx, host, port, timeout))
 	}
 	return out
 }
@@ -93,40 +129,40 @@ func (e *Engine) executeHTTP(ctx context.Context, t db.ProbeTarget, timeout time
 // executeTLS is the pure certificate probe: handshake host:port, success =
 // leaf record carries no Error. Latency wraps the whole collection call
 // (two handshakes — collection + trust verdict), documented as such.
-func (e *Engine) executeTLS(ctx context.Context, t db.ProbeTarget, timeout time.Duration) outcome {
+func (x *targetExecutor) executeTLS(ctx context.Context, t db.ProbeTarget, timeout time.Duration) outcome {
 	host, portStr, err := net.SplitHostPort(t.Target)
 	if err != nil {
-		return outcome{status: "fail", errMsg: "invalid target: " + err.Error()}
+		return outcome{Status: "fail", ErrMsg: "invalid target: " + err.Error()}
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return outcome{status: "fail", errMsg: "invalid target port"}
+		return outcome{Status: "fail", ErrMsg: "invalid target port"}
 	}
 
 	start := time.Now()
-	certs := e.collectCerts(ctx, host, port, timeout)
-	out := outcome{latency: time.Since(start)}
+	certs := x.collectCerts(ctx, host, port, timeout)
+	out := outcome{Latency: time.Since(start)}
 	leaf := certs[0] // collectCerts guarantees ≥1 record
 	if leaf.Error != "" {
-		out.status = classifyError(leaf.Error)
-		out.errMsg = leaf.Error
+		out.Status = classifyError(leaf.Error)
+		out.ErrMsg = leaf.Error
 		return out
 	}
-	out.status = "success"
-	out.tlsVersion = leaf.TLSVersion
-	out.certNotAfter = leaf.NotAfter
+	out.Status = "success"
+	out.TLSVersion = leaf.TLSVersion
+	out.CertNotAfter = leaf.NotAfter
 	trusted := leaf.Trusted
-	out.certTrusted = &trusted
-	out.certs = certs
+	out.CertTrusted = &trusted
+	out.Certs = certs
 	return out
 }
 
 // executeSimple serves the tcp/icmp modules: straight passthrough to the
 // shared probers (target grammar already validated at CRUD time).
-func (e *Engine) executeSimple(ctx context.Context, t db.ProbeTarget, module string, timeout time.Duration) outcome {
-	res, err := e.probers[module].Probe(ctx, t.Target, timeout)
+func (x *targetExecutor) executeSimple(ctx context.Context, t db.ProbeTarget, module string, timeout time.Duration) outcome {
+	res, err := x.probers[module].Probe(ctx, t.Target, timeout)
 	if err != nil {
-		return outcome{status: classifyError(err.Error()), errMsg: err.Error()}
+		return outcome{Status: classifyError(err.Error()), ErrMsg: err.Error()}
 	}
 	return outcomeFromResult(res)
 }
@@ -134,8 +170,8 @@ func (e *Engine) executeSimple(ctx context.Context, t db.ProbeTarget, module str
 // collectCerts wraps the injected collector, preserving CollectCertChain's
 // ≥1-record invariant (error-only record on handshake failure) even if a test
 // double forgets it.
-func (e *Engine) collectCerts(ctx context.Context, host string, port int, timeout time.Duration) []scannerv2.TLSCertRecord {
-	certs := e.certCollect(ctx, host, port, timeout)
+func (x *targetExecutor) collectCerts(ctx context.Context, host string, port int, timeout time.Duration) []scannerv2.TLSCertRecord {
+	certs := x.certCollect(ctx, host, port, timeout)
 	if len(certs) == 0 {
 		return []scannerv2.TLSCertRecord{{IP: host, Port: port, Error: "tls handshake returned no records"}}
 	}
@@ -150,25 +186,25 @@ func (o *outcome) attachCerts(certs []scannerv2.TLSCertRecord) {
 		return
 	}
 	leaf := certs[0]
-	o.tlsVersion = leaf.TLSVersion
-	o.certNotAfter = leaf.NotAfter
+	o.TLSVersion = leaf.TLSVersion
+	o.CertNotAfter = leaf.NotAfter
 	trusted := leaf.Trusted
-	o.certTrusted = &trusted
-	o.certs = certs
+	o.CertTrusted = &trusted
+	o.Certs = certs
 }
 
 // outcomeFromResult maps a shared prober Result to an outcome.
 func outcomeFromResult(res *probe.Result) outcome {
 	out := outcome{
-		latency:    res.Latency,
-		statusCode: res.StatusCode,
+		Latency:    res.Latency,
+		StatusCode: res.StatusCode,
 	}
 	if res.Success {
-		out.status = "success"
+		out.Status = "success"
 		return out
 	}
-	out.status = classifyError(res.ErrorMessage)
-	out.errMsg = res.ErrorMessage
+	out.Status = classifyError(res.ErrorMessage)
+	out.ErrMsg = res.ErrorMessage
 	return out
 }
 

--- a/internal/service/probetarget/metrics.go
+++ b/internal/service/probetarget/metrics.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"mibee-steward/internal/domain"
 )
 
 // metrics wraps the Prometheus collectors the engine exposes on the public
@@ -31,10 +33,13 @@ import (
 // mibee_probe_up / cert expiry from Prometheus, not from MiBee itself).
 // A nil receiver disables all metric ops (tests pass a nil registerer).
 type metrics struct {
-	up         *prometheus.GaugeVec   // mibee_probe_up{name,module}: 1/0
-	duration   *prometheus.GaugeVec   // mibee_probe_duration_seconds{name,module}
-	certExpiry *prometheus.GaugeVec   // mibee_probe_cert_expiry_timestamp_seconds{name,module}
-	checks     *prometheus.CounterVec // mibee_probe_checks_total{status,module}
+	// vantage label (#277): "center" or "agent:{id}" — WHERE the probe ran.
+	// Existing {name,module}-only alert selectors keep matching the new
+	// series (adding a label never narrows an old selector).
+	up         *prometheus.GaugeVec   // mibee_probe_up{name,module,vantage}
+	duration   *prometheus.GaugeVec   // mibee_probe_duration_seconds{name,module,vantage}
+	certExpiry *prometheus.GaugeVec   // mibee_probe_cert_expiry_timestamp_seconds{name,module,vantage}
+	checks     *prometheus.CounterVec // mibee_probe_checks_total{status,module,vantage}
 
 	// seen tracks the gauge label pairs ever recorded so retain() can prune
 	// series of deleted targets (a lingering mibee_probe_up for a target that
@@ -45,8 +50,9 @@ type metrics struct {
 }
 
 type labelPair struct {
-	name   string
-	module string
+	name    string
+	module  string
+	vantage string
 }
 
 // Registration is process-global (DefaultRegisterer) and NewRouter can run
@@ -74,25 +80,25 @@ func newMetrics(r prometheus.Registerer) *metrics {
 				Subsystem: "probe",
 				Name:      "up",
 				Help:      "Whether the last probe of this target succeeded (1/0). Mirrors blackbox_exporter's probe_success.",
-			}, []string{"name", "module"}),
+			}, []string{"name", "module", "vantage"}),
 			duration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: "mibee",
 				Subsystem: "probe",
 				Name:      "duration_seconds",
 				Help:      "Duration of the last probe of this target in seconds.",
-			}, []string{"name", "module"}),
+			}, []string{"name", "module", "vantage"}),
 			certExpiry: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: "mibee",
 				Subsystem: "probe",
 				Name:      "cert_expiry_timestamp_seconds",
 				Help:      "Leaf certificate NotAfter as a Unix timestamp. Mirrors blackbox_exporter's probe_ssl_earliest_cert_expiry; absent when no cert was collected.",
-			}, []string{"name", "module"}),
+			}, []string{"name", "module", "vantage"}),
 			checks: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace: "mibee",
 				Subsystem: "probe",
 				Name:      "checks_total",
 				Help:      "Total probe executions by outcome and module.",
-			}, []string{"status", "module"}),
+			}, []string{"status", "module", "vantage"}),
 		}
 		r.MustRegister(sharedGa.up, sharedGa.duration, sharedGa.certExpiry, sharedGa.checks)
 	})
@@ -106,7 +112,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 // record sets the current-outcome gauges for one target and bumps the checks
 // counter. certExpiryUnix nil = no cert collected this run (the expiry gauge
 // series is dropped so stale expiries don't linger).
-func (m *metrics) record(name, module, status string, latencySeconds float64, certExpiryUnix *float64) {
+func (m *metrics) record(name, module, vantage, status string, latencySeconds float64, certExpiryUnix *float64) {
 	if m == nil {
 		return
 	}
@@ -114,21 +120,24 @@ func (m *metrics) record(name, module, status string, latencySeconds float64, ce
 	if status == "success" {
 		up = 1.0
 	}
-	m.up.WithLabelValues(name, module).Set(up)
-	m.duration.WithLabelValues(name, module).Set(latencySeconds)
+	m.up.WithLabelValues(name, module, vantage).Set(up)
+	m.duration.WithLabelValues(name, module, vantage).Set(latencySeconds)
 	if certExpiryUnix == nil {
-		m.certExpiry.DeleteLabelValues(name, module)
+		m.certExpiry.DeleteLabelValues(name, module, vantage)
 	} else {
-		m.certExpiry.WithLabelValues(name, module).Set(*certExpiryUnix)
+		m.certExpiry.WithLabelValues(name, module, vantage).Set(*certExpiryUnix)
 	}
-	m.checks.WithLabelValues(status, module).Inc()
+	m.checks.WithLabelValues(status, module, vantage).Inc()
 
 	m.mu.Lock()
-	m.seen[name+"/"+module] = labelPair{name: name, module: module}
+	m.seen[name+"/"+module+"/"+vantage] = labelPair{name: name, module: module, vantage: vantage}
 	m.mu.Unlock()
 }
 
-// retain prunes gauge series whose (name,module) is no longer in current —
+// retain prunes CENTER-track gauge series whose (name,module) is no longer in
+// current. Agent-track series (written by the ingest path) are left alone:
+// the center cannot know when an agent stops reporting a target, and a
+// stale agent gauge is the visibility (stale marker) rather than a lie.
 // targets deleted while this process was running stop being reported instead
 // of freezing at their last value.
 func (m *metrics) retain(current map[string]bool) {
@@ -138,10 +147,13 @@ func (m *metrics) retain(current map[string]bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for key, p := range m.seen {
+		if p.vantage != domain.ProbeVantageCenter {
+			continue
+		}
 		if !current[key] {
-			m.up.DeleteLabelValues(p.name, p.module)
-			m.duration.DeleteLabelValues(p.name, p.module)
-			m.certExpiry.DeleteLabelValues(p.name, p.module)
+			m.up.DeleteLabelValues(p.name, p.module, p.vantage)
+			m.duration.DeleteLabelValues(p.name, p.module, p.vantage)
+			m.certExpiry.DeleteLabelValues(p.name, p.module, p.vantage)
 			delete(m.seen, key)
 		}
 	}


### PR DESCRIPTION
## 定位

#277 四步中的**步骤 2(执行通道)**。步骤 1(数据模型,#328)已合入,且其 tick 分流已预置(中心跳过 agent-only 目标)。本 PR 补齐剩下的全链路;步骤 3(UI 并排展示)与差异高亮后续单独做。

## 架构(设计要点)

**配置下发一次,agent 完全本地执行**——与"每 interval 发一条命令"的替代方案相比:拨测间隔可低于命令通道 60s 轮询周期、零稳态流量、中心断线期间探测照常。稳态零流量的保证是指纹门控:每个 agent 的计划内容(排序后规格列表)取 sha256,不变不下发。

| 组件 | 职责 |
|---|---|
| `AgentDispatcher`(中心) | 10s 比对各 agent 计划指纹,变化时 Enqueue `probe` 命令;'all' 计划规范化为接收方轨道;清空时发一次空计划 |
| `Prober`(agent) | 计划应用后本地调度(首见即测,后续按 interval;10s tick 生效增删改);批量缓冲 10s/32 条上报 |
| `POST /agents/probe-report` | agent 令牌认证;**上报身份覆盖 payload vantage**(agent 只能写自己的轨);计划竞争行静默跳过 |
| metrics | 四个 mibee_probe_* 指标加 vantage 标签(旧选择器仍匹配);retain 只剪中心轨 |

执行核拆分:`targetExecutor`(无状态 probers+certCollector)+ 导出 `Outcome` + 包级 `RunTarget` —— agent 复用与中心完全一致的探测语义(含证书链采集)。

**丢批语义**(有意的):探测是观测不是账本——中心不可达时丢一批样本优于在路由器上无限缓冲(scan reporter 保缓冲是因为扫描报告是资产账本,拨测不是)。

## 测试

- dispatcher:分组路由表(agent-only→本 agent / all→每个绑定 agent / center→无人)、指纹跳过(改 interval 恰好重发一次)、空计划清理恰好一次
- ingest:轨道归属覆盖(payload 谎称 center 仍写成 agent:62)、未知目标跳过
- prober:计划整体替换无合并残留、空计划清空
- 本地全量 go test 全绿(Windows;CI Linux 复核)

## 验收(issue 的验收标准)

合并后部署 .102/.174,同一外网目标建 `vantage: all` → 中心与 agent-62 两轨结果分别入库 —— 部署实测后在本 PR 追记。