### PR TITLE
docs: 中文更新日志落地为真翻译 + 英文 CHANGELOG 去中文残留

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,9 @@ jobs:
           node-version: '20'
       - name: markdownlint (MD040 fenced-code-language)
         run: npx -y markdownlint-cli2@0.23.2 "**/*.md"
-      - name: Changelog mirror drift check
+      - name: Changelog docs sync check
+        # regenerates the en mirror (must match the committed copy) and
+        # version-checks the hand-maintained zh translation
         run: |
           ./scripts/gen_changelog_mirror.sh
-          git diff --exit-code -- docs/zh/changelog.md docs/en/changelog.md
+          git diff --exit-code -- docs/en/changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Network-ops staple: periodically pull each router/switch/firewall's running-conf
 - **Storage**: `device_configs` (versioned per `device_uuid`: fetched_at, config_hash, config_text, protocol, diff vs previous) and `ssh_credentials` (encrypted with the same AES-256-GCM master-key cipher as SNMPv3; CRUD API encrypts on write and redacts on read).
 - **SSH probe engine** (`scannerv2/configbackup`): `golang.org/x/crypto/ssh` with a vendor command matrix (Juniper JunOS `show configuration | display set`; HP / Aruba / H3C / Comware `display current-configuration`; Cisco IOS/NX-OS, Arista, Huawei VRP, Mikrotik and unknowns fall back to `show running-config`) and host-key **TOFU** (trust-on-first-use) recording.
 - **Service**: scheduled sweep selects router/switch/firewall devices with bound credentials, fetches, diffs, and records a new version only on change — a change emits a **`device_config_changed`** event into `change_log` + the in-process Watcher (so it feeds the changes page, SSE watch, and notification rules).
-- **Read API + UI**: `GET /devices/{id}/configs` (list), `/{configId}` (detail), `/diff?a=&b=` (two-version compare); device detail gains a **配置历史** tab with version list, detail modal, and hand-colored unified-diff rendering.
+- **Read API + UI**: `GET /devices/{id}/configs` (list), `/{configId}` (detail), `/diff?a=&b=` (two-version compare); device detail gains a **Config History** tab with version list, detail modal, and hand-colored unified-diff rendering.
 - Real-router end-to-end smoke (GL-MT3000) is deferred to the next release — the code path is complete and browser-verified against the API.
 
 ### Built-in notifier: device events → webhook/email (issue #139)
@@ -157,7 +157,7 @@ surgically merge around it. Fixed at the root:
   `ssh_credential_id` column.
 
 
-### Synthetic probing / 拨测 (Phase 1)
+### Synthetic Probing (Phase 1)
 
 **Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured
 probe targets (typically internet resources: a public HTTPS site, a hosted mail
@@ -574,7 +574,7 @@ and introduces official multi-arch container images on GHCR.
 - **Read API** `GET /api/v1/devices/{id}/certificates`: per-port grouping with
   leaf + chain; status-coloring metadata (TLS version, cipher suite, trust
   verdict, error).
-- **Frontend TLS sub-panel**: new "TLS 证书" panel under Scan Discovery — one
+- **Frontend TLS sub-panel**: new "TLS Certificates" panel under Scan Discovery — one
   clickable row per port with status-colored left border (green=valid / amber=
   expiring <15d / red=expired), day-count badge, self-signed/trusted tags.
 - **`CertificateModal.svelte`**: full-chain viewer — status header, summary field

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,10 @@ sync-device-types:
 	@cp -v configs/fingerprints/device-types/device_types.yaml internal/service/scannerv2/runner/device_types.yaml
 	@echo "device_types.yaml synced to runner embed dir"
 
-# docs-changelog-sync regenerates the docs/{zh,en}/changelog.md mirrors from
-# the root CHANGELOG.md (#322). Run whenever CHANGELOG.md changes; the CI
-# `docs` job runs the same script and fails on drift.
+# docs-changelog-sync regenerates the docs/en/changelog.md mirror from the
+# root CHANGELOG.md and version-checks the hand-maintained Chinese translation
+# (docs/zh/changelog.md) against it (#322). Run whenever CHANGELOG.md changes;
+# the CI `docs` job runs the same script and fails on drift.
 docs-changelog-sync:
 	@./scripts/gen_changelog_mirror.sh
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Documentation is maintained bilingually: `zh/` (中文) and `en/` (English) are 
 - [eBPF 被动观测 / eBPF Observer](zh/ebpf.md) · [EN](en/ebpf.md) — passive TC-based observation
 - [指纹库适配器规范 / Fingerprint Spec](zh/fingerprint-spec.md) · [EN](en/fingerprint-spec.md) — normative rule-format specification
 - [开发与贡献 / Development](zh/development.md) · [EN](en/development.md) — environment, conventions, CLA/DCO
-- [更新日志 / Changelog](zh/changelog.md) · [EN](en/changelog.md) — mirror of the root `CHANGELOG.md` (update together)
+- [更新日志 / Changelog](zh/changelog.md) · [EN](en/changelog.md) — the root `CHANGELOG.md` (EN) plus its hand-maintained Chinese translation (update together)
 
 ### 其他 / Extras
 
@@ -39,7 +39,7 @@ Documentation is maintained bilingually: `zh/` (中文) and `en/` (English) are 
 
 - **Single source of truth**: this directory IS the manual. The MiBee Studio website docs center (www.mlsbs.top/#/docs/mibeesteward/) syncs from `docs/{zh,en}/` automatically — the website mirrors the repo, never the other way around.
 - **Website sync mechanics**: the site pulls `docs/{zh,en}/` into `public/docs/mibeesteward/{zh-CN,en-US}/` via its `sync-docs.ps1` script (slug = filename, 1:1). Keep filenames stable; **renaming/moving/deleting a page requires an issue** so the website's `ArticleMap` and `manifest.json` can be updated in lockstep — a silent rename becomes a 404 on the site. In-manual cross-links use bare `slug.md`; targets outside the collection use absolute links.
-- **Changelog mirror**: `en/changelog.md` is a verbatim copy of the root [CHANGELOG.md](../CHANGELOG.md); `zh/changelog.md` is the same content behind a Chinese note. Both are **generated** — run `make docs-changelog-sync` after editing `CHANGELOG.md`; the CI `docs` job fails on drift.
+- **Changelog docs**: `en/changelog.md` is a **generated** verbatim copy of the root [CHANGELOG.md](../CHANGELOG.md) — never hand-edit it; run `make docs-changelog-sync` after editing `CHANGELOG.md`. `zh/changelog.md` is a **hand-maintained Chinese translation** of the same content (the website publishes it verbatim as the zh manual's changelog page, so it must be actual Chinese, not an English mirror). After changing `CHANGELOG.md`, update the translation in the same PR — the sync script's coverage check (identical version-header sets on both sides) and the CI `docs` job fail on drift. Keep code identifiers, config keys, API paths, and issue numbers verbatim.
 - **Fence languages**: every code fence carries a language annotation (`go`, `bash`, `yaml`, `mermaid`, …; plain output as `text`) — enforced by markdownlint MD040 in the CI `docs` job, because the website's highlight.js rendering degrades to monochrome without it.
 - **Diagrams**: use Mermaid fenced blocks; do not use ASCII-art diagrams.
 - **Screenshots**: WebP, 1440×900 viewport, light theme, stored under `{zh,en}/images/` and referenced with relative paths (`images/foo.webp`) — the website sync script downloads relative image srcs into the site automatically. Every screenshot must be **sanitized**: demo-safe IPs (`192.168.1.x` / `192.168.2.x`), generic device names, no real MACs/hostnames/credentials. Capture via `scripts/docs_sanitize_proxy.py` (reverse proxy that rewrites API responses) and audit before publishing.

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -1132,7 +1132,7 @@ Get device heartbeat results.
 
 `status` is one of `success` / `fail` / `timeout`; `checked_at` is an RFC3339 string.
 
-## Synthetic Probing (拨测)
+## Synthetic Probing
 
 Periodic probing of EXPLICIT user-configured endpoints (blackbox_exporter-style), typically external/internet resources. Four modules: `http` / `tls` / `tcp` / `icmp`. The `tls` module — and https-flavored `http` targets — collect the full certificate chain (reusing the scanner's internal cert inventory for external hosts; results carry a trust verdict and TLS version). Reads (`CapProbeRead`) are available to any logged-in user; writes (`CapProbeManage`) require operator and above.
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -57,7 +57,7 @@ Network-ops staple: periodically pull each router/switch/firewall's running-conf
 - **Storage**: `device_configs` (versioned per `device_uuid`: fetched_at, config_hash, config_text, protocol, diff vs previous) and `ssh_credentials` (encrypted with the same AES-256-GCM master-key cipher as SNMPv3; CRUD API encrypts on write and redacts on read).
 - **SSH probe engine** (`scannerv2/configbackup`): `golang.org/x/crypto/ssh` with a vendor command matrix (Juniper JunOS `show configuration | display set`; HP / Aruba / H3C / Comware `display current-configuration`; Cisco IOS/NX-OS, Arista, Huawei VRP, Mikrotik and unknowns fall back to `show running-config`) and host-key **TOFU** (trust-on-first-use) recording.
 - **Service**: scheduled sweep selects router/switch/firewall devices with bound credentials, fetches, diffs, and records a new version only on change — a change emits a **`device_config_changed`** event into `change_log` + the in-process Watcher (so it feeds the changes page, SSE watch, and notification rules).
-- **Read API + UI**: `GET /devices/{id}/configs` (list), `/{configId}` (detail), `/diff?a=&b=` (two-version compare); device detail gains a **配置历史** tab with version list, detail modal, and hand-colored unified-diff rendering.
+- **Read API + UI**: `GET /devices/{id}/configs` (list), `/{configId}` (detail), `/diff?a=&b=` (two-version compare); device detail gains a **Config History** tab with version list, detail modal, and hand-colored unified-diff rendering.
 - Real-router end-to-end smoke (GL-MT3000) is deferred to the next release — the code path is complete and browser-verified against the API.
 
 ### Built-in notifier: device events → webhook/email (issue #139)
@@ -157,7 +157,7 @@ surgically merge around it. Fixed at the root:
   `ssh_credential_id` column.
 
 
-### Synthetic probing / 拨测 (Phase 1)
+### Synthetic Probing (Phase 1)
 
 **Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured
 probe targets (typically internet resources: a public HTTPS site, a hosted mail
@@ -574,7 +574,7 @@ and introduces official multi-arch container images on GHCR.
 - **Read API** `GET /api/v1/devices/{id}/certificates`: per-port grouping with
   leaf + chain; status-coloring metadata (TLS version, cipher suite, trust
   verdict, error).
-- **Frontend TLS sub-panel**: new "TLS 证书" panel under Scan Discovery — one
+- **Frontend TLS sub-panel**: new "TLS Certificates" panel under Scan Discovery — one
   clickable row per port with status-colored left border (green=valid / amber=
   expiring <15d / red=expired), day-count badge, self-signed/trusted tags.
 - **`CertificateModal.svelte`**: full-chain viewer — status header, summary field

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -537,7 +537,7 @@ The synchronous scan endpoint (`POST /api/v1/scanner/scan`) imposes a hard targe
 | `retention.device_neighbors_days` | int | 90 | Device neighbor records retention (days) |
 | `retention.host_services_days` | int | 30 | Host service records retention (days) |
 | `retention.host_tls_certs_days` | int | 30 | TLS certificate records retention (days) |
-| `retention.probe_results_days` | int | 30 | Synthetic-probe (拨测) result history retention (days). `probe_tls_certs` is not swept — it holds only each target's current chain |
+| `retention.probe_results_days` | int | 30 | Synthetic-probe result history retention (days). `probe_tls_certs` is not swept — it holds only each target's current chain |
 | `retention.sweep_interval_hours` | int | 6 | Cleanup sweep interval (hours) |
 | `retention.batch_size` | int | 5000 | Max rows per cleanup batch |
 

--- a/docs/en/integrations.md
+++ b/docs/en/integrations.md
@@ -40,7 +40,7 @@ Notification rules (event → channel, see [Web UI](web-ui.md) → Settings → 
 |---|---|---|
 | `webhook` | `url`, optional `headers` map | Custom headers (e.g. your receiver's token) |
 | `email` | SMTP `host`/`port`/`username`/`password`, `from`, `to` | SMTP AUTH |
-| `feishu` | `url`, optional `secret` | 飞书 custom-bot HMAC signature (enable "签名校验" on the bot and paste the secret) |
+| `feishu` | `url`, optional `secret` | Feishu custom-bot HMAC signature (enable signature verification on the bot and paste the secret) |
 | `wecom` | `url` | none (the webhook URL is the credential — treat it as secret) |
 | `telegram` | `bot_token`, `chat_id` | Bot API token |
 | `discord` | `url`, optional `username` | none (webhook URL is the credential) |

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -1,801 +1,396 @@
-> 本页由 `make docs-changelog-sync` 从仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 自动生成（保留英文原文，便于与仓库逐字对照），请勿手改。
+# 更新日志
 
+本页是仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 的**中文版**，与英文原文逐版本对应维护（技术名词、配置键、API 路径、议题编号保留原文）。新增或修改英文条目后请在同一 PR 内更新本页 —— `make docs-changelog-sync` 会校验两侧版本清单一致，CI `docs` 任务据此拦截漂移。
 
-# Changelog
+格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
+版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-All notable changes to MiBee Steward are documented in this file.
+## [Unreleased]（未发布）
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### 新增
 
-## [Unreleased]
+- **Agent 网络扫描任务（#336）**：目标地址落在 agent 托管网段内的 `scan_tasks`，现在每个 cron tick 都会向该 agent 下发一条扫描命令 —— 不再需要外部定时器或内嵌密码的脚本。下发结果落入任务的运行历史（被拒绝的下发，例如目标超出网段，会作为一条带原因的失败运行记录）。本地网络任务不受影响。
+- **可配置密码策略（#332）**：`auth.password_policy`（min_length + 四类字符开关）。默认值与此前硬编码规则完全一致；部分块只覆盖其显式写出的键。
+- **可配置登录锁定（#338）**：`auth.lockout`（max_failed_attempts / lock_minutes）。锁定期满后现在会重置失败计数 —— 过期后的一次误试不会再立即重新锁定（此前，持有过期密码的周期客户端可能让账户无限期处于锁定态）。账户锁定响应从 429 改为 **423** 并附带 retry-after 提示，UI 也能区分"账户已锁定"与"尝试过于频繁"。
+- **设备文档 Markdown 上传与预览（#324）**：`.md` 上传（MIME 归一化 + 拒绝二进制内容）、经净化（DOMPurify）的弹窗内 GFM 预览、软删除与可用的撤销（恢复端点）、按设备列出文档的修复、`?inline=1` PDF 预览、类型化上传错误（413/415/400）。
+- **合成负载压测工具（#313）**：`cmd/loadgen` 提供一个 127/8 合成设备面（内核 ICMP + SNMP/HTTP/SSH/RTSP 应答器），通过真实 API 驱动全栈基准测试；`scanner.allow_reserved_targets` 是该设备面的逃生开关。
+- **演示模式（#315 / #285）**：`server.demo_mode`（或 `-demo`）在空数据库上灌入虚构的 TEST-NET 资产清单。
+- **多视角拨测数据模型（#328，#277 第 1 步）**：`probe_targets.vantage` 执行计划 + 按视角分离的结果轨道。
+- 官网内容：功能总览 / 场景玩法指引 / 同类工具对比三篇文章，中英双语（#320）。
 
-### Added
+### 修复
 
-- **Agent-network scan tasks (#336)**: `scan_tasks` whose targets resolve to an agent-managed network now dispatch a scan command to that agent on every cron tick — no external timer or password-bearing scripts. Dispatch results land in the task's run history (a rejected dispatch, e.g. out-of-CIDR targets, is recorded as a failed run with the reason). Local-network tasks are unchanged.
-- **Configurable password policy (#332)**: `auth.password_policy` (min_length + four character-class toggles). Defaults reproduce the previous hardcoded rules exactly; partial blocks override only the keys they name.
-- **Configurable login lockout (#338)**: `auth.lockout` (max_failed_attempts / lock_minutes). An expired lock now resets the failure counter — a stray retry after expiry no longer re-locks instantly (previously, a periodic client with a stale password could keep an account locked indefinitely). Account-lock responses moved from 429 to **423** with a retry-after hint, and the UI now distinguishes "account locked" from "too many attempts".
-- **Markdown upload & preview for device documents (#324)**: `.md` upload (MIME normalization + binary-content rejection), GFM preview in a sanitized (DOMPurify) dialog, soft-delete with working undo (restore endpoint), per-device document listing fix, `?inline=1` PDF preview, typed upload errors (413/415/400).
-- **Synthetic load harness (#313)**: `cmd/loadgen` serves a 127/8 synthetic device plane (kernel ICMP + SNMP/HTTP/SSH/RTSP responders) and drives full-stack benchmarks through the real API; `scanner.allow_reserved_targets` is the escape hatch for that plane.
-- **Demo mode (#315 / #285)**: `server.demo_mode` (or `-demo`) seeds a fictional TEST-NET inventory on an empty database.
-- **Multi-vantage probing data model (#328, step 1 of #277)**: `probe_targets.vantage` execution plans + per-vantage result tracks.
-- Website content: feature overview / playbooks / comparison articles, zh+en (#320).
-
-### Fixed
-
-- **Reserved-range scan targets rejected (#318 / #317)**: loopback / unspecified / link-local / multicast / broadcast / 240-4 targets are refused at every scan entry point (task create/update, sync scan, agent command dispatch); CIDR expansion drops network/broadcast addresses (nmap semantics, also closes the .255 phantom-device class of #254). Target expansion consolidated into `internal/cidrutil`.
-- **`MIBEE_*` env overrides for underscore keys (#334 / #331)**: exact env-name→key mapping derived from the Config struct; underscore-bearing keys (`initial_admin_password`, `allow_reserved_targets`, …) were previously silently unreachable from the environment.
-- **Device gauges refresh periodically (#335 / #333)**: `mibee_devices_total` no longer freezes at the process-start snapshot.
-- **`-demo` with a broken config no longer segfaults (#330 / #327)**.
-- **Agent mini-DB startup migrations (#339 / #337)**: the agent's local schema now ships the full column set (offline_since / device_uuid / ssh_credential_id / scan_tasks.network_id+credential_id) and upgrades legacy DBs in place — previously every device-identity roam/replace silently degraded with "no such column".
-- Windows build/test parity restored (#325 / #321); sqlite BUSY write-path governance + retry metrics (#311 / #267); schema version gating + backup retention (#312 / #268); scannerv2 store migrated to sqlc (#314 / #269); dashboard layout freeze (#302); agent fleet management (#309 / #278); fingerprint coverage reporting (#308 / #282); ecosystem notification channels + Grafana dashboards (#307 / #284); SSE change-stream in the UI (#306 / #272); probe UX batch (#305 / #276); VLAN name collection (#304 / #273); `doctor` subcommand (#303 / #281); OpenWrt operator docs (#329 / #316); docs governance batch (#326).
+- **拒绝保留网段扫描目标（#318 / #317）**：环回 / 未指定 / 链路本地 / 多播 / 广播 / 240- 开头目标在每个扫描入口（任务创建/更新、同步扫描、agent 命令下发）一律拒绝；CIDR 展开剔除网络地址与广播地址（nmap 语义，同时关掉 #254 的 .255 幽灵设备一类问题）。目标展开逻辑收敛进 `internal/cidrutil`。
+- **下划线键的 `MIBEE_*` 环境变量覆盖（#334 / #331）**：从 Config 结构体推导出精确的环境变量名 → 配置键映射；此前含下划线的键（`initial_admin_password`、`allow_reserved_targets` 等）在环境变量侧静默不可达。
+- **设备量表周期性刷新（#335 / #333）**：`mibee_devices_total` 不再冻结在进程启动时的快照。
+- **`-demo` 携带损坏配置时不再段错误（#330 / #327）**。
+- **Agent 本地库启动迁移（#339 / #337）**：agent 本地 schema 现在带全量列集（offline_since / device_uuid / ssh_credential_id / scan_tasks.network_id+credential_id）并原地升级旧库 —— 此前每次设备身份漫游/替换都会因 "no such column" 静默劣化。
+- Windows 构建/测试一致性恢复（#325 / #321）；sqlite BUSY 写路径治理 + 重试指标（#311 / #267）；schema 版本门控 + 备份保留（#312 / #268）；scannerv2 store 迁移到 sqlc（#314 / #269）；仪表盘布局冻结修复（#302）；agent 舰队管理（#309 / #278）；指纹覆盖率报告（#308 / #282）；生态通知渠道 + Grafana 仪表盘（#307 / #284）；UI 内 SSE 变更流（#306 / #272）；拨测 UX 批次（#305 / #276）；VLAN 名称采集（#304 / #273）；`doctor` 子命令（#303 / #281）；OpenWrt 运维文档（#329 / #316）；文档治理批（#326）。
 
 ## [0.5.0] - 2026-08-19
 
-**SNMPv3 + multi-role RBAC + device config backup + built-in notifier + synthetic probing + liveness time series.** v0.5.0 clears the enterprise-adoption hard gates: **SNMPv3** (USM authNoPriv/authPriv with an encrypted credential vault), a **role/capability RBAC model with object-level network scoping** (admin / operator / viewer + per-user network grants), **device config backup** (Oxidized/RANCID-style: scheduled `show running-config` pulls over SSH, versioned storage, two-version diffs, change-detection integration), a **minimal built-in notifier** (device events → webhook/email without running Alertmanager), and **synthetic probing** of external endpoints. Under the hood, device liveness becomes a **time series** (killing a change-log noise storm), device identity is keyed by `device_uuid` across satellite tables, and the release is rounded out by OUI longest-prefix vendor inference, a topology-visualization polish pass, observability wiring fixes, and a large frontend UX/a11y/correctness batch.
+**SNMPv3 + 多角色 RBAC + 设备配置备份 + 内置通知器 + 拨测 + 鲜活度时间序列。** v0.5.0 清掉了企业落地的硬门槛：**SNMPv3**（USM authNoPriv/authPriv + 加密凭据保险库）、**角色/能力 RBAC 模型与对象级网络作用域**（admin / operator / viewer + 按用户的网络授权）、**设备配置备份**（Oxidized/RANCID 风格：SSH 定时拉取 `show running-config`、版本化存储、双版本 diff、接入变更检测）、一个**极简内置通知器**（设备事件 → webhook/邮件，无需跑 Alertmanager），以及外部端点的**拨测**。底层方面，设备鲜活度改为**时间序列**（根治变更日志噪声风暴），设备身份以 `device_uuid` 贯穿各卫星表；版本收尾还包含 OUI 最长前缀厂商推断、拓扑可视化打磨、可观测性接线修复，以及一大批前端 UX/无障碍/正确性改进。
 
-### RBAC: multi-role capability model + object-level network scoping (issue #138)
+### RBAC：多角色能力模型 + 对象级网络作用域（议题 #138）
 
-The 2-role model (admin / user with a one-size-fits-all `RequireAdmin`) is replaced by a **capability graph + per-network object scoping** — unlocking team and MSP scenarios:
+双角色模型（admin / user 一刀切的 `RequireAdmin`）被替换为**能力图 + 按网络的对象作用域** —— 解锁团队与 MSP 场景：
 
-- **Roles & capabilities**: `users.role` CHECK widened to `admin` / `operator` / `viewer` (`user` remains as a legacy alias for viewer). Every route is gated by a **capability** (`CapDeviceRead`, `CapScanTrigger`, `CapDeviceWrite`, …) via a new `RequireCapability` middleware; roles map to capability sets and admin inherits everything. All `RequireAdmin` call sites were remapped, and shared read surfaces uniformly require their `CapXxxRead` capability.
-- **Network grants**: new `user_network_grants` table + admin management API (`/api/v1/users/{id}/network-grants` + `/api/v1/networks/{id}/grants`) + a users-page UI for assigning which networks a non-admin can see.
-- **Scope modes** (`rbac.scope_default`, default `open`): in `open` mode non-admins see every network (single-team behavior preserved); in `closed` mode a non-admin sees ONLY granted networks — enforced across the whole read surface (device lists/detail, scanner tasks/runs/results, changes, topology), with unauthorized details returning `404`. Admin always bypasses scope; unknown config values fall back to `open` (fail-safe against lockout).
-- **Scanner object scoping**: `scan_tasks.network_id` stamps each task's owning network; in closed mode non-admins only see/trigger tasks within their granted networks, and the scan-target network-boundary check carries over.
-- Migration is zero-drama for existing installs: admins stay admins, `user` rows keep working as viewers, and `open` mode preserves the previous visibility exactly.
+- **角色与能力**：`users.role` CHECK 扩为 `admin` / `operator` / `viewer`（`user` 保留为 viewer 的遗留别名）。每条路由都由一个**能力**（`CapDeviceRead`、`CapScanTrigger`、`CapDeviceWrite` 等）经新的 `RequireCapability` 中间件把关；角色映射到能力集，admin 继承一切。所有 `RequireAdmin` 调用点完成重映射，共享只读面统一要求对应的 `CapXxxRead` 能力。
+- **网络授权**：新 `user_network_grants` 表 + 管理端 API（`/api/v1/users/{id}/network-grants` + `/api/v1/networks/{id}/grants`）+ 用户页 UI，用于指定非 admin 用户可见哪些网络。
+- **作用域模式**（`rbac.scope_default`，默认 `open`）：`open` 模式下非 admin 可见全部网络（保留单团队行为）；`closed` 模式下非 admin **只**可见被授权的网络 —— 在整个读面上强制（设备列表/详情、扫描任务/运行/结果、变更、拓扑），未授权详情返回 `404`。admin 始终绕过作用域；未知配置值回落 `open`（防锁死的失效安全）。
+- **扫描器对象作用域**：`scan_tasks.network_id` 为每个任务盖所属网络章；closed 模式下非 admin 只能查看/触发其授权网络内的任务，扫描目标的网络边界检查同样生效。
+- 存量安装零波澜迁移：admin 仍是 admin，`user` 行继续按 viewer 工作，`open` 模式完整保留既有可见性。
 
-### SNMPv3 (authNoPriv / authPriv) — issue #135
+### SNMPv3（authNoPriv / authPriv）— 议题 #135
 
-The last hard enterprise gate: hardened environments increasingly disable v2c community strings, and every serious competitor supports v3.
+最后一个企业硬门槛：加固环境日益禁用 v2c 社区串，而所有像样的竞品都支持 v3。
 
-- **Credential vault**: new `snmp_credentials` table stores USM credentials (user, auth passphrase + protocol, priv passphrase + protocol, security level) **encrypted at rest with AES-256-GCM**, keyed by `security.master_key` (exactly 32 bytes, `MIBEE_SECURITY_MASTER_KEY` override). The key is optional until the first v3 credential exists — existing v1/v2c deployments keep working unchanged.
-- **Probe support**: the SNMP probe's version loop gains `Version3`; authNoPriv (MD5/SHA/SHA-2) and authPriv (+ AES/DES) credentials are tried per target, and ALL OID paths work under v3 — the 8-OID identity collection and the LLDP-MIB / CDP-MIB / Bridge-MIB / Q-BRIDGE-MIB / STP-MIB / IF-MIB topology walks.
-- **API + UI**: credential CRUD with write-time encryption and read-time redaction (passphrases never echo back); scan forms and device pages carry v3 options with a security-level dropdown.
-- Agent-side v3 is intentionally deferred (issue #241 — needs a distributed credential design); agents keep v1/v2c.
+- **凭据保险库**：新 `snmp_credentials` 表存储 USM 凭据（用户名、auth 口令 + 协议、priv 口令 + 协议、安全级别），**落盘 AES-256-GCM 加密**，密钥来自 `security.master_key`（恰好 32 字节，可用 `MIBEE_SECURITY_MASTER_KEY` 覆盖）。在第一个 v3 凭据出现之前密钥是可选的 —— 既有 v1/v2c 部署完全不受影响。
+- **探测支持**：SNMP 探测器的版本循环加入 `Version3`；authNoPriv（MD5/SHA/SHA-2）与 authPriv（+ AES/DES）凭据按目标尝试，所有 OID 路径在 v3 下可用 —— 8-OID 身份采集以及 LLDP-MIB / CDP-MIB / Bridge-MIB / Q-BRIDGE-MIB / STP-MIB / IF-MIB 拓扑遍历。
+- **API + UI**：凭据 CRUD，写入加密、读取脱敏（口令永不回显）；扫描表单与设备页带 v3 选项和安全级别下拉。
+- agent 侧 v3 有意延后（议题 #241 —— 需要分布式凭据设计）；agent 维持 v1/v2c。
 
-### Device config backup — Oxidized/RANCID-style (issue #137)
+### 设备配置备份 — Oxidized/RANCID 风格（议题 #137）
 
-Network-ops staple: periodically pull each router/switch/firewall's running-config, version it, diff it, and wire config changes into change detection. Ships end-to-end (browser-verified); **opt-in** via `scanner.config_backup.enabled` (default off — requires `security.master_key` + an SSH credential bound to a device).
+网络运维的标配：周期性拉取每台路由器/交换机/防火墙的 running-config，版本化、做 diff、并把配置变更接入变更检测。端到端交付（浏览器实测）；经 `scanner.config_backup.enabled` **选择开启**（默认关 —— 需要 `security.master_key` + 绑定到设备的 SSH 凭据）。
 
-- **Storage**: `device_configs` (versioned per `device_uuid`: fetched_at, config_hash, config_text, protocol, diff vs previous) and `ssh_credentials` (encrypted with the same AES-256-GCM master-key cipher as SNMPv3; CRUD API encrypts on write and redacts on read).
-- **SSH probe engine** (`scannerv2/configbackup`): `golang.org/x/crypto/ssh` with a vendor command matrix (Juniper JunOS `show configuration | display set`; HP / Aruba / H3C / Comware `display current-configuration`; Cisco IOS/NX-OS, Arista, Huawei VRP, Mikrotik and unknowns fall back to `show running-config`) and host-key **TOFU** (trust-on-first-use) recording.
-- **Service**: scheduled sweep selects router/switch/firewall devices with bound credentials, fetches, diffs, and records a new version only on change — a change emits a **`device_config_changed`** event into `change_log` + the in-process Watcher (so it feeds the changes page, SSE watch, and notification rules).
-- **Read API + UI**: `GET /devices/{id}/configs` (list), `/{configId}` (detail), `/diff?a=&b=` (two-version compare); device detail gains a **配置历史** tab with version list, detail modal, and hand-colored unified-diff rendering.
-- Real-router end-to-end smoke (GL-MT3000) is deferred to the next release — the code path is complete and browser-verified against the API.
+- **存储**：`device_configs`（按 `device_uuid` 版本化：fetched_at、config_hash、config_text、protocol、与前版 diff）和 `ssh_credentials`（与 SNMPv3 同一套 AES-256-GCM 主密钥加密；CRUD API 写加密读脱敏）。
+- **SSH 探测引擎**（`scannerv2/configbackup`）：`golang.org/x/crypto/ssh` + 厂商命令矩阵（Juniper JunOS `show configuration | display set`；HP / Aruba / H3C / Comware `display current-configuration`；Cisco IOS/NX-OS、Arista、华为 VRP、Mikrotik 及未知设备回落 `show running-config`）与主机密钥 **TOFU**（首次使用即信任）记录。
+- **服务**：定时清扫选取绑定了凭据的路由器/交换机/防火墙设备，抓取、比对，仅在变更时记录新版本 —— 变更会向 `change_log` + 进程内 Watcher 发出 **`device_config_changed`** 事件（进而喂给变更页、SSE watch 与通知规则）。
+- **读取 API + UI**：`GET /devices/{id}/configs`（列表）、`/{configId}`（详情）、`/diff?a=&b=`（双版本对比）；设备详情新增 **Config History** 标签页（英文界面；中文界面为"配置历史"），带版本列表、详情弹窗与手工着色的 unified-diff 渲染。
+- 真机端到端冒烟（GL-MT3000）延后到下一版 —— 代码路径完整，且已针对 API 完成浏览器验证。
 
-### Built-in notifier: device events → webhook/email (issue #139)
+### 内置通知器：设备事件 → webhook/邮件（议题 #139）
 
-SOHO/branch users no longer need a Prometheus+Alertmanager stack just to get "device lost" emails. A **rule engine** subscribes to the change-detection Watcher and routes matched events through the existing notification dispatcher (webhook/email channels, 3 workers, per-user read state) — a thin rule→channel hop, deliberately NOT an alerting engine:
+SOHO/分支用户不再需要为了收到"设备失联"邮件而搭一套 Prometheus+Alertmanager。**规则引擎**订阅变更检测 Watcher，把命中事件经既有通知分发器（webhook/邮件通道、3 个 worker、按用户的已读状态）路由出去 —— 一层薄薄的规则→通道跳转，刻意**不做**告警引擎：
 
-- New `notification_rules` table: event type (`device_lost` / `device_recovered` / `device_added` / `device_changed`), scope (all / network / device-by-uuid), target channel, `cooldown_minutes` (default 30) per (rule × device) anti-flap window, enable toggle.
-- The engine layers per-(rule, device) cooldowns on top of the change-detector's existing liveness cooldown — flapping devices don't spam channels.
+- 新 `notification_rules` 表：事件类型（`device_lost` / `device_recovered` / `device_added` / `device_changed`）、作用域（全部 / 网络 / 按 UUID 的设备）、目标通道、按（规则 × 设备）防抖的 `cooldown_minutes`（默认 30）、启用开关。
+- 引擎在变更检测器既有鲜活度冷却之上叠加按（规则, 设备）的冷却 —— 抖动设备不会刷屏通道。
 
-### Device liveness time series + identity hardening (issues #114 / #115 / #116 / #117 / #120 / #129)
+### 设备鲜活度时间序列 + 身份加固（议题 #114 / #115 / #116 / #117 / #120 / #129）
 
-Fixes a change-detection noise storm at the root: liveness (online/offline) was modeled as discrete `device_changed` events, so every status flip fired a row (70k+ burying real changes on the test network).
+从根上修复变更检测噪声风暴：鲜活度（在线/离线）此前被建模为离散 `device_changed` 事件，每次状态翻转都写一行（测试网络上 7 万+ 行淹没了真实变更）。
 
-- **`device_liveness` time series** (in the heartbeat store): one online/offline verdict sample per device per tick, batched through the existing buffered-write/WAL infrastructure. Queries: `OnlineRatio` (window jitter-vs-transition signal), `OfflineDuration`, `LivenessHistory`. Disposable — `devices.status` stays the source of truth.
-- **Tiered change events**: status flips are consumed by the liveness tier instead of spamming `device_changed`; real adds/changes/losses stay crisp.
-- **`device_uuid` as the satellite key**: heartbeat targets and the satellite tables key by the stable device UUID (not IP), so address changes don't fork history. Fixes the empty-sentinel regression where a device's second scan showed stale data (#129).
-- **Lease sweeper flap decay**: agent-network flap counts decay instead of hard-resetting, so a flapping device trends toward lost instead of ping-ponging.
-- **Silent-device retention**: scanner-discovered devices with no heartbeat are auto-pruned — MAC-bearing devices after `retention.silent_device_days_mac` (default 7d), MAC-less identities after `retention.silent_device_hours_no_mac` (default 24h). Manual devices are never auto-deleted; coming back online resets the clock.
-- **Liveness in the UI**: device detail exposes last-seen / offline-since / last-online.
+- **`device_liveness` 时间序列**（心跳库内）：每设备每 tick 一条在线/离线判定样本，走既有的缓冲写/WAL 设施。查询：`OnlineRatio`（窗口内抖动 vs 翻转信号）、`OfflineDuration`、`LivenessHistory`。可丢弃 —— `devices.status` 仍是事实源。
+- **分层变更事件**：状态翻转被鲜活度层消化，不再刷 `device_changed`；真实的新增/变更/失联保持清晰。
+- **`device_uuid` 作为卫星表键**：心跳目标与卫星表按键稳定的设备 UUID（而非 IP）关联，地址变化不再分叉历史。修复设备第二次扫描显示陈旧哨兵数据的回归（#129）。
+- **租约清扫器抖动衰减**：agent 网络的抖动计数改为衰减而非硬清零，抖动设备会趋向失联而不是来回横跳。
+- **静默设备保留**：无心跳的扫描发现设备自动清退 —— 带 MAC 的设备 `retention.silent_device_days_mac`（默认 7 天）后、无 MAC 身份 `retention.silent_device_hours_no_mac`（默认 24 小时）后。手动登记的设备永不自动删除；重新上线重置计时。
+- **UI 中的鲜活度**：设备详情暴露最近发现 / 离线始于 / 最近在线。
 
-### Topology visualization polish (issue #136)
+### 拓扑可视化打磨（议题 #136）
 
-The L2 data (LLDP/CDP/Bridge/Q-BRIDGE/STP edges) was already the richest among OSS peers — now the rendering catches up:
+L2 数据（LLDP/CDP/Bridge/Q-BRIDGE/STP 边）本就已是 OSS 同类中最全 —— 这次让渲染跟上：
 
-- **Layered force-directed layout**: core/distribution/access layers with distinct node colors; the legend doubles as a per-layer visibility filter.
-- **Search + focus**: typing dims non-matching nodes; clicking a node highlights its neighbors and opens a detail card (IP/MAC/type/degree).
-- **Port drill-down**: edges expose local/remote port, VLAN tag, and STP role from `topology_edges`.
-- **Performance**: option rebuilds are incremental; large graphs stay interactive.
+- **分层力导向布局**：核心/汇聚/接入三层节点异色；图例兼作按层可见性过滤器。
+- **搜索 + 聚焦**：输入即压暗不匹配节点；点击节点高亮其邻居并打开详情卡（IP/MAC/类型/度数）。
+- **端口下钻**：边暴露来自 `topology_edges` 的本地/对端端口、VLAN 标签与 STP 角色。
+- **性能**：选项重建改为增量；大图保持可交互。
 
-### Handler/service charter debt cleared: the 4 grandfathered handlers migrated (issue #240)
+### Handler/Service 章程债务清偿：4 个豁免 handler 迁移完毕（议题 #240）
 
-The last four mutating handlers that wrote to the DB directly (documented as
-charter debt since #166) now go through service layers — the charter has no
-remaining debt rows:
+最后四个直写数据库的变更类 handler（自 #166 起记录为章程债务）全部改走 service 层 —— 章程不再有存量债务行：
 
-- **`service.NetworkService`**: network CRUD; the raw-SQL UPDATE workaround
-  (sqlc truncation) moved out of the handler into the service.
-- **`service.AgentTokenService`**: agent-token create/revoke/delete, including
-  the `networks.agent_id` stamp-on-create / conditional-clear-on-revoke wiring.
-  Token MINTING stays in the HTTP layer (one-time credential display) and is
-  injected as a `TokenMinter` func — keeps the service free of api-layer imports.
-- **`service.AgentCommandService`**: enqueue (with the scan-target
-  network-boundary check, now returning a typed `BoundaryError` that carries the
-  offending IPs verbatim), ack, complete.
-- **`service.ScannerResultService`**: `BulkDeleteResults` (before-date
-  validation + delete).
+- **`service.NetworkService`**：网络 CRUD；raw-SQL UPDATE 的权宜方案（sqlc 截断问题）从 handler 移入 service。
+- **`service.AgentTokenService`**：agent 令牌的创建/吊销/删除，含 `networks.agent_id` 的创建时盖章 / 吊销时条件清空接线。令牌**铸造**留在 HTTP 层（一次性凭据展示），以 `TokenMinter` 函数注入 —— service 层保持不依赖 api 层。
+- **`service.AgentCommandService`**：入队（含扫描目标网络边界检查，现返回携带违规 IP 原文的类型化 `BoundaryError`）、确认、完成。
+- **`service.ScannerResultService`**：`BulkDeleteResults`（前日期校验 + 删除）。
 
-Read-only passthroughs (List/Poll/ListAll/export) stay on `*db.Queries` per the
-charter's sanctioned exception. Behavior is unchanged at the HTTP surface (one
-message nuance: a revoke of an already-revoked token now returns "agent token
-not found" instead of "...or already revoked"). `internal/api/AGENTS.md` debt
-table cleared.
+只读透传（List/Poll/ListAll/export）按章程许可的例外继续使用 `*db.Queries`。HTTP 表面行为不变（一处消息差异：吊销一个已吊销令牌现在返回 "agent token not found" 而非 "...or already revoked"）。`internal/api/AGENTS.md` 债务表清空。
 
-### Metrics: dead collectors wired up + metrics_path honored (issues #238 / #239)
+### 指标：死采集器接线 + metrics_path 生效（议题 #238 / #239）
 
-**HeartbeatFailures was a dead alert** — `mibee_heartbeat_checks_total` (and five
-siblings) were registered at `/metrics` but never incremented in production
-code, so the alert's expression was permanently 0. Fixed by moving the
-collectors to a new neutral package and wiring the producers:
+**HeartbeatFailures 此前是个死告警** —— `mibee_heartbeat_checks_total`（及五个兄弟指标）在 `/metrics` 注册了却从未在生产代码中递增，告警表达式恒为 0。修复方式是把采集器搬到中立包并接上生产方：
 
-- **`internal/metrics`** (new): the 7 `mibee_*` collectors moved out of
-  `internal/api/handler` so the service layer can increment them without an
-  handler→service→handler import cycle. `handler.MetricsHandler` /
-  `UpdateDeviceMetrics` unchanged in behavior.
-- **Heartbeat**: `probeAndRecord` now increments
-  `mibee_heartbeat_checks_total{status}` per recorded outcome and observes
-  `mibee_heartbeat_latency_seconds{method}` — the `HeartbeatFailures` alert
-  rule evaluates against real data.
-- **Scanner**: run completion/failure increments
-  `mibee_scanner_runs_total{status}`, observes
-  `mibee_scanner_duration_seconds`, and adds alive hosts to
-  `mibee_scanner_hosts_discovered`; `mibee_scanner_tasks_total{status}` is
-  refreshed at scheduler start and after task CRUD
-  (`metrics.RefreshScannerTaskGauges`).
-- **`prometheus.metrics_path`** now actually configures the mount point
-  (previously defined in config but hard-coded to `/metrics`; empty or
-  non-absolute values fall back to `/metrics`).
+- **`internal/metrics`**（新包）：7 个 `mibee_*` 采集器搬出 `internal/api/handler`，service 层得以递增它们而不引发 handler→service→handler 导入环。`handler.MetricsHandler` / `UpdateDeviceMetrics` 行为不变。
+- **心跳**：`probeAndRecord` 现在按记录结果递增 `mibee_heartbeat_checks_total{status}` 并观测 `mibee_heartbeat_latency_seconds{method}` —— `HeartbeatFailures` 告警规则终于对着真实数据求值。
+- **扫描器**：运行完成/失败递增 `mibee_scanner_runs_total{status}`、观测 `mibee_scanner_duration_seconds`、向 `mibee_scanner_hosts_discovered` 累加存活主机；`mibee_scanner_tasks_total{status}` 在调度器启动与任务 CRUD 后刷新（`metrics.RefreshScannerTaskGauges`）。
+- **`prometheus.metrics_path`** 现在真正生效于挂载点（此前配置里定义了却硬编码 `/metrics`；空值或非绝对路径回落 `/metrics`）。
 
-### sqlc: generated code back in sync with schema.sql + CI drift guard (issue #237)
+### sqlc：生成代码与 schema.sql 重新对齐 + CI 漂移守卫（议题 #237）
 
-The committed `internal/db` had been stale since #233 (`scan_tasks.network_id`
-landed in schema + migrations without `sqlc generate`), so any full regenerate
-emitted per-query Row structs that broke ~10 call sites — PR #235 had to
-surgically merge around it. Fixed at the root:
+仓库里的 `internal/db` 自 #233 起就处于陈旧状态（`scan_tasks.network_id` 进了 schema + 迁移却没跑 `sqlc generate`），任何一次全量再生成都会产出破坏约 10 个调用点的逐查询 Row 结构 —— PR #235 只能绕着做外科手术式合并。根因修复：
 
-- `db/queries/devices.sql` full-row lists now select `ssh_credential_id` (6
-  lists) and `db/queries/scan_tasks.sql` selects `network_id` (7 lists) — the
-  column sets match the tables again, so sqlc restores model reuse and NO call
-  sites needed changes. The `CreateScanTask` INSERT still does not set
-  `network_id` (stamped post-insert by raw SQL, as before).
-- Full `sqlc generate` is now idempotent against the committed tree (fresh
-  generate produces an empty diff).
-- **CI drift guard**: the `sqlc-verify` job installs sqlc **v1.31.1** (matching
-  the committed generator) and fails when `sqlc generate` produces a diff in
-  `internal/db/` — schema/query changes must ship with regenerated code.
-- Tests with hand-rolled inline `devices` schemas gained the
-  `ssh_credential_id` column.
+- `db/queries/devices.sql` 的全行列表现在选出 `ssh_credential_id`（6 处），`db/queries/scan_tasks.sql` 选出 `network_id`（7 处）—— 列集与表重新吻合，sqlc 恢复模型复用，且**零**调用点需要改动。`CreateScanTask` 的 INSERT 仍不设置 `network_id`（照旧由 raw SQL 在插入后盖章）。
+- 全量 `sqlc generate` 对当前树幂等（全新生成产出空 diff）。
+- **CI 漂移守卫**：`sqlc-verify` 任务安装 sqlc **v1.31.1**（与仓库内生成器版本一致），`sqlc generate` 在 `internal/db/` 产生 diff 即失败 —— schema/查询变更必须随附再生成后的代码。
+- 手写内联 `devices` schema 的测试补上了 `ssh_credential_id` 列。
 
+### 拨测（Synthetic Probing，第 1 期）
 
-### Synthetic probing / 拨测 (Phase 1)
+**对显式配置的外部端点做 blackbox 风格探测（PR #235）** —— 用户配置拨测目标（典型为互联网资源：公开 HTTPS 站点、托管邮件的 TLS 端口），按固定间隔探测，经数据库/API/UI 管理。扫描器的内网 TLS 证书采集（`CollectCertChain`）被直接复用于外部主机名（SNI 自动推导），把证书链清点能力延伸到局域网之外。
 
-**Blackbox-style probing of EXPLICIT external endpoints (PR #235)** — user-configured
-probe targets (typically internet resources: a public HTTPS site, a hosted mail
-TLS port) probed on fixed intervals, managed via DB/API/UI. The scanner's
-internal-network TLS certificate collection (`CollectCertChain`) is reused
-directly against external hostnames (SNI auto-derived), extending cert-chain
-inventory beyond the LAN.
+- **三张表**：`probe_targets`（name 唯一，module CHECK http/tls/tcp/icmp，interval 10–86400s、timeout 1–60s，反规范化的 last_* 结果）、`probe_results`（只追加的历史，带每次运行的证书摘要；RFC3339 字符串时间戳）、`probe_tls_certs`（每个目标**当前**的证书链，先删后插；瞬时握手失败保留上一条已知良好链 —— 区别于扫描器的当前态语义）。
+- **引擎**（`internal/service/probetarget/`）：10s tick 重读启用目标，CRUD 免重启生效；下次到期时间从 `last_run_at` 恢复（无启动风暴）；8 并发探测上限；在途守卫使同一目标的定时与手动运行互斥；`POST /{id}/trigger` 同步探测并返回记录的结果。
+- **模块**：http/tcp/icmp 复用共享心跳探测器（`probe.Result` 增加 `StatusCode`）；tls —— 以及 https 形态的 http —— 调 `CollectCertChain` 拿完整链（叶 + 签发者 + 信任判定 + TLS 版本/密码套件）。
+- **API** `/api/v1/probe-targets`：CRUD + trigger + `/{id}/results` + `/{id}/certificates`（证书响应复用设备端点的 `tlsPortCerts` 形状，前端 `CertificateModal` 零改动可用）。RBAC：`probe:read`（viewer 起）、`probe:manage`（operator 起）。
+- **Prometheus**：`mibee_probe_up`（对应 `probe_success`）、`mibee_probe_duration_seconds`、`mibee_probe_cert_expiry_timestamp_seconds`（对应 `probe_ssl_earliest_cert_expiry`）、`mibee_probe_checks_total`；`deploy/prometheus/alert_rules.yml` 内含两条示例告警规则（`ProbeTargetDown`、`ProbeCertExpiringSoon`）。
+- **保留**：`retention.probe_results_days`（默认 30 天），由既有清理服务清扫。
+- **前端**：`/probes` 管理页（状态/延迟/证书剩余天数徽章、启用开关、历史弹窗、证书链弹窗），中英 i18n，导航入口。
+- **sqlc 注记**：查询文件注释不得含撇号 —— sqlc 的 SQLite 词法器会吞掉它并静默截断生成语句（已记入 `db/AGENTS.md`）。
 
-- **Three tables**: `probe_targets` (name UNIQUE, module CHECK
-  http/tls/tcp/icmp, interval 10–86400s, timeout 1–60s, denormalized last_*
-  outcome), `probe_results` (append-only history with per-run cert summary;
-  RFC3339 string timestamps), `probe_tls_certs` (each target's CURRENT chain,
-  delete-then-insert; a transient handshake failure keeps the last known-good
-  chain — unlike the scanner's current-state semantics).
-- **Engine** (`internal/service/probetarget/`): 10s tick re-reads enabled
-  targets so CRUD applies without restart; next-due times resume from
-  `last_run_at` on restart (no startup storm); 8-probe concurrency bound;
-  in-flight guard makes scheduled and manual runs of one target mutually
-  exclusive; `POST /{id}/trigger` probes synchronously and returns the recorded
-  result.
-- **Modules**: http/tcp/icmp reuse the shared heartbeat probers
-  (`probe.Result` gains `StatusCode`); tls — and https-flavored http — call
-  `CollectCertChain` for the full chain (leaf + issuers + trust verdict +
-  TLS version/cipher).
-- **API** `/api/v1/probe-targets`: CRUD + trigger + `/{id}/results` +
-  `/{id}/certificates` (the cert response reuses the device endpoint's
-  `tlsPortCerts` shape, so the frontend `CertificateModal` works unmodified).
-  RBAC: `probe:read` (viewer+), `probe:manage` (operator+).
-- **Prometheus**: `mibee_probe_up` (mirrors `probe_success`),
-  `mibee_probe_duration_seconds`, `mibee_probe_cert_expiry_timestamp_seconds`
-  (mirrors `probe_ssl_earliest_cert_expiry`), `mibee_probe_checks_total`; two
-  example alert rules (`ProbeTargetDown`, `ProbeCertExpiringSoon`) in
-  `deploy/prometheus/alert_rules.yml`.
-- **Retention**: `retention.probe_results_days` (default 30d) swept by the
-  existing cleanup service.
-- **Frontend**: `/probes` management page (status/latency/cert-days badges,
-  enable toggle, history modal, certificate chain modal), zh/en i18n, nav entry.
-- **sqlc note**: query-file comments must NOT contain apostrophes — sqlc's
-  SQLite lexer swallows them and silently truncates the generated statement
-  (documented in `db/AGENTS.md`).
+### MAC 位标志：本地管理 / 多播（自第 1 期起中性化）
+**对 #118 第 1 期的修正（PR #121）** —— 第 1 期把本地管理（U/L）位当作"随机化 MAC"判定，并把此类设备降级为 `(ip, network_id)` 身份。这是语义越界：按 IEEE 802 / RFC 7042，U/L 位只表示"本地管理"，**无法**区分隐私随机化（iOS/Android，不稳定）与本地固定设置（软路由 / 虚拟化 / 手工，稳定）。在测试网络上，这误标了 7 台稳定的软路由/NAS，并因身份降级把其中一台（R68s）拆到了两个网络。本次变更回退错误行为，同时保留该位作为中性观测标志。
 
+- **身份降级回退**（`device_bridge.go` 的 `resolveDeviceIdentity`）：强制 `(ip, network_id)` 身份的 LAA 位闸门移除；设备身份回归纯 MAC 优先（仅在无 MAC 时走既有的 `(ip, network_id)` 回落）。
+- **中性命名**：U/L 位报告为**"本地管理（locally administered）"**，而非"随机化"。重命名：`scan_attributes.mac_is_randomized` → `mac_is_locally_administered`；辅助函数 `store.IsLocalMAC` → `IsLocallyAdministeredMAC`；UI 徽章文案 "Randomized" → "Locally Admin."，配中性 tooltip 说明该位无法区分随机与固定。`mac_is_multicast` / `IsMulticastMAC` 不变（多播位无歧义）。
+- 该标志仅作观测 —— **不**改变设备身份。完整论证（RFC 7042、IEEE 数据的许可边界等）见议题 #118 的调研评论。
 
-### MAC bit flags: locally-administered / multicast (neutralized from Phase 1)
-**Correction of #118 Phase 1 (PR #121)** — Phase 1 treated the
-locally-administered (U/L) bit as a "randomized MAC" verdict and downgraded such
-devices to `(ip, network_id)` identity. That was a semantic overreach: per IEEE
-802 / RFC 7042 the U/L bit only means "locally administered", and it **cannot**
-distinguish privacy randomization (iOS/Android, unstable) from a locally fixed
-setting (soft-router / hypervisor / manual, stable). On the test network this
-mislabelled 7 stable soft-routers/NASes and split one (R68s) across networks
-because of the identity downgrade. This change reverts the wrong behavior while
-keeping the bit as a neutral observability flag.
+### OUI 厂商推断：MA-S / MA-M / MA-L 最长前缀匹配
+**确定性的 MAC 富化** —— OUI 查询现在通过三注册库的**最长前缀匹配**把 MAC 解析到 IEEE 注册厂商：MA-S（/36，9 位十六进制，前身 IAB）→ MA-M（/28，7 位）→ MA-L（/24，6 位）。这是必须的：MA-S/MA-M 子块是从 IEEE 或其他厂商持有的 /24 OUI 中划出的 —— 没有最长前缀，以 `8C1F64B14..` 开头的 MAC 会被误标为 "IEEE Registration Authority" 而非 "Murata"（MA-S 子受让方）。
 
-- **Identity downgrade reverted** (`resolveDeviceIdentity` in `device_bridge.go`):
-  the LAA-bit gate that forced `(ip, network_id)` identity is removed; device
-  identity is pure MAC-primary again (with the existing `(ip, network_id)`
-  fallback only when no MAC is known).
-- **Neutral naming**: the U/L bit is reported as **"locally administered"**, not
-  "randomized". Renamed: `scan_attributes.mac_is_randomized` →
-  `mac_is_locally_administered`; helper `store.IsLocalMAC` →
-  `IsLocallyAdministeredMAC`; UI badge label "Randomized" → "Locally Admin." with
-  a neutral tooltip stating the bit cannot tell random from fixed. `mac_is_multicast` / `IsMulticastMAC` unchanged (multicast bit is unambiguous).
-- The flag is observability-only — it does NOT change device identity. See
-  issue #118 research comment for the full rationale (RFC 7042, license boundary
-  for IEEE data, etc.).
+- **`vendor/oui.go`**：`Lookup` 改为最长前缀匹配；新 `LookupFull` 返回 `(vendor, prefix)`，调用方可记录命中了哪个块。加载器索引全部三种长度的前缀（`NormalizeMACPrefix` 的 6 位十六进制上限经由新的 `normalizeHexPrefix` 解除）。
+- **新 `scan_attributes` 字段**：`oui_prefix`（命中的 6/7/9 位块）与 `oui_vendor`（IEEE 组织名 —— NIC 芯片厂商）。与既有 `vendor`（设备经 SNMP/HTTP/TLS 自报的品牌）**分开**；两者在 OEM/贴牌/虚拟化场景下会不一致。
+- **开箱覆盖**：`scanner.oui_path` 为空时，引擎自动从**内嵌**的 CC-BY-SA 精编表（`vendor/oui_curated.txt`，`//go:embed`）播种 —— 全新安装对常见设备即刻可用厂商推断。用户配置的完整 IEEE 文件仍可覆盖。
+- **`scripts/fetch-oui.sh` 重写**：抓取三份 IEEE CSV（MA-L/MA-M/MA-S），用 Python CSV 解析合并为单一 `<prefix>\t<vendor>` 文件（厂商名含逗号/引号）。同时修复下载 URL 的既有笔误（`standardeee.org` → `standards-oui.ieee.org`）—— 旧脚本从非规范镜像下载，本会失败。
+- **许可边界保持**：IEEE 注册库是 "All rights reserved" 的事实数据 —— **不**并入 CC-BY-SA 指纹语料（见 `docs/fingerprint-spec.md` §8"数据与代码之别"）。内嵌精编表是手工撰写的 CC-BY-SA 子集，不是 IEEE 复制品；完整 IEEE 数据集保持为可选的运行时下载。
 
-### OUI vendor inference: MA-S / MA-M / MA-L longest-prefix match
-**Deterministic MAC enrichment** — the OUI lookup now resolves a MAC to its
-IEEE-registered vendor via **longest-prefix-match** across the three registries:
-MA-S (/36, 9 hex, formerly IAB) → MA-M (/28, 7 hex) → MA-L (/24, 6 hex). This is
-mandatory because MA-S/MA-M sub-blocks are carved out of /24 OUIs owned by IEEE
-or another vendor — without longest-prefix, a MAC starting `8C1F64B14..` would
-be mislabelled "IEEE Registration Authority" instead of "Murata" (the MA-S
-sub-assignee).
+### UI：OUI 厂商（NIC 芯片）进入设备视图
+**上条 OUI 厂商推断的跟进** —— 新的 `oui_vendor` / `oui_prefix` 字段（第 2 期）现已在 UI 可见，并与设备自报 `vendor` 品牌区分展示。
 
-- **`vendor/oui.go`**: `Lookup` now does longest-prefix match; new `LookupFull`
-  returns `(vendor, prefix)` so callers can record which block matched. The
-  loader indexes prefixes of all three lengths (the 6-hex cap in
-  `NormalizeMACPrefix` is lifted via a new `normalizeHexPrefix`).
-- **New `scan_attributes` fields**: `oui_prefix` (the matched 6/7/9-hex block)
-  and `oui_vendor` (the IEEE organization name — the NIC silicon vendor). Kept
-  SEPARATE from the existing `vendor` (the device's self-declared brand via
-  SNMP/HTTP/TLS); the two differ in OEM/rebrand/virtualization cases.
-- **Out-of-box coverage**: the engine now auto-seeds from an EMBEDDED curated
-  CC-BY-SA table (`vendor/oui_curated.txt`, via `//go:embed`) when
-  `scanner.oui_path` is empty — a fresh install gets vendor inference for common
-  devices without any setup. A user-configured full IEEE file still overrides it.
-- **`scripts/fetch-oui.sh` rewritten**: fetches all three IEEE CSVs (MA-L/MA-M/
-  MA-S), merges into one `<prefix>\t<vendor>` file with Python CSV parsing
-  (vendor names contain commas/quotes). Also fixes a pre-existing typo in the
-  download URL (`standardeee.org` → `standards-oui.ieee.org`) — the old script
-  downloaded from a non-canonical mirror and would have failed.
-- **License boundary preserved**: the IEEE registries are "All rights reserved"
-  factual data — they are NOT folded into the CC-BY-SA fingerprint corpus (see
-  `docs/fingerprint-spec.md` §8 "Data vs code distinction"). The embedded
-  curated table is a hand-authored CC-BY-SA subset, not an IEEE reproduction;
-  the full IEEE set stays an optional runtime download.
+- **设备详情发现面板**：Vendor 之后新增 "OUI Vendor (NIC)" 行，显示 `oui_vendor`，tooltip 展示命中的 IEEE 块（`oui_prefix`）。
+- **展开行设备摘要**：同样位置追加该字段。
+- **Extras 泄漏修复**：store 的 `RecordDevice`/`buildStoreScanAttributes` 路径此前会让 `oui_prefix`/`oui_vendor`（及 `mac`）漏进 `scan_attributes.extras`（在 Extras 面板显示为原始 `OUI_PREFIX`/`OUI_VENDOR` 键）。现在它们映射到类型化字段并排除在 Extras 之外。
 
-### UI: OUI vendor (NIC silicon) surfaced in device views
-**Follow-up to the OUI vendor inference above** — the new `oui_vendor` /
-`oui_prefix` fields (Phase 2) are now visible in the UI, kept distinct from the
-device's self-declared `vendor` brand.
+### HTTP 面加固（议题 #133 / #164 / #165 / #177）
+- **感知可信代理的 RealIP**：弃用的 `chimw.RealIP`（无条件信任 `X-Forwarded-For`）被替换为只在来源属于配置的 `server.trusted_proxies` 时才采信转发头的中间件 —— 客户端 IP 无法再经该头伪造。
+- **哨兵错误 → 正确的 400**：service 层校验错误类型化为哨兵；handler 用 `errors.Is` 映射，不再对用户失误返回 500。
+- **credential.go 错误泄漏**：内部错误细节不再漏给 API 客户端；裸 `http.Error` 响应改为 JSON；补上哨兵映射。
 
-- **Device detail Discovery panel**: a new "OUI Vendor (NIC)" row after Vendor,
-  showing `oui_vendor` with the matched IEEE block (`oui_prefix`) as a tooltip.
-- **Expand-row device summary**: the same field after Vendor.
-- **Extras-leak fix**: the store's `RecordDevice`/`buildStoreScanAttributes`
-  path was letting `oui_prefix`/`oui_vendor` (and `mac`) fall through into
-  `scan_attributes.extras` (visible as raw `OUI_PREFIX`/`OUI_VENDOR` keys in the
-  Extras panel). They're now mapped to the typed fields and kept out of Extras.
+### 前端 UX / 无障碍 / 正确性批次（议题 #150–#176）
+SPA 的一次整固 pass：
+- **破坏性操作门**：批量设备状态翻转需要确认；五个创建/编辑弹窗增加"有未保存修改时放弃需确认"守卫。
+- **DataTable 无障碍重构**：事件委托行变为真正可交互（键盘可达、可聚焦）—— 不再只有点击。
+- **扫描取消**：长扫描可在扫描页中止（AbortController），同一校验模式应用到扫描任务与 agent 目标；登录密码获得 Zod schema。
+- **2FA 类型安全**：登录 2FA 路径去掉 `as any` 断言；2FA 后强制改密复用同一弹窗。
+- **变更反馈一致性**：用户页 toast、文档页静默成功、扫描页合并错误处理。
+- **本地化格式化**：`toLocaleString` 跟随 paraglide UI 语言（日期/数字与所选语言一致）。
+- **空态诚实**：搜索无结果不再显示误导性的创建 CTA；错误态与空态分离。
+- **修复**：`/changes/watch` SSE 不再永远显示"已断开"（#195）；变更页以结构化摘要显示显示名/IP 而非原始 JSON（#196）；仪表盘离线设备回落路径在名称退化为当前 IP 时正确解析（#197）；设备列表按 IP/网络/厂商/主机名排序带数字 IP 排序为服务端实现（#122）。
 
-### HTTP surface hardening (issues #133 / #164 / #165 / #177)
-- **Trusted-proxy-aware RealIP**: the deprecated `chimw.RealIP` (which
-  unconditionally trusted `X-Forwarded-For`) is replaced by middleware that
-  only honors forwarded headers from configured `server.trusted_proxies` —
-  client IPs can no longer be spoofed via the header.
-- **Sentinel errors → proper 400s**: service-layer validation errors are typed
-  sentinels; handlers map them with `errors.Is` instead of returning 500s for
-  user mistakes.
-- **credential.go error leak**: internal error details no longer leak to API
-  clients; plain `http.Error` responses became JSON; sentinel mapping added.
+### 性能与并发（议题 #162 / #163）
+- **扫描器性能**：UUID 查询缓存、`PRAGMA temp_store=MEMORY`、DetectLost 路径批量 miss-count 递增。
+- **并发卫生**：调度器在锁外做 IO，`LeaseSweeper` 拥有 WaitGroup，限流器与 eBPF 观测器在关机时干净停止。
 
-### Frontend UX / a11y / correctness batch (issues #150–#176)
-A consolidation pass across the SPA:
-- **Destructive-action gates**: batch device-status flips require confirmation;
-  five create/edit modals gain a confirm-on-dirty-discard guard.
-- **DataTable a11y refactor**: event-delegation rows become properly
-  interactive (keyboard-handled, focusable) — no more click-only rows.
-- **Scanner cancel**: long scans can be aborted from the scan page
-  (AbortController), with the same validation pattern applied to scan tasks and
-  agent targets; login password gains a Zod schema.
-- **2FA type safety**: the login 2FA path drops its `as any` assertions;
-  forced password-change after 2FA reuses the same modal.
-- **Mutation feedback consistency**: users-page toasts, documents-page
-  quiet-success, scanner-page merged error handling.
-- **Locale-aware formatting**: `toLocaleString` calls follow the paraglide UI
-  locale (dates/numbers match the chosen language).
-- **Empty-state honesty**: search-with-no-results no longer shows a misleading
-  create CTA; error states stay distinct from empty states.
-- **Fixes**: `/changes/watch` SSE no longer reports "disconnected" forever
-  (#195); the changes page shows display names/IPs with structured summaries
-  instead of raw JSON (#196); the dashboard offline-device fallback resolves
-  the current IP when the name degenerates to it (#197); device-list sorting
-  by IP/network/vendor/hostname with numeric IP ordering is server-side
-  (#122).
+### 代码健康（议题 #132 / #141 / #157 / #158 / #160 / #161）
+- **`internal/repository/` 解散** —— repository 类型移入 `internal/service/` 靠近消费者（少跳一层）。
+- **Handler 存根塌缩**：server/TLS handler 家族数据化注册 —— 删除约 68 个手写存根。
+- **巨型文件拆分**：`main.go` 迁移逻辑 → `migrations.go`；扫描器配置类型 → `scanner_config.go`。
+- 死代码清理：v1 扫描器存根、错放的测试辅助、`var _` 占位。
 
-### Performance & concurrency (issues #162 / #163)
-- **Scanner perf**: UUID lookup cache, `PRAGMA temp_store=MEMORY`, and batched
-  miss-count increments on the DetectLost path.
-- **Concurrency hygiene**: scheduler runs IO outside its lock,
-  `LeaseSweeper` owns a WaitGroup, the rate limiter and eBPF observer stop
-  cleanly on shutdown.
+### 测试覆盖网（议题 #134 / #171）
+对先前无测试核心的一轮特征化 + 回归测试：`runMigrations` 幂等 + 全新库、device-bridge 身份合并、router-ARP 配置解析、保留期清扫、与调度器耦合的扫描任务触发/取消、auth/CSRF/RBAC 中间件、网络 CRUD、2FA-TOTP（含一个绕过守卫）、用户管理安全路径、SNMP 凭据 handler（含口令泄漏守卫）、扫描任务 + 审计 handler，以及首批 `.svelte` 页面渲染测试（登录 / 设备 / 扫描 / 拨测）。
 
-### Code health (issues #132 / #141 / #157 / #158 / #160 / #161)
-- **`internal/repository/` dissolved** — repository types moved into
-  `internal/service/` next to their consumers (one less layer to jump).
-- **Handler stub collapse**: server/TLS handler families register
-  data-driven — ~68 handwritten stubs deleted.
-- **God-file splits**: `main.go` migration logic → `migrations.go`; scanner
-  config types → `scanner_config.go`.
-- Dead-code cleanup: v1 scanner stub, misplaced test helpers, `var _`
-  placeholders.
+### 文档
+- **官网手册迁入仓库**（`docs/{zh,en}/`，14 个双语文件）：介绍、快速开始、架构、API、配置、部署、开发、发现、分布式、eBPF、OpenWrt、指纹规范、产品范围、更新日志 —— 仓库成为官网同步的唯一事实源（议题 #234）。
+- 拨测/合成探测文档 + 配置样例补齐（议题 #236）；`config.example.yaml` 找回代码在用而样例缺失的 9 个配置块（agent/rdns/mdns/arp_scan/reconcile/retention，议题 #131）。
 
-### Test coverage net (issues #134 / #171)
-A characterization-and-regression series over the previously untested core:
-`runMigrations` idempotency + fresh-DB, device-bridge identity merges,
-router-ARP config parsing, retention sweeps, scheduler-coupled scan-task
-trigger/cancel, auth/CSRF/RBAC middleware, network CRUD, 2FA-TOTP (incl. a
-bypass guard), user-management security paths, SNMP-credential handler
-(incl. a passphrase-leak guard), scanner-task + audit handlers, and the first
-`.svelte` page render tests (login / devices / scanner / probes).
-
-### Documentation
-- **Website manuals migrated into the repo** (`docs/{zh,en}/`, 14 bilingual
-  files): introduction, quick-start, architecture, API, configuration,
-  deployment, development, discovery, distributed, eBPF, OpenWrt,
-  fingerprint-spec, product-scope, changelog — the repo is now the single
-  source of truth the website syncs from (issue #234).
-- Probe/synthetic-probing docs + config samples completed (issue #236);
-  `config.example.yaml` regained 9 config blocks that code used but the sample
-  lacked (agent/rdns/mdns/arp_scan/reconcile/retention, issue #131).
-
-### Deferred
-- Agent-side SNMPv3 credentials (issue #241 — needs a distributed
-  credential/key-distribution design; agents stay on v1/v2c).
-- Config-backup real-router end-to-end smoke (GL-MT3000) — code complete,
-  hardware-gated verification.
+### 暂缓
+- agent 侧 SNMPv3 凭据（议题 #241 —— 需要分布式凭据/密钥分发设计；agent 维持 v1/v2c）。
+- 配置备份真机端到端冒烟（GL-MT3000）—— 代码完整，验证受硬件门控。
 
 ## [0.4.0] - 2026-07-29
 
-**Router-resident discovery + OpenWrt deployment + device-persistence rewrite.**
-v0.4.0's headline is a new **router form factor**: when the center or agent runs
-ON the gateway, it gains four Tier-1 passive discovery sources (DHCP leases,
-conntrack, hostapd, dnsmasq query log) that see hosts active probing can't —
-sleeping IoT, firewalled hosts, WiFi-only clients. This ships with first-class
-**OpenWrt** deployment (procd init scripts for both binaries) and a
-**single-writer device-persistence rewrite** that eliminates a long-standing
-dual-write fissure. Rounded out by a frontend IA restructure, server-side
-search/sort that survives pagination, per-user notification read state, Zod form
-validation, and a DataTable XSS hardening pass.
+**路由器驻留发现 + OpenWrt 部署 + 设备持久化重写。** v0.4.0 的头牌是新的**路由器形态**：当中心或 agent 运行在网关上时，获得四个一阶被动发现源（DHCP 租约、conntrack、hostapd、dnsmasq 查询日志），看得见主动探测看不见的主机 —— 沉睡的 IoT、被防火墙拦的主机、纯 WiFi 客户端。随附一等公民的 **OpenWrt** 部署（两个二进制都有 procd init 脚本）和消除长期双写裂缝的**单写者设备持久化重写**。收尾还包括前端信息架构重组、跨页存活的服务端搜索/排序、按用户的通知已读态、Zod 表单校验与 DataTable XSS 加固批次。
 
-### Router-resident discovery sources (Phase A/B)
-The discovery engine (`internal/service/scannerv2/discovery/`) gains four
-Tier-1 sources that only work when the host IS the LAN's gateway/AP — the NAT
-choke point that sees every flow. All are opt-in (default off) and no-op where
-their backing file/socket is absent, so a host-based deployment degrades
-gracefully.
+### 路由器驻留发现源（Phase A/B）
+发现引擎（`internal/service/scannerv2/discovery/`）新增四个只有当宿主**就是**局域网网关/AP 时才能工作的一阶源 —— NAT 咽喉点看得见每一条流。全部选择开启（默认关），且在底层文件/socket 缺失时无操作，宿主型部署优雅降级。
 
-- **`dhcp_leases`**: reads the local DHCP server's lease table (dnsmasq
-  `/tmp/dhcp.leases` on OpenWrt, `/var/lib/misc/dnsmasq.leases` on Debian) — the
-  authoritative hostname↔MAC↔IP map, covering devices that never answer
-  SNMP/ICMP/rDNS.
-- **`conntrack`**: reads `/proc/net/nf_conntrack` and emits the LAN-side
-  endpoint of every ESTABLISHED/ASSURED flow — the "who is talking RIGHT NOW"
-  view. Liveness + discovery for hosts that don't answer active probes but
-  maintain outbound flows. Filters to `network.cidr`.
-- **`hostapd`**: enumerates WiFi STAs via the hostapd control socket
-  (`/var/run/hostapd/<phy>`), falling back to `iw station dump`. Captures signal
-  dBm / connect time / SSID — unavailable to a wired host. `interfaces` lists
-  wlan names; empty = autodetect.
-- **`dns_log`**: tails the dnsmasq query log (`--log-queries` output) and emits
-  each querying host + the domain — a powerful passive fingerprint (devices that
-  block inbound probes still do outbound DNS). Operator must enable query
-  logging (UCI: `uci set dhcp.@dnsmasq[0].logqueries=1`).
-- **`arp_scan` active source** (`discovery/arp_scan_*`): active ARP-sweep source
-  (CAP_NET_RAW, build-tag stub when unavailable) — complements the existing
-  passive `arp_cache`/`multicast`/`router_arp` sources.
-- **Passive-source wiring on the agent** (Phase A): the agent binary now runs
-  the discovery engine, so a router-form agent reports its LAN's passive
-  discoveries into the center alongside scan results.
-- **Multicast / `router_arp` silent-failure fix**: these sources no longer fail
-  silently — they disable themselves with a logged reason when their socket /
-  SNMP walk is unavailable, instead of appearing healthy while emitting nothing.
-  A new warning fires when `router_arp` is redundant to a router-resident
-  source already covering the same hosts.
+- **`dhcp_leases`**：读取本机 DHCP 服务器的租约表（OpenWrt 上 dnsmasq 的 `/tmp/dhcp.leases`，Debian 上 `/var/lib/misc/dnsmasq.leases`）—— 权威的 主机名↔MAC↔IP 映射，覆盖从不响应 SNMP/ICMP/rDNS 的设备。
+- **`conntrack`**：读取 `/proc/net/nf_conntrack`，对每条 ESTABLISHED/ASSURED 流发出其局域网侧端点 —— "谁**正在**通信"视图。为不响应主动探测但维持出站流的主机提供鲜活度 + 发现。按 `network.cidr` 过滤。
+- **`hostapd`**：经 hostapd 控制套接字（`/var/run/hostapd/<phy>`）枚举 WiFi STA，回落 `iw station dump`。采集信号 dBm / 接入时间 / SSID —— 有线宿主拿不到。`interfaces` 列 wlan 名；留空 = 自动探测。
+- **`dns_log`**：tail dnsmasq 查询日志（`--log-queries` 输出），发出每个发起查询的主机 + 域名 —— 强力被动指纹（拦入站探测的设备照样做出站 DNS）。运维需开启查询日志（UCI：`uci set dhcp.@dnsmasq[0].logqueries=1`）。
+- **`arp_scan` 主动源**（`discovery/arp_scan_*`）：主动 ARP 扫掠源（CAP_NET_RAW，不可用时构建标签存根）—— 补齐既有的被动 `arp_cache`/`multicast`/`router_arp` 源。
+- **agent 侧被动源接线**（Phase A）：agent 二进制现在运行发现引擎，路由器形态的 agent 会把其局域网的被动发现连同扫描结果一起报给中心。
+- **多播 / `router_arp` 静默失败修复**：这些源不再静默失败 —— socket / SNMP 遍历不可用时自行停用并记录原因，而不是"看起来健康却什么都不发"。新增一条告警：当 `router_arp` 与某个已覆盖相同主机的路由器驻留源重复时触发。
 
-### OpenWrt deployment (Form C router-center)
-First-class support for running the center or agent directly on an OpenWrt
-router — the natural home for the router-resident sources above.
+### OpenWrt 部署（Form C 路由器中心）
+把中心或 agent 直接跑在 OpenWrt 路由器上的一等支持 —— 上述路由器驻留源的天然归宿。
 
-- **procd init scripts**: `deploy/openwrt/mibee-steward.init` and
-  `mibee-agent.init` — UCI-configured services that start on boot, restart on
-  crash, and run as an unprivileged user. README documents install, config, and
-  the CAP_NET_RAW story.
-- **ARMv7 build target** + init-script dedup: the release matrix and OpenWrt
-  packaging were polished for the common low-power-router target (ARMv7), and
-  the two init scripts were de-duplicated.
+- **procd init 脚本**：`deploy/openwrt/mibee-steward.init` 与 `mibee-agent.init` —— UCI 配置的服务，开机自启、崩溃重启、以非特权用户运行。README 记录安装、配置与 CAP_NET_RAW 事项。
+- **ARMv7 构建目标** + init 脚本去重：发布矩阵与 OpenWrt 打包面向常见低功耗路由目标（ARMv7）打磨，两个 init 脚本完成去重。
 
-### Device persistence: single-writer funnel + device replacement
-**Architecture fix** — eliminates the dual-write fissure where the `devices` row
-was written by two independent paths (`store.RecordDevice` and
-`runner.applyDeviceBridge`) with inconsistent field semantics. The most visible
-symptom was that a synchronous `POST /scanner/scan` left the row `status=
-'unknown'` (only the store wrote it), while a scheduled scan flipped it to
-`online` (the runner's write). A device-replacement case (router swap) exposed a
-worse failure: the new device's data landed on a stale IP while the live gateway
-row kept showing the dead old device, because the two writers disagreed on
-identity + which fields to overwrite.
+### 设备持久化：单写者漏斗 + 设备替换
+**架构修复** —— 消除 `devices` 行由两条独立路径（`store.RecordDevice` 与 `runner.applyDeviceBridge`）写入、字段语义不一致的双写裂缝。最直观的症状：同步 `POST /scanner/scan` 留下的行 `status='unknown'`（只有 store 写它），而计划扫描翻成 `online`（runner 写的）。一次设备替换案例（换路由器）暴露了更糟的失败：新设备的数据落在了陈旧 IP 上，而活网关行继续显示死掉的旧设备 —— 因为两个写者对身份 + 覆盖哪些字段意见不合。
 
-- **Single device writer**: `runner.applyDeviceBridge` is now the sole authority
-  for the `devices` row lifecycle (identity creation, display name, `status`,
-  heartbeat seeding, change-detection, device-replacement detection). The sync
-  scan API (`scanner.go` `Scan`) now persists alive hosts through
-  `runner.ApplyReport` — the SAME path async scan tasks use — so a sync scan and
-  a scheduled scan leave identical rows.
-- **`store.RecordDevice` reduced to enrichment-only**: it no longer INSERTs
-  identities, sets `name`/`status`, or detects replacement. It only enriches an
-  already-existing matched row (mac/type/brand/scan_attributes) as a best-effort
-  pre-write inside the orchestrator; it cannot conflict with the runner.
-- **Device replacement detection** (`resolveDeviceIdentity` in
-  `device_bridge.go`): when a scan's MAC matches a device on a different IP and
-  that IP is held by a different-MAC device (router/asset swap), the IP-holder
-  wins, its identity fields are force-overwritten with the new device's, and the
-  prior MAC-matched row is marked offline. The before/after change-detection
-  diff records the old→new identity in `change_log`.
+- **单一设备写者**：`runner.applyDeviceBridge` 成为 `devices` 行生命周期的唯一权威（身份创建、显示名、`status`、心跳播种、变更检测、设备替换检测）。同步扫描 API（`scanner.go` 的 `Scan`）现在经 `runner.ApplyReport` 持久化存活主机 —— 与异步扫描任务**同一条**路径 —— 同步扫描与计划扫描留下的行完全一致。
+- **`store.RecordDevice` 缩减为仅富化**：不再 INSERT 身份、设置 `name`/`status`、检测替换。只作为编排器内的尽力前置写，富化已匹配的行（mac/type/brand/scan_attributes）；与 runner 不再有冲突面。
+- **设备替换检测**（`device_bridge.go` 的 `resolveDeviceIdentity`）：当扫描的 MAC 命中另一个 IP 上的设备、而该 IP 又由另一个 MAC 的设备持有时（路由器/资产换新），IP 持有者胜出，其身份字段被新设备的强制覆盖，先前 MAC 命中的行标记离线。变更检测的前后 diff 把旧→新身份记入 `change_log`。
 
-### Network reconciliation (drift detection)
-- **`internal/service/scannerv2/reconcile/`**: a background job that finds
-  devices whose IP has drifted outside their stamped `networks.cidr` (e.g. a
-  roaming laptop that picked up a new subnet's DHCP) and surfaces them for
-  operator correction. **Detect-and-surface, not auto-fix** — automatically
-  re-homing a device is destructive (changes identity, breaks historical
-  linkage, can flap on overlapping IP space), so correction stays a human
-  decision. Findings are exposed via structured `slog` warnings (rate-limited),
-  a `mibee_network_mismatches` Prometheus gauge per network, and the
-  `Reconcile()` return value (a future admin endpoint). Backed by the new
-  `internal/cidrutil` package.
+### 网络对账（漂移检测）
+- **`internal/service/scannerv2/reconcile/`**：后台任务查找 IP 漂移出其盖章 `networks.cidr` 的设备（如漫游笔记本拿到了新网段的 DHCP），浮出给运维纠正。**检测并浮出，不自动改** —— 自动重挂设备是破坏性的（改身份、断历史关联、在重叠 IP 空间上会抖动），纠正保留为人工决策。发现经结构化 `slog` 告警（限速）、按网络的 `mibee_network_mismatches` Prometheus 量表、以及 `Reconcile()` 返回值（未来的管理端点）暴露。由新 `internal/cidrutil` 包支撑。
 
-### Configurability
-- **Detection thresholds + heartbeat cadence now configurable** (were
-  hard-coded): `scanner.lost_threshold` (consecutive-scan absence count before
-  "lost", default 2), `heartbeat.tick_interval_seconds` (probe-loop cadence,
-  default 30), `heartbeat.offline_threshold` (probe failures before offline,
-  default 5), `heartbeat.offline_backoff_ticks` (probe an already-offline host
-  once every N ticks, default 10 → ~5min on a 30s ticker). All carry `MIBEE_*`
-  env overrides; `0` means "use default". See `internal/config/defaults.go`.
-- **Rate limit raised** `rate_limit.global_per_minute` 100 → 600, with SPA
-  static assets (`/_app/*`) exempted and `data:` fonts allowed in CSP — the old
-  100/min starved multi-tab + background-polling sessions.
-- **Shared constants extracted** (`config.SysUpTimeOID`,
-  `config.DefaultScanPortSpec`): the sysUpTime OID (copied across 6 sites) and
-  the curated scan port set are now single-source constants, killing the
-  duplication that invited drift.
+### 可配置性
+- **检测阈值 + 心跳节奏可配置**（此前硬编码）：`scanner.lost_threshold`（判"失联"的连续缺席扫描数，默认 2）、`heartbeat.tick_interval_seconds`（探测循环节奏，默认 30）、`heartbeat.offline_threshold`（判离线的探测失败数，默认 5）、`heartbeat.offline_backoff_ticks`（已离线主机每 N tick 探测一次，默认 10 → 30s ticker 下约 5 分钟）。全部带 `MIBEE_*` 环境覆盖；`0` 表示"用默认"。见 `internal/config/defaults.go`。
+- **限流放宽** `rate_limit.global_per_minute` 100 → 600，SPA 静态资源（`/_app/*`）豁免、CSP 放行 `data:` 字体 —— 旧的 100/min 会饿死多标签页 + 后台轮询会话。
+- **共享常量抽取**（`config.SysUpTimeOID`、`config.DefaultScanPortSpec`）：sysUpTime OID（曾在 6 处复制）与精编扫描端口集收敛为单一来源常量，消除诱发漂移的重复。
 
-### Domain: device types
-- **`phone` and `printer` device types** added to the type union
-  (`internal/domain/device.go`) and the `devices.type` CHECK constraint — both
-  the schema and the Go enum are the single source of truth, guarded by a
-  schema-sync drift test. The hostname/brand/port → type inference table
-  (`configs/fingerprints/device-types/device_types.yaml`) is fully data-driven
-  (adding a signature = one YAML entry, not a Go `case`).
+### 领域：设备类型
+- **新增 `phone` 与 `printer` 设备类型**，进入类型联合（`internal/domain/device.go`）与 `devices.type` CHECK 约束 —— schema 与 Go 枚举互为事实源，由 schema 同步漂移测试守卫。主机名/品牌/端口 → 类型推断表（`configs/fingerprints/device-types/device_types.yaml`）完全数据驱动（加签名 = 一条 YAML，不是 Go `case`）。
 
-### Management UI restructure
-- **Information architecture overhaul**: sidebar regrouped, scan entry points
-  consolidated, **topology merged into the Devices page as a view toggle**
-  (radial graph ↔ table), and a dashboard **attention banner** with a primary
-  action surfacing what needs an operator's eye.
-- **Device-detail restructure**: health banner + 5-tab navigation (overview /
-  services / TLS certs / neighbors / changes).
-- **Device edit/delete** via a shared `DeviceEditModal.svelte` reachable from
-  both the list and detail pages.
-- **Shared primitives**: `PageHeader` / `PageShell` / `LoadingButton` extracted
-  and adopted across pages for consistent loading + layout.
+### 管理 UI 重组
+- **信息架构大修**：侧栏重新分组、扫描入口收敛、**拓扑作为视图开关并入设备页**（辐射图 ↔ 表格切换）、仪表盘新增**待办横幅**带主操作，浮出需要运维目光的事项。
+- **设备详情重组**：健康横幅 + 5 标签导航（概览 / 服务 / TLS 证书 / 邻居 / 变更）。
+- **设备编辑/删除**经共享 `DeviceEditModal.svelte`，列表页与详情页皆可达。
+- **共享基元**：抽出 `PageHeader` / `PageShell` / `LoadingButton` 并全站采用，统一加载态与布局。
 
-### Server-side search, sort, and pagination
-A batch of correctness fixes where client-side filtering silently lost results
-once a list grew past one page — search/sort now runs on the server so it spans
-the full dataset:
-- **Server-side search** on users / audit / changes / documents / scan-tasks /
-  scan-results (`fix(web,api)` #54, #55, #64, #86).
-- **Scan-results sort** server-side so ordering holds across pages (#55).
-- **Dedicated `PATCH /channels/{id}`** for the channel enabled-toggle (#53) —
-  writes only `enabled`, avoiding a GET-then-write race.
-- **CSV import** reads the backend `{added, errors}` result instead of the
-  preview count, so the post-import tally matches reality (#58).
+### 服务端搜索、排序与分页
+一批"客户端过滤在列表超过一页后静默丢结果"的正确性修复 —— 搜索/排序改在服务端跑，覆盖全量数据：
+- **服务端搜索**覆盖 users / audit / changes / documents / scan-tasks / scan-results（`fix(web,api)` #54、#55、#64、#86）。
+- **扫描结果排序**移到服务端，排序跨页保持（#55）。
+- **专用 `PATCH /channels/{id}`** 承接通道启用开关（#53）—— 只写 `enabled`，避免 GET 后再写的竞态。
+- **CSV 导入**读取后端 `{added, errors}` 结果而非预览计数，导入后的账面与现实一致（#58）。
 
-### Notifications
-- **Per-user unread tracking** (`notification_read_states` table): the header
-  bell now shows a per-user unread count and clears on dropdown open. Previously
-  the bell was system-wide (no recipient concept).
-- **NotificationBell** pauses polling in background tabs and backs off on
-  failure — stops hammering the API from idle tabs (#67).
+### 通知
+- **按用户未读跟踪**（`notification_read_states` 表）：顶栏铃铛显示按用户的未读数，下拉打开即清。此前铃铛是系统级的（没有接收者概念）。
+- **NotificationBell** 在后台标签页暂停轮询、失败退避 —— 阻止空闲标签页敲打 API（#67）。
 
-### Frontend hardening
-- **DataTable XSS fix** (`lib/utils/html.ts`): a tagged-template `html()`
-  helper that escapes interpolated values, with all rich-text callers migrated
-  off string concatenation (#50, #87).
-- **Zod schema validation** added to 7 forms (login, register, device edit,
-  network, channel, scan, CSV import) — client-side validation now mirrors the
-  backend rules (#66, #106).
-- **Error-state honesty**: pages no longer disguise server errors as empty
-  states — a failed fetch shows an error + retry UI instead of a blank "no data"
-  panel (#65); device-detail shows error + skeleton states instead of blank
-  (#56).
-- **API client hardening**: GET retry on transient 5xx, env-based base URL, and
-  a unified 401 handler that routes session-expiry to re-login (#73, #109).
-- **i18n completeness**: localized scattered hardcoded English across 9+ pages,
-  the discovery funnel, topology tooltips, ChangeDiff labels, and layout/a11y
-  labels; API error messages + form-validation messages now go through the i18n
-  boundary (#40–#63, #101–#105).
-- **a11y + component cleanup**: ARIA ids, focus management, Escape-to-close on
-  click-toggle menus, chart resize handling, scanner alive-hosts table
-  **pagination for large (/22+) ranges** with the bar hidden when results fit
-  one page (#74, #100, #108, #110, #112).
-- **Misc P2/P3 batches**: lib/components, agents/settings/networks/documents,
-  and devices subtrees got consolidated correctness / type-safety / a11y passes.
+### 前端加固
+- **DataTable XSS 修复**（`lib/utils/html.ts`）：标签模板 `html()` 辅助函数对插值转义，全部富文本调用方从字符串拼接迁出（#50、#87）。
+- **Zod schema 校验**加入 7 个表单（登录、注册、设备编辑、网络、通道、扫描、CSV 导入）—— 客户端校验镜像后端规则（#66、#106）。
+- **错误态诚实**：页面不再把服务端错误伪装成空态 —— 拉取失败显示错误 + 重试 UI 而非空白"无数据"面板（#65）；设备详情显示错误 + 骨架屏而非空白（#56）。
+- **API 客户端加固**：瞬时 5xx GET 重试、环境变量基础 URL、统一 401 处理把会话过期导向重新登录（#73、#109）。
+- **i18n 补全**：9+ 页面散落的硬编码英文本地化，含发现漏斗、拓扑 tooltip、ChangeDiff 标签、布局/无障碍标签；API 错误消息 + 表单校验消息走 i18n 边界（#40–#63、#101–#105）。
+- **无障碍 + 组件清理**：ARIA id、焦点管理、点击切换菜单的 Escape 关闭、图表 resize 处理、扫描存活主机表**大网段（/22+）分页**（结果一页装得下时隐藏分页条）（#74、#100、#108、#110、#112）。
+- **杂项 P2/P3 批次**：lib/components、agents/settings/networks/documents、devices 子树做了整固的正确性 / 类型安全 / 无障碍 pass。
 
-### Operations
-- **`change_log` noise reduction**: service-evidence dedup + offline-backoff cut
-  the steady write of timeout rows for dead hosts.
-- **`agent` race fixes**: `TestCommandPoller_ScanPayload_StringQuoted` and
-  `TestReporter_SendsStateHashHeader` data/logic races fixed (CI runs `-race`).
-- **Fingerprint corpus sync** from `mibee-fingerprints-go` (http-tls + ports
-  rules), with golden tests covering the synced http-server-* + smb-version
-  rules.
+### 运维
+- **`change_log` 降噪**：服务证据去重 + 离线退避，砍掉了死主机超时行的持续写入。
+- **`agent` 竞态修复**：`TestCommandPoller_ScanPayload_StringQuoted` 与 `TestReporter_SendsStateHashHeader` 的数据/逻辑竞态修复（CI 跑 `-race`）。
+- 从 `mibee-fingerprints-go` 同步**指纹语料**（http-tls + ports 规则），同步的 http-server-* + smb-version 规则有 golden 测试覆盖。
 
-### License
-- **AGPLv3 + commercial dual-licensing** applied project-wide (supersedes the
-  earlier PolyForm NC): full AGPL-3.0 `LICENSE`, `LICENSE-COMMERCIAL.md`,
-  `NOTICE` third-party attributions, `CLA.md` + `.github/DCO.md` + DCO CI check,
-  and `SPDX-License-Identifier: AGPL-3.0-or-later` headers on all `.go`/`.ts`/
-  `.svelte`/`.c`/`.sql` source; fingerprint YAMLs carry CC-BY-SA 4.0 headers.
+### 许可证
+- **AGPLv3 + 商业双授权**全仓落地（取代早期的 PolyForm NC）：完整 AGPL-3.0 `LICENSE`、`LICENSE-COMMERCIAL.md`、`NOTICE` 三方署名、`CLA.md` + `.github/DCO.md` + DCO CI 检查，全部 `.go`/`.ts`/`.svelte`/`.c`/`.sql` 源码带 `SPDX-License-Identifier: AGPL-3.0-or-later` 头；指纹 YAML 带 CC-BY-SA 4.0 头。
 
 ## [0.3.0] - 2026-07-18
 
-**Full L2 topology + TLS certificate inventory + container images** — v0.3.0
-completes the topology story started in v0.2.0 (CDP/Q-BRIDGE/STP probes, radial
-visualization, neighbor identity inference), adds a TLS certificate inventory
-that collects the full cert chain from every TLS-wrapped service on each device,
-and introduces official multi-arch container images on GHCR.
+**完整 L2 拓扑 + TLS 证书清点 + 容器镜像** —— v0.3.0 补完 v0.2.0 起步的拓扑故事（CDP/Q-BRIDGE/STP 探测、辐射可视化、邻居身份推断），新增从每台设备所有 TLS 包装服务采集完整证书链的 TLS 证书清点，并引入 GHCR 官方多架构容器镜像。
 
-### TLS certificate inventory
-- **TLS cert collection** (`probe/cert_collector.go`): single source of truth —
-  `CollectCertChain(ctx, ip, port, timeout)` performs a TLS handshake
-  (InsecureSkipVerify for inventory) and extracts the full peer chain. Per-cert:
-  Subject/Issuer/SAN (DNS/IP/email)/serial/validity/sig algorithm/key algorithm
-  + bits (RSA/ECDSA/Ed25519)/is_ca/self_signed/SHA-256 fingerprint/PEM;
-  per-handshake: TLS version, cipher suite, best-effort trust verdict. Failure
-  path returns an error record (still persisted) so the UI can show "we tried
-  this port".
-- **TLS-wrapped service handlers** (`handler/tls_collect.go`): 8 handlers
-  (`https`, `ldaps`, `smtps`, `imaps`, `pop3s`, `ftps`, `ircs`, `telnets`)
-  sharing one `tlsCollectHandler` core — each `Collect()` calls
-  `probe.CollectCertChain` and returns a `TLSCertCollected` payload. Handler
-  count 21 → 29.
-- **Extended MiscClassifier**: TLS-wrapped service ports (465/989/990/992/993/994/995)
-  now asserted as service identities so the cert-collect handler runs for them.
-- **Extended TLSProbe**: default port set expanded from 4 to 12 (+ 465/636/989/
-  990/992/993/994/995). Refactored to emit richer evidence fields (`not_before`/
-  `not_after`/`sig_algorithm`/`key_algorithm`/`fingerprint_sha256`/`san_email`).
-- **`host_tls_certs` table**: one row per cert in each port's chain (cert_index
-  0 = leaf, 1..N = issuers); PEM + typed columns; indexed on `(ip, port)` and
-  `not_after` (for expiry sweeps).
-- **Read API** `GET /api/v1/devices/{id}/certificates`: per-port grouping with
-  leaf + chain; status-coloring metadata (TLS version, cipher suite, trust
-  verdict, error).
-- **Frontend TLS sub-panel**: new "TLS 证书" panel under Scan Discovery — one
-  clickable row per port with status-colored left border (green=valid / amber=
-  expiring <15d / red=expired), day-count badge, self-signed/trusted tags.
-- **`CertificateModal.svelte`**: full-chain viewer — status header, summary field
-  grid (Subject/Issuer/Validity/SAN/algorithms/fingerprint), collapsible chain
-  entries, PEM block with copy-to-clipboard.
-- **Retention** `retention.host_tls_certs_days` (default 30).
-- **i18n**: new `certificates` section (34 keys, EN + ZH).
+### TLS 证书清点
+- **TLS 证书采集**（`probe/cert_collector.go`）：单一事实源 —— `CollectCertChain(ctx, ip, port, timeout)` 完成 TLS 握手（清点用途 InsecureSkipVerify）并提取完整对端链。每证书：Subject/Issuer/SAN（DNS/IP/email）/序列号/有效期/签名算法/密钥算法 + 位数（RSA/ECDSA/Ed25519）/is_ca/self_signed/SHA-256 指纹/PEM；每握手：TLS 版本、密码套件、尽力信任判定。失败路径返回错误记录（仍持久化），UI 能显示"这个端口我们试过了"。
+- **TLS 包装服务 handler**（`handler/tls_collect.go`）：8 个 handler（`https`、`ldaps`、`smtps`、`imaps`、`pop3s`、`ftps`、`ircs`、`telnets`）共享一个 `tlsCollectHandler` 核心 —— 每个的 `Collect()` 调 `probe.CollectCertChain` 并返回 `TLSCertCollected` 载荷。handler 数 21 → 29。
+- **MiscClassifier 扩展**：TLS 包装服务端口（465/989/990/992/993/994/995）现被断言为服务身份，证书采集 handler 得以为其运行。
+- **TLSProbe 扩展**：默认端口集从 4 扩到 12（+ 465/636/989/990/992/993/994/995）。重构为发出更丰富的证据字段（`not_before`/`not_after`/`sig_algorithm`/`key_algorithm`/`fingerprint_sha256`/`san_email`）。
+- **`host_tls_certs` 表**：每端口链中每证书一行（cert_index 0 = 叶，1..N = 签发者）；PEM + 类型化列；`(ip, port)` 与 `not_after` 建索引（供到期清扫）。
+- **读取 API** `GET /api/v1/devices/{id}/certificates`：按端口分组带叶 + 链；状态着色元数据（TLS 版本、密码套件、信任判定、错误）。
+- **前端 TLS 子面板**：扫描发现下新增 "TLS Certificates" 面板（中文界面为"TLS 证书"）—— 每端口一行可点击，左侧状态着色边条（绿=有效 / 琥珀=15 天内到期 / 红=已过期）、剩余天数徽章、自签/受信标签。
+- **`CertificateModal.svelte`**：全链查看器 —— 状态头、摘要字段网格（Subject/Issuer/有效期/SAN/算法/指纹）、可折叠链条目、带复制按钮的 PEM 块。
+- **保留** `retention.host_tls_certs_days`（默认 30）。
+- **i18n**：新 `certificates` 节（34 键，EN + ZH）。
 
-### Topology probe breadth
-- **CDP-MIB probe** (`active:cdp_mib`): walks CISCO-CDP-MIB `cdpCacheTable`
-  on Cisco/CDP-speaking switches. Uses device id as the neighbor merge key.
-  Emits `protocol:"CDP"` neighbor edges.
-- **Q-BRIDGE-MIB probe** (`active:q_bridge_mib`): walks IEEE 802.1Q
-  `dot1qTpFdbPort` for VLAN-aware MAC→port forwarding entries. Recovers L2
-  adjacency on tagged/inter-VLAN topologies. Emits `protocol:"Q-BRIDGE"` edges
-  with ifName-resolved port names.
-- **STP-MIB probe** (`active:stp_mib`): walks BRIDGE-MIB `dot1dStp` for
-  Spanning Tree facts (root bridge, designated port, port role/state). Emits
-  `protocol:"STP"` evidence.
-- **IF-MIB ifName resolution** (`probe.ResolvePortNames`): shared helper that
-  turns numeric ifIndex/port values into human-readable interface names (e.g.
-  `GigabitEthernet0/1`). Used by CDP/Q-BRIDGE probes.
+### 拓扑探测广度
+- **CDP-MIB 探测器**（`active:cdp_mib`）：在 Cisco/说 CDP 的交换机上遍历 CISCO-CDP-MIB `cdpCacheTable`。以 device id 作为邻居合并键。发出 `protocol:"CDP"` 邻居边。
+- **Q-BRIDGE-MIB 探测器**（`active:q_bridge_mib`）：遍历 IEEE 802.1Q `dot1qTpFdbPort` 拿 VLAN 感知的 MAC→端口转发表项。在打标签/跨 VLAN 拓扑上恢复 L2 邻接。发出带 ifName 解析端口名的 `protocol:"Q-BRIDGE"` 边。
+- **STP-MIB 探测器**（`active:stp_mib`）：遍历 BRIDGE-MIB `dot1dStp` 拿生成树事实（根桥、指定端口、端口角色/状态）。发出 `protocol:"STP"` 证据。
+- **IF-MIB ifName 解析**（`probe.ResolvePortNames`）：共享辅助函数把数字 ifIndex/端口值转成人类可读接口名（如 `GigabitEthernet0/1`）。CDP/Q-BRIDGE 探测器使用。
 
-### Topology visualization
-- **Network topology page** (`/topology`): a full-network radial tree view
-  (ECharts `tree` series, newly tree-shaken in) of devices as nodes and
-  `device_neighbors` as edges. Node color by device type; edge color by protocol
-  (LLDP blue / Bridge-MIB green); dashed edges point at unidentified neighbors.
-  Network filter + 60s auto-refresh; click a node to open its detail page.
-- **Device-detail Neighbors panel**: a table of a device's L2 neighbors with the
-  neighbor's name/IP/type (via a device JOIN — `neighbor_device_id` was always
-  NULL in v0.2.0; now resolved at query time) and a link to its detail page.
+### 拓扑可视化
+- **网络拓扑页**（`/topology`）：全网辐射树视图（ECharts `tree` 系列，新 tree-shake 进来），设备为节点、`device_neighbors` 为边。节点色按设备类型；边色按协议（LLDP 蓝 / Bridge-MIB 绿）；虚线边指向未识别邻居。网络过滤 + 60s 自动刷新；点节点开其详情页。
+- **设备详情邻居面板**：设备 L2 邻居表，带邻居的名称/IP/类型（经设备 JOIN —— v0.2.0 里 `neighbor_device_id` 恒为 NULL，现查询时解析）及详情页链接。
 
-### LLDP discovery (two paths)
-- **SNMP LLDP-MIB probe** (`active:lldp_mib`, default ON): walks `lldpRemTable`
-  on SNMP-speaking switches/APs that run LLDP — the cross-vendor standard.
-  Emits `protocol:"LLDP"` neighbor edges through the existing neighbor pipeline
-  (zero new wiring). Unprivileged (UDP/161); no new dependencies.
-- **Raw-frame LLDPDU listener** (`WITH_LLDP` build-tag, default OFF): captures
-  ethertype 0x88cc frames via AF_PACKET (needs CAP_NET_RAW) to see
-  LLDP-broadcasting endpoints (IP phones, APs, NAS) that don't run SNMP LLDP-MIB.
-  Mirrors the eBPF observer's build-tag pattern — the default build ships a
-  no-op stub so it stays unprivileged (`make build-with-lldp` to enable).
+### LLDP 发现（双路径）
+- **SNMP LLDP-MIB 探测器**（`active:lldp_mib`，默认开）：在说 SNMP 且跑 LLDP 的交换机/AP 上遍历 `lldpRemTable` —— 跨厂商标准。经既有邻居管线发出 `protocol:"LLDP"` 邻居边（零新增接线）。非特权（UDP/161）；无新依赖。
+- **原始帧 LLDPDU 监听器**（`WITH_LLDP` 构建标签，默认关）：经 AF_PACKET 捕获 ethertype 0x88cc 帧（需 CAP_NET_RAW），看见不发 SNMP LLDP-MIB 但广播 LLDP 的端点（IP 话机、AP、NAS）。镜像 eBPF 观测器的构建标签模式 —— 默认构建带无操作存根保持非特权（`make build-with-lldp` 启用）。
 
-### Neighbor identity inference
-- Orchestrator gains pluggable `NeighborIdentityInfer` callback wired to the
-  RuleClassifier — CDP/LLDP neighbors get vendor/model/type inferred from their
-  platform string.
-- **`EnrichDeviceByMAC`**: enriches a device's vendor/model/type/hostname by MAC
-  (the neighbor merge key), preserving existing non-empty values.
+### 邻居身份推断
+- 编排器新增可插拔 `NeighborIdentityInfer` 回调接到 RuleClassifier —— CDP/LLDP 邻居从其平台串推断厂商/型号/类型。
+- **`EnrichDeviceByMAC`**：按 MAC（邻居合并键）富化设备的厂商/型号/类型/主机名，保留既有非空值。
 
-### Container images & deployment profiles
-- **GHCR publishing**: every `v*` tag now builds a multi-arch (linux/amd64 +
-  linux/arm64) image at `ghcr.io/mi-bee-studio/mibeesteward`, tagged
-  `:latest` / `:<version>` / `:<major>.<minor>` / `:sha-<short>`. The release
-  workflow's `publish` job waits on `[release, docker]` so a GitHub Release is
-  only created when both binaries and image succeed. Image is the unprivileged
-  variant (LLDP/CDP/eBPF compiled as stubs).
-- **Docker network-mode profiles**: three compose profiles so the deployment
-  shape matches the intent — `bridge` (default, NAT'd, MAC/ARP degraded),
-  `host` (recommended, ≈ bare-metal probe fidelity), `macvlan` (own LAN IP).
-  Measured on the test LAN: the default docker bridge found 0/26 device MACs vs
-  30/31 with host networking (the container's `/proc/net/arp` only sees the
-  bridge gateway). See `docs/{en,zh}/deployment.md` § "Docker network mode".
-- **Dockerfile**: `BUILD_TAGS` arg (WITH_LLDP/CDP/EBPF opt-in), opt-in `SETCAP`
-  (file caps break exec() when the cap isn't in the bounding set, so default
-  off), `NPM_REGISTRY`/`GOPROXY` args for restricted-network builds,
-  `NODE_OPTIONS` for the vite heap, `/data` pre-owned by the non-root user.
-- **Makefile**: `docker-build` / `-priv` / `-up` / `-up-bridge` /
-  `-up-macvlan` / `-down` / `-logs` targets.
-- **`configs/config.docker.yaml`**: container template (network.cidr, /data
-  paths, bridge-mode router_arp guidance).
+### 容器镜像与部署形态
+- **GHCR 发布**：每个 `v*` 标签构建多架构镜像（linux/amd64 + linux/arm64）发布到 `ghcr.io/mi-bee-studio/mibeesteward`，打 `:latest` / `:<version>` / `:<major>.<minor>` / `:sha-<short>` 标签。发布工作流的 `publish` 任务等待 `[release, docker]` —— 只有二进制与镜像都成功才创建 GitHub Release。镜像为非特权变体（LLDP/CDP/eBPF 编译为存根）。
+- **Docker 网络模式形态**：三个 compose profile 让部署形状匹配意图 —— `bridge`（默认，NAT，MAC/ARP 劣化）、`host`（推荐，≈ 裸机探测保真）、`macvlan`（独立局域网 IP）。测试局域网实测：默认 docker bridge 找到 0/26 设备 MAC，host 网络为 30/31（容器的 `/proc/net/arp` 只看得见网桥网关）。见 `docs/{en,zh}/deployment.md` § "Docker 网络模式"。
+- **Dockerfile**：`BUILD_TAGS` 参数（WITH_LLDP/CDP/EBPF 选择启用）、可选 `SETCAP`（能力不在 bounding set 时 file caps 会破坏 exec()，故默认关）、受限网络构建的 `NPM_REGISTRY`/`GOPROXY` 参数、vite 堆的 `NODE_OPTIONS`、`/data` 预归属非 root 用户。
+- **Makefile**：`docker-build` / `-priv` / `-up` / `-up-bridge` / `-up-macvlan` / `-down` / `-logs` 目标。
+- **`configs/config.docker.yaml`**：容器模板（network.cidr、/data 路径、bridge 模式 router_arp 指引）。
 
 ### CI
-- **`docker-build` smoke-test job** (ci.yml): on every PR, builds the image
-  (amd64 only, no push) and boots it with a minimal config, waiting up to 30s
-  for `/health` — catches Dockerfile/compose regressions before a tag.
-- **Node.js 20 deprecation**: actions still target Node 20; GitHub is forcing
-  Node 24 (warning, not failure). Upgrade pending.
+- **`docker-build` 冒烟任务**（ci.yml）：每个 PR 构建镜像（仅 amd64，不推送）并以最小配置启动，最长等 30s 探活 `/health` —— 在打标签前抓住 Dockerfile/compose 回归。
+- **Node.js 20 弃用**：actions 仍目标 Node 20；GitHub 正在强制 Node 24（告警，未失败）。升级待办。
 
-### Retention hardening
-- `device_neighbors` and `host_services` now have retention sweepers (they grew
-  unbounded in v0.2.0 — a latent bloat bug). Defaults: 90d neighbors (topology
-  history value), 30d host_services. Per-table `retention.*` config keys +
-  `days<=0` safety guard.
-- Also fixes a latent sqlc v1.27.0 bug: a non-ASCII char in a query comment
-  corrupted sibling-query codegen (silently emitted broken SQL — runtime query
-  failure, not a build error).
+### 保留期加固
+- `device_neighbors` 与 `host_services` 有了保留清扫器（v0.2.0 起无限增长 —— 潜在膨胀 bug）。默认：neighbors 90 天（拓扑历史价值）、host_services 30 天。每表 `retention.*` 配置键 + `days<=0` 安全守卫。
+- 同时修复一个潜伏的 sqlc v1.27.0 bug：查询注释里的非 ASCII 字符会破坏兄弟查询的代码生成（静默产出坏 SQL —— 运行时查询失败，不是构建错误）。
 
-### Test coverage
-- **taskservice** (scan-task state machine): was zero-tested. Now covers
-  CRUD, validation, pagination clamping, not-found mapping, and nil-scheduler
-  behavior.
-- **Fingerprint golden test**: a quality regression guard (real-world evidence
-  samples → expected service/metadata), distinct from the existing count test —
-  so a rule edit that breaks identification fails even if the count is unchanged.
+### 测试覆盖
+- **taskservice**（扫描任务状态机）：此前零测试。现覆盖 CRUD、校验、分页钳制、not-found 映射、nil 调度器行为。
+- **指纹 golden 测试**：质量回归守卫（真实世界证据样本 → 期望的服务/元数据），区别于既有计数测试 —— 破坏识别的规则编辑即使计数不变也会失败。
 
-### Fingerprint library
-- Extended `snmp-data.yaml` with consumer/SMB networking sysObjectID prefixes
-  underrepresented vs the enterprise-heavy table (ASUS, D-Link, Zyxel, Tenda,
-  DrayTek, alternate TP-Link/Mikrotik subtypes). Each is one YAML entry.
-- New `lldp-cdp.yaml` rules for CDP/LLDP device identification.
+### 指纹库
+- 扩充 `snmp-data.yaml`：补上相比企业向表格偏少用的消费级/ SMB 网络设备 sysObjectID 前缀（ASUS、D-Link、Zyxel、Tenda、DrayTek、TP-Link/Mikrotik 备选子型）。每条一个 YAML 条目。
+- 新 `lldp-cdp.yaml` 规则用于 CDP/LLDP 设备识别。
 
-### Fixes
-- Removed deprecated `tls.VersionSSL30` (staticcheck SA1019).
-- gofmt + golangci-lint cleanup (QF1008, unused params, embedded selectors).
+### 修复
+- 移除弃用的 `tls.VersionSSL30`（staticcheck SA1019）。
+- gofmt + golangci-lint 清理（QF1008、未用参数、内嵌选择器）。
 
 ## [0.2.0] - 2026-07-13
 
-Distributed multi-network discovery, topology-aware probing, a change-detection
-engine, and a data-driven fingerprint rule library. The release ships **two
-binaries**: the center (`mibee-steward`, the existing SPA-embedded server) and
-the new discovery **agent** (`mibee-agent`) for remote LANs.
+分布式多网络发现、拓扑感知探测、变更检测引擎与数据驱动的指纹规则库。本版发布**两个二进制**：中心（`mibee-steward`，既有内嵌 SPA 的服务器）与新发现的 **agent**（`mibee-agent`），面向远程局域网。
 
-### Distributed discovery (center + agent)
-- **Agent binary** (`cmd/agent`): runs the scannerv2 engine against the LAN it
-  sits on and reports results to the center via `POST /api/v1/agents/report`.
-  Pull model — the agent initiates all connections (report + poll commands), so
-  it works behind NAT. CGO-free, runs as a regular user.
-- **Center ingestion**: agent reports are converted to local device portraits via
-  the device bridge; agent-managed networks are excluded from the center's own
-  cross-subnet probing (the agent's reports ARE the liveness signal).
-- **Anti-entropy fast path**: agents send an `X-Network-State-Hash` header
-  (SHA-256 of the alive set's identity+classification fields); on a match the
-  center skips the per-host device bridge and only refreshes leases — the
-  steady-state path for stable networks.
-- **Lease model**: agent reports refresh per-device leases; lost detection for
-  agent networks is TTL-based (`LeaseSweeper`, default 5m TTL), distinct from
-  the center's own consecutive-scan `DetectLost`.
-- **Command channel**: center enqueues scan commands; the agent polls, acks, and
-  completes them (~60s cycle).
-- **Agent token auth**: machine-to-machine bearer tokens bound to a
-  `network_id` + `agent_id` (admin CRUD at `/api/v1/agents/tokens`).
-- **Watch SSE + agent disconnect backfill**: `GET /changes/watch` foundation;
-  agents reconnect by re-sending their last hash.
+### 分布式发现（中心 + agent）
+- **Agent 二进制**（`cmd/agent`）：在其所在的局域网运行 scannerv2 引擎，经 `POST /api/v1/agents/report` 向中心上报结果。拉模型 —— agent 主动发起所有连接（上报 + 轮询命令），因此在 NAT 后可用。CGO-free，普通用户即可运行。
+- **中心侧摄取**：agent 报告经 device bridge 转成本地设备画像；agent 托管网络排除在中心自己的跨网段探测之外（agent 的报告**就是**鲜活度信号）。
+- **反熵快速路径**：agent 发送 `X-Network-State-Hash` 头（存活集合的身份+分类字段的 SHA-256）；命中时中心跳过逐主机 device bridge，只刷新租约 —— 稳定网络的稳态路径。
+- **租约模型**：agent 报告刷新按设备租约；agent 网络的失联检测基于 TTL（`LeaseSweeper`，默认 5 分钟 TTL），区别于中心自身网络的连续扫描 `DetectLost`。
+- **命令通道**：中心入队扫描命令；agent 轮询、确认、完成（约 60s 周期）。
+- **Agent 令牌认证**：绑定 `network_id` + `agent_id` 的机对机 bearer 令牌（管理端 CRUD 在 `/api/v1/agents/tokens`）。
+- **Watch SSE + agent 断线回填**：`GET /changes/watch` 奠基；agent 重连时重发其最后的哈希。
 
-### Topology & probing
-- **Bridge-MIB neighbor probe**: walks `BRIDGE-MIB` to discover L2 neighbors and
-  persists `device_neighbors` (Phase 4 topology layer).
-- **SMB2 Negotiate probe + FTP banner reliability**: richer service evidence.
-- **TLS cert CN brand override**: recognizes OpenWrt / GL.iNet / iStoreOS from
-  certificate subject/issuer fields.
-- **Router ARP** walk for cross-subnet MAC resolution.
+### 拓扑与探测
+- **Bridge-MIB 邻居探测器**：遍历 `BRIDGE-MIB` 发现 L2 邻居并持久化 `device_neighbors`（拓扑层 Phase 4）。
+- **SMB2 Negotiate 探测器 + FTP banner 可靠性**：更丰富的服务证据。
+- **TLS 证书 CN 品牌覆盖**：从证书 subject/issuer 字段识别 OpenWrt / GL.iNet / iStoreOS。
+- **Router ARP** 遍历解决跨网段 MAC。
 
-### Change-detection engine
-- Records `device_added` / `device_changed` / `device_lost` to `change_log` +
-  an in-process `Watcher` (center only). `device_lost` has two paths:
-  consecutive-scan `miss_count` (center's own network) and TTL-based lease
-  expiry (agent networks). Query via `GET /api/v1/changes`; history page in the UI.
+### 变更检测引擎
+- 向 `change_log` + 进程内 `Watcher`（仅中心）记录 `device_added` / `device_changed` / `device_lost`。`device_lost` 有两条路径：连续扫描 `miss_count`（中心自身网络）与基于 TTL 的租约到期（agent 网络）。经 `GET /api/v1/changes` 查询；UI 有历史页。
 
-### Fingerprint rule library (data-driven)
-- Identification rules are now **data** (YAML), not hand-written Go. A
-  `RuleClassifier` loads rules at startup from a configured path or the rules
-  embedded in the binary. Adding a device signature = one YAML entry.
-- **Imported corpora** (license-clean): Rapid7 Recog (~1174 rules, Apache-2.0)
-  and SNMP/Recog data tables (~2554 rules total after scoping). nmap's NPSL is
-  excluded (never imported). See `cmd/fpimport/` for the converter.
-- The standalone engine lives at
-  [github.com/Mi-Bee-Studio/mibee-fingerprints-go](https://github.com/Mi-Bee-Studio/mibee-fingerprints-go).
-- Logic that can't be a single declarative rule (SNMP bitmask heuristic, camera
-  cross-evidence fusion) stays as Go code.
+### 指纹规则库（数据驱动）
+- 识别规则从手写 Go 变为**数据**（YAML）。`RuleClassifier` 启动时从配置路径或二进制内嵌规则加载。加设备签名 = 一条 YAML 条目。
+- **导入语料**（许可干净）：Rapid3 Recog（约 1174 条规则，Apache-2.0）与 SNMP/Recog 数据表（划定范围后共约 2554 条）。nmap 的 NPSL 排除（永不导入）。转换器见 `cmd/fpimport/`。
+- 独立引擎位于 [github.com/Mi-Bee-Studio/mibee-fingerprints-go](https://github.com/Mi-Bee-Studio/mibee-fingerprints-go)。
+- 无法成为单条声明式规则的逻辑（SNMP 位掩码启发、相机跨证据融合）保留为 Go 代码。
 
-### Management UI
-- **Networks admin page**: create / edit / delete logical networks
-  (POST/PUT/DELETE `/api/v1/networks`) — the network registry the agents bind to.
-- **Discovery status page**: passive host-discovery runtime counters + recent
-  discoveries (`GET /api/v1/discovery/status`).
-- **Devices page**: user-toggleable optional columns (persisted to localStorage);
-  device name links to the detail page; the type union now mirrors all device
-  categories.
-- **Change history page** with structured before/after diffs.
-- **CSRF-safe exports**: CSV/JSON downloads now route through the API client
-  (previously bypassed it via raw `fetch`, dropping the CSRF header).
+### 管理 UI
+- **网络管理页**：逻辑网络的创建 / 编辑 / 删除（POST/PUT/DELETE `/api/v1/networks`）—— agent 绑定的网络注册表。
+- **发现状态页**：被动主机发现运行时计数 + 近期发现（`GET /api/v1/discovery/status`）。
+- **设备页**：用户可切换的可选列（持久化到 localStorage）；设备名链到详情页；类型联合镜像全部设备类别。
+- **变更历史页**带结构化前后 diff。
+- **CSRF 安全导出**：CSV/JSON 下载改走 API 客户端（此前经裸 `fetch` 绕过它，丢 CSRF 头）。
 
-### Operational
-- Server bind-retry prevents restart storms from lingering sockets.
-- Agent HTTP-transport keep-alive deadlock fix + scan deadline enforcement.
-- Anti-entropy + lease model + heartbeat scope governance.
+### 运维
+- 服务器绑定重试防止残留 socket 引发的重启风暴。
+- Agent HTTP 传输 keep-alive 死锁修复 + 扫描截止期强制。
+- 反熵 + 租约模型 + 心跳作用域治理。
 
-### Known limitations
-- The center is single-instance (SQLite). Multi-center clustering is not in scope.
-- No built-in alerting — integrate with Alertmanager / Uptime Kuma.
-- eBPF passive observer requires a special build (`make build-with-ebpf`) and
-  runtime privileges.
+### 已知限制
+- 中心为单实例（SQLite）。多中心集群不在范围内。
+- 无内置告警 —— 与 Alertmanager / Uptime Kuma 集成。
+- eBPF 被动观测器需要特殊构建（`make build-with-ebpf`）与运行时特权。
 
 ## [0.1.0] - 2026-07-07
 
-First public release. MiBee Steward is a device management & network-layer
-auto-discovery system with an embedded SvelteKit SPA, packaged as a single
-binary.
+首次公开发布。MiBee Steward 是一个设备管理与网络层自动发现系统，内嵌 SvelteKit SPA，打包为单一二进制。
 
-### Core capabilities
-- **Network discovery**: plugin-based scanner v2 (ICMP, TCP portscan, SNMP,
-  RTSP, ONVIF, HTTP, ARP, UDP-discovery) with 5-layer pipeline
-  (probe → classify → handler → persist).
-- **Identity inference**: device type/vendor/OS/hostname inferred from scan
-  evidence (cameras, servers, switches, routers, NAS, etc.).
-- **Device registry**: full CRUD, batch operations, CSV export, custom
-  attributes, document linking, device-systems grouping.
-- **Heartbeat monitoring**: asset-freshness probing (ICMP/TCP/HTTP/SNMP) with
-  dedicated time-series store, in-memory status cache, WAL-isolation-safe sync.
-- **Authentication**: JWT (cookie + Bearer), 2FA (TOTP), login lockout, token
-  blacklist, RBAC (admin/user).
-- **Dashboard**: configurable widgets, Prometheus-backed time-series charts.
-- **Audit logging**: all admin actions recorded.
-- **Prometheus integration**: `/metrics` + `/sd` (HTTP service discovery).
-- **Notification channels**: webhook/email channel management with test dispatch.
-- **i18n**: Chinese and English, fully translated.
+### 核心能力
+- **网络发现**：插件化扫描器 v2（ICMP、TCP 端口扫描、SNMP、RTSP、ONVIF、HTTP、ARP、UDP 发现），5 层管线（探测 → 分类 → handler → 持久化）。
+- **身份推断**：从扫描证据推断设备类型/厂商/系统/主机名（相机、服务器、交换机、路由器、NAS 等）。
+- **设备登记**：完整 CRUD、批量操作、CSV 导出、自定义属性、文档关联、设备系统分组。
+- **心跳监控**：资产鲜活度探测（ICMP/TCP/HTTP/SNMP），专用时序存储、内存状态缓存、WAL 隔离安全的同步。
+- **认证**：JWT（cookie + Bearer）、2FA（TOTP）、登录锁定、令牌黑名单、RBAC（admin/user）。
+- **仪表盘**：可配置小组件、Prometheus 支撑的时序图表。
+- **审计日志**：全部管理操作留痕。
+- **Prometheus 集成**：`/metrics` + `/sd`（HTTP 服务发现）。
+- **通知通道**：webhook/邮件通道管理带测试发送。
+- **i18n**：中英双语完整翻译。
 
-### Deployment
-- Single binary (CGO-free, SQLite via modernc.org/sqlite), embedded SPA.
-- Docker (multi-stage, non-root), systemd unit, nginx reverse-proxy config.
-- Configurable data retention sweeper for all high-volume tables.
-- CLI: `mibee-steward -version`, `mibee-steward reset-admin-password`.
+### 部署
+- 单一二进制（CGO-free，SQLite 走 modernc.org/sqlite），内嵌 SPA。
+- Docker（多阶段、非 root）、systemd 单元、nginx 反向代理配置。
+- 全部高量表可配置的数据保留清扫器。
+- CLI：`mibee-steward -version`、`mibee-steward reset-admin-password`。
 
-### Known limitations
-- Single-instance (SQLite). Distributed/multi-network mode is future work.
-- No built-in alerting engine — alerting is intentionally out of scope
-  (integrate with Alertmanager/Uptime Kuma).
-- eBPF passive observer requires a special build (`make build-with-ebpf`) and
-  runtime privileges.
+### 已知限制
+- 单实例（SQLite）。分布式/多网络模式是未来工作。
+- 无内置告警引擎 —— 告警有意排除在范围外（与 Alertmanager/Uptime Kuma 集成）。
+- eBPF 被动观测器需要特殊构建（`make build-with-ebpf`）与运行时特权。

--- a/scripts/gen_changelog_mirror.sh
+++ b/scripts/gen_changelog_mirror.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-# Regenerate the docs/{zh,en}/changelog.md mirrors from the root CHANGELOG.md
-# (#322). Run via `make docs-changelog-sync` whenever CHANGELOG.md changes; the
-# CI `docs` job runs this same script and fails on drift, so a release that
-# forgets to refresh the mirrors is caught before merge.
+# Changelog docs sync (#322, reworked 2026-08): docs/en/changelog.md is a
+# verbatim mirror of the root CHANGELOG.md and is REGENERATED here. Do not
+# hand-edit it — edit CHANGELOG.md and re-run `make docs-changelog-sync`.
 #
-# - en/changelog.md: verbatim copy of CHANGELOG.md
-# - zh/changelog.md: one-line Chinese provenance note + the verbatim content
+# docs/zh/changelog.md is a hand-maintained CHINESE TRANSLATION — this script
+# never touches it. Instead it runs a coverage check: the set of version
+# headers (`## [Unreleased]` / `## [0.5.0] - date` / …) must be identical on
+# both sides, so a release that adds entries to CHANGELOG.md without updating
+# the translation (or vice versa) fails before merge.
 #
-# Do not hand-edit the mirrors — edit CHANGELOG.md and re-run this script.
+# The CI `docs` job runs this same script and additionally fails when the
+# regenerated en mirror differs from the committed one.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -18,14 +21,22 @@ if [[ ! -f CHANGELOG.md ]]; then
   echo "error: CHANGELOG.md not found at repo root" >&2
   exit 1
 fi
+if [[ ! -f docs/zh/changelog.md ]]; then
+  echo "error: docs/zh/changelog.md not found (hand-maintained translation)" >&2
+  exit 1
+fi
 
 cp CHANGELOG.md docs/en/changelog.md
 
-{
-  echo "> 本页由 \`make docs-changelog-sync\` 从仓库根目录 [CHANGELOG.md](../../CHANGELOG.md) 自动生成（保留英文原文，便于与仓库逐字对照），请勿手改。"
-  echo
-  echo
-  cat CHANGELOG.md
-} > docs/zh/changelog.md
+versions_of() {
+  grep -E '^## \[' "$1" | grep -oE '\[[^]]+\]' | sort
+}
 
-echo "docs/{zh,en}/changelog.md regenerated from CHANGELOG.md"
+if ! diff <(versions_of CHANGELOG.md) <(versions_of docs/zh/changelog.md) > /tmp/changelog-versions.diff; then
+  echo "error: version coverage mismatch between CHANGELOG.md and docs/zh/changelog.md:" >&2
+  cat /tmp/changelog-versions.diff >&2
+  echo "Update the Chinese translation (docs/zh/changelog.md) to match, then re-run." >&2
+  exit 1
+fi
+
+echo "docs/en/changelog.md regenerated from CHANGELOG.md; zh translation version coverage OK"


### PR DESCRIPTION
## 背景

官网(www.mlsbs.top)从 `docs/{zh,en}/` 逐字同步手册。排查官网"中英文乱串、文档几乎不可用"问题时确认的最大单一来源: **`docs/zh/changelog.md` 是英文镜像**(#322/#323 的决策——`make docs-changelog-sync` 把根 CHANGELOG.md 原文复制、仅在头部加一行中文说明),于是官网中文手册的"更新日志"页整页英文(779 行里只有 4 行中文)。次要来源:英文 CHANGELOG 条目本身夹中文 UI 词(`配置历史` tab、`TLS 证书` panel、`Synthetic probing / 拨测`),verbatim 同步带进了官网 en-US 页。

## 变更

### 中文更新日志:英文镜像 → 手维护真翻译
- `docs/zh/changelog.md` 重写为全量中文翻译:Unreleased → 0.1.0 全部版本、55 个章节与英文一一对应(结构 parity 已核对);术语对齐 docs/zh 既有译法(拨测/单写者/网络授权/租约/画像/鲜活度);技术名词、配置键、API 路径、议题编号保留原文
- 脚本**不再覆盖** zh 文件——手翻译不会再被生成器冲掉

### 生成器与 CI 联动重设计
- `gen_changelog_mirror.sh`:
  - `docs/en/changelog.md`:仍是自动再生的逐字镜像(勿手改)
  - `docs/zh/changelog.md`:改为**版本覆盖校验**——两侧 `## [version]` 清单必须一致,防止"改了 CHANGELOG 忘更新中文翻译"(或反向)静默漂移;已做负向测试确认能拦截
- CI `docs` 任务: `git diff --exit-code` 收窄到 en 镜像(zh 由脚本内覆盖检查把关)
- `Makefile` / `docs/README.md`:流程说明同步更新

### 英文侧去中文残留(6 处)
| 位置 | 修改 | 依据 |
|---|---|---|
| CHANGELOG `device_config_changed` 条目 | `配置历史` tab → **Config History** tab | 与英文 UI 实际标签一致(`devicedetail.Tab Config`) |
| CHANGELOG 0.5.0 拨测章节标题 | `Synthetic probing / 拨测` → **Synthetic Probing** | 章节标题去双语混排 |
| CHANGELOG 0.3.0 前端条目 | `TLS 证书` panel → **TLS Certificates** panel | 与英文 UI 实际标签一致(`certificates.Title`) |
| docs/en/api.md | `## Synthetic Probing (拨测)` → `## Synthetic Probing` | 同上 |
| docs/en/configuration.md | `Synthetic-probe (拨测)` → `Synthetic-probe` | 同上 |
| docs/en/integrations.md | `飞书 … "签名校验"` → **Feishu … signature verification** | 产品名与操作名英文化 |

docs/en 全量扫描:除 changelog(随本 PR 修复)外已无 CJK 残留。

## 验证

- [x] `make docs-changelog-sync`:en 镜像再生 + zh 覆盖检查通过
- [x] 负向测试:篡改 zh 版本头 → 脚本以非零退出并给出 diff
- [x] zh 翻译完整性:55/55 章节头对齐、无纯英文 bullet 残留
- [x] UI 标签用词与 `web/messages/en.json` 核对

## 关联

- 官网侧(layout-driven 切换、同步滞后 4 天、features/playbooks/comparison 未入同步集)已在 mickeyzzc/mibeestudio 提 issue 跟踪——属站点仓库职责。
- 本 PR 合入后官网重跑 `sync-docs.ps1` 即可拿到中文更新日志与干净的 en 页。