### PR TITLE
test(db): db/queries 非 ASCII 守卫 + 三条被腐蚀查询执行冒烟（#290）

### DIFF
--- a/internal/db/sqlc_unicode_regressions_test.go
+++ b/internal/db/sqlc_unicode_regressions_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mibee-steward/internal/db"
+	"mibee-steward/internal/testutil"
+)
+
+// TestQueriesFilesASCIIOnly pins the #290 root cause: sqlc v1.31.1 corrupts
+// the tail of a regenerated SQL constant when the query file contains
+// multi-byte characters (em-dash, "<>", ...). The corruption is
+// POSITION-DEPENDENT - the same file can pass CI for months and break the
+// moment an unrelated edit shifts byte offsets onto a multi-byte rune - so
+// "the current output looks fine" proves nothing. Zero non-ASCII input is the
+// only reliable defense; db/schema.sql is exempt (schema comments never feed
+// the statement-reconstruction path that corrupts).
+func TestQueriesFilesASCIIOnly(t *testing.T) {
+	dir := queriesDir(t)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var offenders []string
+	found := false
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		found = true
+		content, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		require.NoError(t, err)
+		for i, line := range strings.Split(string(content), "\n") {
+			for _, r := range line {
+				if r > 0x7F {
+					offenders = append(offenders, fmt.Sprintf(
+						"%s:%d: non-ASCII %q (U+%04X) - rewrite the comment in ASCII",
+						e.Name(), i+1, string(r), r))
+				}
+			}
+		}
+	}
+	require.True(t, found, "no .sql files found under %s - path resolution broke", dir)
+	require.Empty(t, offenders,
+		"db/queries/*.sql must stay pure ASCII (sqlc unicode-comment corruption, #290):\n%s",
+		strings.Join(offenders, "\n"))
+}
+
+// queriesDir resolves the repo's db/queries directory relative to this test
+// file, independent of the working directory `go test` happens to use.
+func queriesDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "db", "queries")
+}
+
+// TestDeleteProbeResultsStaleBatched_Executes is the runtime half of the #290
+// regression suite: the corrupted constant (`... LIMIT ?` missing its closing
+// paren) parsed fine at Go compile time and only exploded as
+// "SQL logic error: incomplete input" when the retention sweep ran - on the
+// real router it failed on every startup. Executing the query proves the
+// generated statement parses AND deletes exactly the stale rows.
+func TestDeleteProbeResultsStaleBatched_Executes(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	q := db.New(conn)
+	ctx := context.Background()
+
+	res, err := conn.Exec(`INSERT INTO probe_targets (name, module, target) VALUES ('t1', 'http', 'https://example.com')`)
+	require.NoError(t, err)
+	targetID, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	// Two stale rows (RFC3339 sorts lexically), one fresh.
+	for _, checkedAt := range []string{
+		"2026-01-01T00:00:00Z",
+		"2026-01-02T00:00:00Z",
+		"2026-09-01T00:00:00Z",
+	} {
+		_, err = conn.Exec(`INSERT INTO probe_results (target_id, status, checked_at) VALUES (?, 'success', ?)`,
+			targetID, checkedAt)
+		require.NoError(t, err)
+	}
+
+	deleted, err := q.DeleteProbeResultsStaleBatched(ctx, db.DeleteProbeResultsStaleBatchedParams{
+		CheckedAt: "2026-08-01T00:00:00Z",
+		Limit:     500,
+	})
+	require.NoError(t, err, "the #290-corrupted statement failed here with 'incomplete input'")
+	require.EqualValues(t, 2, deleted)
+
+	var remaining int
+	require.NoError(t, conn.QueryRow(`SELECT COUNT(*) FROM probe_results`).Scan(&remaining))
+	require.Equal(t, 1, remaining, "only the fresh row must survive")
+}
+
+// TestUpdateDeviceStatus_Executes covers the second query the #290 corruption
+// hit: the generated constant lost the `?` after `WHERE id =`, which a bare
+// parse smoke test catches and the offline_since CASE semantics exercise too.
+func TestUpdateDeviceStatus_Executes(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	q := db.New(conn)
+	ctx := context.Background()
+
+	res, err := conn.Exec(`INSERT INTO devices (name, ip_address, status) VALUES ('d1', '192.168.64.1', 'online')`)
+	require.NoError(t, err)
+	devID, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	flip := func(status string) {
+		require.NoError(t, q.UpdateDeviceStatus(ctx, db.UpdateDeviceStatusParams{
+			Status:  status,
+			Column2: status,
+			Column3: status,
+			ID:      devID,
+		}))
+	}
+
+	flip("offline")
+	var status string
+	var offlineSince *string
+	require.NoError(t, conn.QueryRow(`SELECT status, offline_since FROM devices WHERE id = ?`, devID).
+		Scan(&status, &offlineSince))
+	require.Equal(t, "offline", status)
+	require.NotNil(t, offlineSince, "transitioning TO offline must stamp offline_since")
+
+	flip("online")
+	require.NoError(t, conn.QueryRow(`SELECT status, offline_since FROM devices WHERE id = ?`, devID).
+		Scan(&status, &offlineSince))
+	require.Equal(t, "online", status)
+	require.Nil(t, offlineSince, "transitioning TO online must clear offline_since")
+}
+
+// TestListTopologyEdgesByNetwork_Executes covers the third #290 casualty: the
+// constant ended mid-identifier (`ORDER BY ... DESC, te.`), so the topology
+// graph listing would have failed at runtime had anything called it.
+func TestListTopologyEdgesByNetwork_Executes(t *testing.T) {
+	conn, err := testutil.SetupTestDBFromSchema()
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	q := db.New(conn)
+	ctx := context.Background()
+
+	var a, b int64
+	for i, name := range []string{"sw-a", "sw-b"} {
+		res, err := conn.Exec(`INSERT INTO devices (name, ip_address, status, network_id, device_uuid) VALUES (?, ?, 'online', 1, ?)`,
+			name, fmt.Sprintf("192.168.64.%d", 10+i), fmt.Sprintf("uuid-edge-%d", i))
+		require.NoError(t, err)
+		id, err := res.LastInsertId()
+		require.NoError(t, err)
+		if i == 0 {
+			a = id
+		} else {
+			b = id
+		}
+	}
+
+	_, err = conn.Exec(`INSERT INTO topology_edges (from_device_id, to_device_id, edge_type, via_protocol, metadata)
+		VALUES (?, ?, 'l2', 'LLDP', '{}')`, a, b)
+	require.NoError(t, err)
+
+	nid := int64(1)
+	edges, err := q.ListTopologyEdgesByNetwork(ctx, db.ListTopologyEdgesByNetworkParams{
+		Column1:     nid,
+		NetworkID:   &nid,
+		NetworkID_2: &nid,
+	})
+	require.NoError(t, err, "the #290-corrupted statement failed here with 'incomplete input'")
+	require.Len(t, edges, 1)
+	require.Equal(t, "l2", edges[0].EdgeType)
+}


### PR DESCRIPTION
## 背景

#290 的修复(注释 ASCII 化)已随 #294 落地,但 issue 清单里的「CI 加防护」一项一直没做。本 PR 补上两层防线,完成该项:

## 1. TestQueriesFilesASCIIOnly — 源头守卫

强制 `db/queries/*.sql` 纯 ASCII。理由(引自 #290 根因分析):sqlc v1.31.1 的多字节腐蚀是**位置相关**的——同一批 ↔/— 字符可能几个月不引爆,直到某次无关编辑移动字节偏移(#253 合入即如此)。「当前生成物看起来没问题」证明不了任何事,零多字节输入才是唯一可靠防御。

`db/schema.sql` 豁免:schema 注释不进语句重构路径(实测 `sqlc generate` 反复运行零漂移;schema 里现存两处 em-dash 无害)。

## 2. 执行冒烟 — 第二层防线

`DeleteProbeResultsStaleBatched` / `UpdateDeviceStatus` / `ListTopologyEdgesByNetwork` 三条 #290 受害查询真跑一遍(建库 + 插数据 + 断言语义,含 offline_since 翻转 /  lexical RFC3339 截断删除 / 拓扑边过滤)。被腐蚀的常量 Go 编译期不报错,只在运行期炸 "incomplete input"(真机每次启动必失败)——执行测试兜住这一层。

## TDD 验证

红绿已演示:临时注入单个 em-dash → 守卫精确报 `probe_results.sql:45: U+2014`;还原 → 绿。

Closes #290(补齐清单最后一项)。