### PR TITLE
test(doctor): ICMP ping_group_range 检查抽出纯函数并补单测（#316 / #288）

### DIFF
--- a/cmd/server/doctor.go
+++ b/cmd/server/doctor.go
@@ -252,22 +252,8 @@ func doctor(args []string) int {
 	// the group to be inside /proc/sys/net/ipv4/ping_group_range. The OpenWrt
 	// default "1 0" (disabled) leaves every probe "permission denied".
 	if raw, err := os.ReadFile("/proc/sys/net/ipv4/ping_group_range"); err == nil {
-		var lo, hi int
-		if n, _ := fmt.Sscanf(strings.TrimSpace(string(raw)), "%d %d", &lo, &hi); n == 2 {
-			gid := os.Getgid()
-			switch {
-			case lo > hi:
-				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "fail",
-					detail:  fmt.Sprintf("disabled (%s) — unprivileged ICMP probes will fail", strings.TrimSpace(string(raw))),
-					fixHint: `echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range (or add to sysctl.d; required for ICMP without root)`})
-			case gid >= lo && gid <= hi:
-				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "ok",
-					detail: fmt.Sprintf("gid %d within [%d %d]", gid, lo, hi)})
-			default:
-				checks = append(checks, doctorCheck{name: "icmp ping_group_range", status: "warn",
-					detail:  fmt.Sprintf("service gid %d outside [%d %d]", gid, lo, hi),
-					fixHint: "widen ping_group_range or run the service under a covered group"})
-			}
+		if c, ok := icmpPingGroupRangeCheck(string(raw), os.Getgid()); ok {
+			checks = append(checks, c)
 		}
 	}
 
@@ -278,6 +264,36 @@ func doctor(args []string) int {
 		}
 	}
 	return 0
+}
+
+// icmpPingGroupRangeCheck turns /proc/sys/net/ipv4/ping_group_range content
+// into a doctorCheck (#288). ok=false means the input didn't parse as two
+// numbers — emit no check rather than a false failure (the sysctl file may be
+// absent or unexpected on exotic kernels). Decision table:
+//
+//   - lo > hi            → fail: the range is inverted = disabled ("1 0" is
+//     the GL.iNet/OpenWrt default); unprivileged ICMP
+//     probes fail with EPERM even for root
+//   - gid in [lo, hi]    → ok
+//   - otherwise          → warn: the service's gid isn't covered
+func icmpPingGroupRangeCheck(raw string, gid int) (doctorCheck, bool) {
+	var lo, hi int
+	if n, _ := fmt.Sscanf(strings.TrimSpace(raw), "%d %d", &lo, &hi); n != 2 {
+		return doctorCheck{}, false
+	}
+	switch {
+	case lo > hi:
+		return doctorCheck{name: "icmp ping_group_range", status: "fail",
+			detail:  fmt.Sprintf("disabled (%s) — unprivileged ICMP probes will fail", strings.TrimSpace(raw)),
+			fixHint: `echo "0 2147483647" > /proc/sys/net/ipv4/ping_group_range (or add to sysctl.d; required for ICMP without root)`}, true
+	case gid >= lo && gid <= hi:
+		return doctorCheck{name: "icmp ping_group_range", status: "ok",
+			detail: fmt.Sprintf("gid %d within [%d %d]", gid, lo, hi)}, true
+	default:
+		return doctorCheck{name: "icmp ping_group_range", status: "warn",
+			detail:  fmt.Sprintf("service gid %d outside [%d %d]", gid, lo, hi),
+			fixHint: "widen ping_group_range or run the service under a covered group"}, true
+	}
 }
 
 func printReport(checks []doctorCheck) {

--- a/cmd/server/doctor_test.go
+++ b/cmd/server/doctor_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (c) 2026 Mi Bee Studio. All rights reserved.
+//
+// This file is part of MiBee Steward, distributed under the GNU Affero General
+// Public License v3.0 or later; see LICENSE for the full text. A commercial
+// license is available for use cases the AGPL does not accommodate; see
+// LICENSE-COMMERCIAL.md.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIcmpPingGroupRangeCheck pins the #288 operator diagnostic: the GL.iNet
+// OpenWrt firmware ships ping_group_range="1 0" (lo>hi = disabled), which
+// makes every unprivileged ICMP probe fail with "permission denied" even for
+// root. The check's decision table must classify all four shapes the field
+// can produce, and stay silent on unparseable input (never a false failure).
+func TestIcmpPingGroupRangeCheck(t *testing.T) {
+	t.Run("disabled range means probes will fail", func(t *testing.T) {
+		c, ok := icmpPingGroupRangeCheck("1 0\n", 0)
+		require.True(t, ok)
+		require.Equal(t, "fail", c.status)
+		require.Contains(t, c.detail, "disabled")
+	})
+
+	t.Run("gid inside range is ok", func(t *testing.T) {
+		c, ok := icmpPingGroupRangeCheck("0 2147483647\n", 0)
+		require.True(t, ok)
+		require.Equal(t, "ok", c.status)
+		c, ok = icmpPingGroupRangeCheck("100 200\n", 150)
+		require.True(t, ok)
+		require.Equal(t, "ok", c.status)
+	})
+
+	t.Run("gid outside range warns", func(t *testing.T) {
+		c, ok := icmpPingGroupRangeCheck("100 200\n", 0)
+		require.True(t, ok)
+		require.Equal(t, "warn", c.status)
+		require.Contains(t, c.detail, "outside")
+	})
+
+	t.Run("unparseable input emits no check", func(t *testing.T) {
+		_, ok := icmpPingGroupRangeCheck("garbage", 0)
+		require.False(t, ok)
+		_, ok = icmpPingGroupRangeCheck("", 0)
+		require.False(t, ok)
+		_, ok = icmpPingGroupRangeCheck("5", 0) // one number, not two
+		require.False(t, ok)
+	})
+}
+
+func TestHumanBytes(t *testing.T) {
+	require.Equal(t, "512 B", humanBytes(512))
+	require.Equal(t, "1.0 KB", humanBytes(1<<10))
+	require.Equal(t, "5.0 MB", humanBytes(5<<20))
+	require.Equal(t, "2.0 GB", humanBytes(2<<30))
+}


### PR DESCRIPTION
## 背景

doctor 的 ICMP 能力检查(#316 落地,源自 #288 GL 固件真机发现:`ping_group_range=1 0` 连 root 也禁 ping socket)原先内联在 `doctor()` 里直读 `/proc`,不可单测。本 PR 按 TDD 补齐:先写测试(编译红:undefined 符号),再把判断逻辑抽成纯函数 `icmpPingGroupRangeCheck(raw, gid)`(行为逐字保持),转绿。

## 决策表测试钉住四种形态

| 输入 | 期望 |
|---|---|
| 反转区间 `"1 0"`(GL/OpenWrt 默认) | **fail** + 修复提示 |
| gid 在区间内(两种合法形态各验一次) | ok |
| 服务 gid 在区间外 | warn |
| 无法解析(garbage / 空 / 单数字) | **不出检查**(绝不误报 fail) |

另补 `humanBytes` 边界值测试。