### PR TITLE
feat(make): 采集器补三架构交叉编译目标 — 消除 build-agent 宿主架构陷阱

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-s -w -X mibee-steward/internal/version.Version=$(VERSION)
 BUILD_DIR=bin
 
-.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan build-linux-amd64 build-linux-arm64 build-linux-arm clean test dev migrate-up sync-fingerprints sync-device-types sync-oui-curated docs-changelog-sync fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
+.PHONY: all build build-all build-frontend build-server build-agent build-with-ebpf build-with-lldp build-with-arpscan build-linux-amd64 build-linux-arm64 build-linux-arm build-agent-linux-amd64 build-agent-linux-arm64 build-agent-linux-arm clean test dev migrate-up sync-fingerprints sync-device-types sync-oui-curated docs-changelog-sync fpimport docker-build docker-build-priv docker-up docker-up-bridge docker-up-macvlan docker-down docker-logs
 
 all: build
 
@@ -37,6 +37,21 @@ build-linux-arm64: sync-device-types sync-oui-curated
 # documents this arch for OpenWrt form B/C. MIPS is NOT supported (modernc/libc).
 build-linux-arm: sync-device-types sync-oui-curated
 	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm ./cmd/server/
+
+# Agent (form B) cross-compile — same three archs as the center above. The
+# agent has no frontend/embed-dist step, but it DOES embed the fingerprint
+# corpus + curated OUI, so the two sync targets remain prerequisites. Without
+# these targets a form-B deploy reflexively runs `make build-agent` and ships
+# a HOST-arch binary to the router (observed on the MT2500: an x86-64 ELF
+# flashed to aarch64 fails with a confusing "syntax error" from ash).
+build-agent-linux-amd64: sync-device-types sync-oui-curated
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/mibee-agent-linux-amd64 ./cmd/agent/
+
+build-agent-linux-arm64: sync-device-types sync-oui-curated
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/mibee-agent-linux-arm64 ./cmd/agent/
+
+build-agent-linux-arm: sync-device-types sync-oui-curated
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/mibee-agent-linux-arm ./cmd/agent/
 
 # Build with the eBPF passive observer enabled. Requires clang/llvm/bpftool
 # and kernel BTF on the build host; produces a binary that, at runtime, needs

--- a/deploy/openwrt/README.md
+++ b/deploy/openwrt/README.md
@@ -46,7 +46,16 @@ make build-linux-amd64   # x86_64 (generic Linux host)
 make build-linux-arm64   # ARMv8 (GL.iNet MT3000, ipq807x, mt798x)
 make build-linux-arm     # ARMv7 32-bit (older ARM boards)
 make build-all           # all three at once (server binary each)
+
+# Form B (agent) equivalents — same three archs:
+make build-agent-linux-arm64   # e.g. deploying to a GL.iNet router
+make build-agent-linux-amd64
+make build-agent-linux-arm
 ```
+
+(`make build-agent` without a `-linux-<arch>` suffix builds for the HOST
+architecture — handy when the build host IS the target, a foot-gun when it
+isn't.)
 
 ## Install (form B — agent → remote center)
 

--- a/docs/en/openwrt.md
+++ b/docs/en/openwrt.md
@@ -62,7 +62,7 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
 # → ~24MB (includes the embedded SvelteKit SPA)
 ```
 
-`GOARCH=arm` (32-bit, GOARM=7) also works for older ARM boards; `GOARCH=mips*` does **not**. Note: the repo's Makefile cross-compile targets (`make build-linux-arm64` etc.) build the **center** binary (they run the device-type sync the embed step needs); cross-compile the agent with the raw `go build` above, or use `make build-agent` for a native-arch build:
+`GOARCH=arm` (32-bit, GOARM=7) also works for older ARM boards; `GOARCH=mips*` does **not**. Note: the repo's Makefile cross-compile targets (`make build-linux-arm64` etc.) build the **center** binary; the agent has matching `make build-agent-linux-arm64` / `-amd64` / `-arm` targets (both sets run the device-type sync the embed step needs). A bare `make build-agent` builds for the **host** architecture:
 
 ```bash
 # Center (Form C) — Makefile targets (amd64 / arm64 / arm likewise):

--- a/docs/zh/openwrt.md
+++ b/docs/zh/openwrt.md
@@ -62,7 +62,7 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
 # → ~24MB（含嵌入式 SvelteKit SPA）
 ```
 
-`GOARCH=arm`（32 位，GOARM=7）也可用于老款 ARM 板；`GOARCH=mips*` **不支持**。注意：仓库 Makefile 的交叉编译目标（`make build-linux-arm64` 等）构建的是**中心**二进制（内含设备类型同步的 embed 前置步骤）；采集器的交叉编译用上面的 raw `go build`，本机架构下也可用 `make build-agent`：
+`GOARCH=arm`（32 位，GOARM=7）也可用于老款 ARM 板；`GOARCH=mips*` **不支持**。注意：仓库 Makefile 的交叉编译目标（`make build-linux-arm64` 等）构建的是**中心**二进制；采集器有对应的 `make build-agent-linux-arm64` / `-amd64` / `-arm` 目标（两组都内含设备类型同步的 embed 前置步骤）。不带架构后缀的 `make build-agent` 构建的是**本机架构**：
 
 ```bash
 # 中心（形态 C）——Makefile 目标（amd64 / arm64 / arm 同理）：


### PR DESCRIPTION
## 背景

form B(agent 上路由)部署时,`make build-agent` 是最顺手的反射动作,但它构建**宿主架构**产物——x86-64 开发机上 cross 到 aarch64 路由即 ENOEXEC,ash 兜底当 shell 脚本执行,报一条毫不相干的 \`syntax error: unexpected word\`(MT2500 真机实测,#37 form B 冒烟时踩中)。此前 deploy/openwrt/README 与双语手册的 workaround 是"采集器交叉编译请手打 raw \`go build\`"。

## 改动

- Makefile 补 \`build-agent-linux-{amd64,arm64,arm}\`,与 center 的 \`build-linux-*\` 完全对称(前置同样的 sync-device-types/sync-oui-curated——agent 也内嵌指纹语料 + 精选 OUI)
- \`deploy/openwrt/README.md\` 交叉编译清单 + 双语 openwrt 手册注记改为正面用法,并明示"不带架构后缀的 build-agent = 本机架构"
- arm64 目标实机验证过:产物即今日 form B 冒烟所用的构建路径

`build-all` 语义未动(仍是三架构 center),避免改变既有调用方预期。